### PR TITLE
PE-4860: Turbo upload refactoring

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,8 +21,8 @@ import {
   epochHeightSelector,
   observer,
   prescribedObserversSource,
+  reportSink,
 } from './system.js';
-import { uploadReportWithTurbo } from './turbo.js';
 
 const report = await observer.generateReport();
 console.log(JSON.stringify(report, null, 2));
@@ -41,7 +41,7 @@ console.log(
 );
 console.log(prescribedObservers);
 
-await uploadReportWithTurbo(report);
+await reportSink.saveReport(report);
 //const observationReportObjectTxId = await uploadReportWithTurbo(report);
 //if (observationReportObjectTxId !== null) {
 //  const saveObservationTxIds = await publishObservation.saveObservations(

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,5 +84,5 @@ export const NAME_ASSESSMENT_CONCURRENCY = +env.varOrDefault(
   '5',
 );
 
-// used for posting interactions to the contract
+// Wallet used to upload reports and interact with the contract
 export const KEY_FILE = './wallets/' + OBSERVER_WALLET + '.json';

--- a/src/store/composite-report-sink.ts
+++ b/src/store/composite-report-sink.ts
@@ -1,0 +1,36 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { ObserverReport, ReportSaveResult, ReportSink } from '../types.js';
+
+export class CompositeReportSink implements ReportSink {
+  private sinks: ReportSink[];
+
+  constructor({ sinks }: { sinks: ReportSink[] }) {
+    this.sinks = sinks;
+  }
+
+  async saveReport(
+    report: ObserverReport,
+  ): Promise<ReportSaveResult | undefined> {
+    // TODO decide how to handle errors
+    await Promise.allSettled(this.sinks.map((sink) => sink.saveReport(report)));
+
+    // TODO decide if/how to return IDs
+    return undefined;
+  }
+}

--- a/src/store/fs-report-store.ts
+++ b/src/store/fs-report-store.ts
@@ -17,9 +17,9 @@
  */
 import fs from 'node:fs';
 
-import { ObserverReport, ReportStore } from '../types.js';
+import { ObserverReport, ReportSink, ReportStore } from '../types.js';
 
-export class FsReportStore implements ReportStore {
+export class FsReportStore implements ReportSink, ReportStore {
   private baseDir: string;
 
   constructor({ baseDir }: { baseDir: string }) {
@@ -30,6 +30,7 @@ export class FsReportStore implements ReportStore {
     if (!fs.existsSync(this.baseDir)) {
       await fs.promises.mkdir(this.baseDir, { recursive: true });
     }
+
     const reportFile = `${this.baseDir}/${report.epochStartHeight}.json`;
     if (!fs.existsSync(reportFile)) {
       await fs.promises.writeFile(
@@ -37,6 +38,8 @@ export class FsReportStore implements ReportStore {
         JSON.stringify(report),
       );
     }
+
+    return undefined;
   }
 
   async getReport(epochStartHeight: number): Promise<ObserverReport | null> {

--- a/src/store/turbo-report-sink.ts
+++ b/src/store/turbo-report-sink.ts
@@ -29,6 +29,10 @@ async function createReportDataItem(
       { name: 'App-Name', value: 'AR-IO Observer' },
       { name: 'App-Version', value: '0.0.1' },
       { name: 'Content-Type', value: 'application/json' },
+      {
+        name: 'AR-IO-Epoch-Start-Height',
+        value: report.epochStartHeight.toString(),
+      },
     ],
   });
   await signedDataItem.sign(signer);

--- a/src/store/turbo-report-sink.ts
+++ b/src/store/turbo-report-sink.ts
@@ -18,7 +18,7 @@
 import { TurboAuthenticatedClient } from '@ardrive/turbo-sdk/node';
 import { ArweaveSigner, createData } from 'arbundles/node';
 
-import { ObserverReport, ReportSaveResult, ReportSink } from './types.js';
+import { ObserverReport, ReportSaveResult, ReportSink } from '../types.js';
 
 async function createReportDataItem(
   signer: ArweaveSigner,
@@ -37,7 +37,7 @@ async function createReportDataItem(
 }
 
 // TODO implement full ReportStore interface
-export class TurboReportStore implements ReportSink {
+export class TurboReportSink implements ReportSink {
   private readonly turboClient: TurboAuthenticatedClient;
   private readonly signer: ArweaveSigner;
 

--- a/src/system.ts
+++ b/src/system.ts
@@ -41,7 +41,7 @@ import { RandomObserversSource } from './observers/random-observers-source.js';
 import { EPOCH_BLOCK_LENGTH, EpochHeightSource } from './protocol.js';
 import { CompositeReportSink } from './store/composite-report-sink.js';
 import { FsReportStore } from './store/fs-report-store.js';
-import { TurboReportStore } from './turbo.js';
+import { TurboReportSink } from './store/turbo-report-sink.js';
 import { ReportSink } from './types.js';
 
 const REPORT_CACH_TTL_SECS = 60 * 60; // 1 hour
@@ -155,7 +155,7 @@ const signer =
 
 const turboReportSink =
   turboClient && signer
-    ? new TurboReportStore({
+    ? new TurboReportSink({
         turboClient: turboClient,
         signer,
       })

--- a/src/system.ts
+++ b/src/system.ts
@@ -105,12 +105,6 @@ export const observer = new Observer({
   nameAssessmentConcurrency: config.NAME_ASSESSMENT_CONCURRENCY,
 });
 
-export const chosenObserversSource = new RandomObserversSource({
-  observedGatewayHostList: observedGatewayHostList,
-  entropySource: compositeEntropySource,
-  numObserversToSource: 50,
-});
-
 export const prescribedObserversSource = new RandomObserversSource({
   observedGatewayHostList: observedGatewayHostList,
   entropySource: chainEntropySource,

--- a/src/system.ts
+++ b/src/system.ts
@@ -167,7 +167,7 @@ if (turboReportSink !== undefined) {
   stores.push(turboReportSink);
 }
 
-const reportSink = new CompositeReportSink({
+export const reportSink = new CompositeReportSink({
   sinks: stores,
 });
 

--- a/src/turbo.ts
+++ b/src/turbo.ts
@@ -32,7 +32,7 @@ export async function uploadReportWithTurbo(
   let reportTxId: string | undefined;
   if (walletJwk !== undefined && turboClient !== undefined) {
     // Convert the JSON object to a JSON string
-    const reportString = JSON.stringify(report, null, 2);
+    const reportString = JSON.stringify(report);
     try {
       const signer = new ArweaveSigner(walletJwk);
       const signedDataItem = createData(reportString, signer, {

--- a/src/turbo.ts
+++ b/src/turbo.ts
@@ -18,7 +18,7 @@
 import { TurboAuthenticatedClient } from '@ardrive/turbo-sdk/node';
 import { ArweaveSigner, createData } from 'arbundles/node';
 
-import { ObserverReport } from './types.js';
+import { ObserverReport, ReportSaveResult, ReportSink } from './types.js';
 
 async function createReportDataItem(
   signer: ArweaveSigner,
@@ -37,7 +37,7 @@ async function createReportDataItem(
 }
 
 // TODO implement full ReportStore interface
-export class TurboReportStore {
+export class TurboReportStore implements ReportSink {
   private readonly turboClient: TurboAuthenticatedClient;
   private readonly signer: ArweaveSigner;
 
@@ -52,7 +52,9 @@ export class TurboReportStore {
     this.signer = signer;
   }
 
-  async saveReport(report: ObserverReport): Promise<string | undefined> {
+  async saveReport(
+    report: ObserverReport,
+  ): Promise<ReportSaveResult | undefined> {
     try {
       const signedDataItem = await createReportDataItem(this.signer, report);
 
@@ -72,7 +74,9 @@ export class TurboReportStore {
         fastFinalityIndexes,
       });
 
-      return id;
+      return {
+        reportTxId: id,
+      };
     } catch (error) {
       console.error('Failed to upload report to Turbo!', error);
     } finally {

--- a/src/turbo.ts
+++ b/src/turbo.ts
@@ -28,9 +28,9 @@ const tags = [
 
 export async function uploadReportWithTurbo(
   report: ObserverReport,
-): Promise<string | null> {
+): Promise<string | undefined> {
+  let reportTxId: string | undefined;
   if (walletJwk !== undefined && turboClient !== undefined) {
-    let reportTxId = '';
     // Convert the JSON object to a JSON string
     const reportString = JSON.stringify(report, null, 2);
     try {
@@ -45,6 +45,7 @@ export async function uploadReportWithTurbo(
           dataItemStreamFactory: () => signedDataItem.getRaw(),
           dataItemSizeFactory: () => signedDataItem.getRaw().length,
         });
+      reportTxId = id;
 
       // upload complete!
       console.log('Successfully upload report (object) to Turbo!', {
@@ -53,20 +54,17 @@ export async function uploadReportWithTurbo(
         dataCaches,
         fastFinalityIndexes,
       });
-      reportTxId = id;
     } catch (error) {
       // upload failed
       console.error('Failed to upload report (object) to Turbo!', error);
-      return null;
     } finally {
       const { winc: newBalance } = await turboClient.getBalance();
       console.log('New balance:', newBalance);
     }
-    return reportTxId;
   } else {
     console.error('Key missing, skipping upload');
-    return null;
   }
+  return reportTxId;
 }
 
 //export async function uploadReportFromDiskWithTurbo(

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,8 +143,16 @@ export interface ObserverReport {
 // Report store
 //
 
+export interface ReportSaveResult {
+  reportTxId?: string;
+}
+
+export interface ReportSink {
+  saveReport(report: ObserverReport): Promise<ReportSaveResult | undefined>;
+}
+
 export interface ReportStore {
-  saveReport(report: ObserverReport): Promise<void>;
+  saveReport(report: ObserverReport): Promise<ReportSaveResult | undefined>;
   getReport(epochStartHeight: number): Promise<ObserverReport | null>;
   latestReport(): Promise<ObserverReport | null>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,10 +76,6 @@ export interface ObservationPublisher {
     observerReportTxId: string,
     observerReport: ObserverReport,
   ): Promise<string[]>;
-  uploadAndSaveObservations(observerReportFileName: string): Promise<{
-    observerReportTxId: string | null;
-    saveObservationsTxIds: string[];
-  }>;
 }
 
 //

--- a/src/warp.ts
+++ b/src/warp.ts
@@ -26,7 +26,6 @@ import {
 } from 'warp-contracts/mjs';
 
 import { CONTRACT_ID, KEY_FILE } from './config.js';
-import { uploadReportWithTurbo } from './turbo.js';
 import { ObservationPublisher, ObserverReport } from './types.js';
 
 export const arweave = new Arweave({
@@ -163,59 +162,59 @@ export class PublishFromObservation implements ObservationPublisher {
     return saveObservationsTxIds;
   }
 
-  async uploadAndSaveObservations(observerReportFileName: string): Promise<{
-    observerReportTxId: string | null;
-    saveObservationsTxIds: string[];
-  }> {
-    const report: ObserverReport = JSON.parse(
-      fs.readFileSync(observerReportFileName).toString(),
-    );
+  //async uploadAndSaveObservations(observerReportFileName: string): Promise<{
+  //  observerReportTxId: string | null;
+  //  saveObservationsTxIds: string[];
+  //}> {
+  //  const report: ObserverReport = JSON.parse(
+  //    fs.readFileSync(observerReportFileName).toString(),
+  //  );
 
-    const observerReportTxId = await uploadReportWithTurbo(report);
-    if (observerReportTxId === null) {
-      console.log('Error submitting report to turbo.');
-      return { observerReportTxId: null, saveObservationsTxIds: [] };
-    }
+  //  const observerReportTxId = await uploadReportWithTurbo(report);
+  //  if (observerReportTxId === null) {
+  //    console.log('Error submitting report to turbo.');
+  //    return { observerReportTxId: null, saveObservationsTxIds: [] };
+  //  }
 
-    // get contract manifest
-    const { evaluationOptions = {} } = await getContractManifest({
-      contractTxId: CONTRACT_ID,
-    });
+  //  // get contract manifest
+  //  const { evaluationOptions = {} } = await getContractManifest({
+  //    contractTxId: CONTRACT_ID,
+  //  });
 
-    // Read the AR.IO Contract
-    const contract = this.warp.pst(CONTRACT_ID);
+  //  // Read the AR.IO Contract
+  //  const contract = this.warp.pst(CONTRACT_ID);
 
-    // connect to wallet
-    contract.connect(this.wallet).setEvaluationOptions(evaluationOptions);
+  //  // connect to wallet
+  //  contract.connect(this.wallet).setEvaluationOptions(evaluationOptions);
 
-    const failedGatewaySummaries: string[] =
-      getFailedGatewaySummaryFromReport(report);
+  //  const failedGatewaySummaries: string[] =
+  //    getFailedGatewaySummaryFromReport(report);
 
-    // split up the failed gateway summaries if they are bigger than the max individual summary size
-    const splitFailedGatewaySummaries = splitArrayBySize(
-      failedGatewaySummaries,
-      maxFailedGatewaySummarySizeInBytes,
-    );
+  //  // split up the failed gateway summaries if they are bigger than the max individual summary size
+  //  const splitFailedGatewaySummaries = splitArrayBySize(
+  //    failedGatewaySummaries,
+  //    maxFailedGatewaySummarySizeInBytes,
+  //  );
 
-    // Processes each failed gateway summary using the same observation report tx id.
-    const saveObservationsTxIds: string[] = [];
-    for (const failedGatewaySummary of splitFailedGatewaySummaries) {
-      const saveObservationsTxId = await contract.writeInteraction(
-        {
-          function: 'saveObservations',
-          observerReportTxId,
-          failedGateways: failedGatewaySummary,
-        },
-        {
-          disableBundling: true,
-        },
-      );
-      if (saveObservationsTxId) {
-        saveObservationsTxIds.push(saveObservationsTxId.originalTxId);
-      } else {
-        saveObservationsTxIds.push('invalid');
-      }
-    }
-    return { observerReportTxId, saveObservationsTxIds };
-  }
+  //  // Processes each failed gateway summary using the same observation report tx id.
+  //  const saveObservationsTxIds: string[] = [];
+  //  for (const failedGatewaySummary of splitFailedGatewaySummaries) {
+  //    const saveObservationsTxId = await contract.writeInteraction(
+  //      {
+  //        function: 'saveObservations',
+  //        observerReportTxId,
+  //        failedGateways: failedGatewaySummary,
+  //      },
+  //      {
+  //        disableBundling: true,
+  //      },
+  //    );
+  //    if (saveObservationsTxId) {
+  //      saveObservationsTxIds.push(saveObservationsTxId.originalTxId);
+  //    } else {
+  //      saveObservationsTxIds.push('invalid');
+  //    }
+  //  }
+  //  return { observerReportTxId, saveObservationsTxIds };
+  //}
 }


### PR DESCRIPTION
- Simplifies handling of missing wallets.
- Implement the `ReportSink` on a `TurboSink` class.
- Adds a `CompositeReportSink` that's used to do the actual uploads.
- Decouples Warp from Turbo (more work needed to restore Warp functionality).
- Adds a epoch start height tag.