### PR TITLE
chore(PE-5237): turn down logging in warp

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prom-client": "^14.0.1",
     "swagger-ui-express": "^5.0.0",
     "wait": "^0.4.2",
-    "warp-contracts": "^1.4.18",
+    "warp-contracts": "1.4.28",
     "winston": "^3.7.2",
     "yaml": "^2.3.1",
     "yargs": "^17.7.2"

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,3 +101,5 @@ export const KEY_FILE = './wallets/' + OBSERVER_WALLET + '.json';
 
 export const SUBMIT_CONTRACT_INTERACTIONS =
   env.varOrDefault('SUBMIT_CONTRACT_INTERACTIONS', 'false') === 'true';
+
+export const WARP_LOG_LEVEL = env.varOrDefault('WARP_LOG_LEVEL', 'fatal');

--- a/src/contract/warp-contract.ts
+++ b/src/contract/warp-contract.ts
@@ -22,6 +22,7 @@ import {
   EvaluationManifest,
   EvaluationOptions,
   InteractionResult,
+  LoggerFactory,
   Tag,
   Warp,
   WriteInteractionOptions,
@@ -88,6 +89,9 @@ export class WarpContract implements ObserverContract {
     this.warp = warp;
     this.cacheUrl = cacheUrl;
     this.contractId = contractId;
+
+    // Warp logger
+    LoggerFactory.INST.logLevel('fatal');
 
     // Initialize the AR.IO contract
     this.contract = this.warp.pst(contractId);

--- a/src/contract/warp-contract.ts
+++ b/src/contract/warp-contract.ts
@@ -22,7 +22,6 @@ import {
   EvaluationManifest,
   EvaluationOptions,
   InteractionResult,
-  LoggerFactory,
   Tag,
   Warp,
   WriteInteractionOptions,
@@ -89,9 +88,6 @@ export class WarpContract implements ObserverContract {
     this.warp = warp;
     this.cacheUrl = cacheUrl;
     this.contractId = contractId;
-
-    // Warp logger
-    LoggerFactory.INST.logLevel('fatal');
 
     // Initialize the AR.IO contract
     this.contract = this.warp.pst(contractId);

--- a/src/system.ts
+++ b/src/system.ts
@@ -26,6 +26,8 @@ import { default as NodeCache } from 'node-cache';
 import * as fs from 'node:fs';
 import {
   JWKInterface,
+  LogLevel,
+  LoggerFactory,
   WarpFactory,
   defaultCacheOptions,
 } from 'warp-contracts/mjs';
@@ -197,6 +199,8 @@ if (turboReportSink !== undefined) {
   });
 }
 
+// Set our warp log level
+LoggerFactory.INST.logLevel(config.WARP_LOG_LEVEL as LogLevel);
 export const warp = WarpFactory.forMainnet(
   {
     ...defaultCacheOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5205,10 +5205,10 @@ warp-arbundles@^1.0.4:
     buffer "^6.0.3"
     warp-isomorphic "^1.0.7"
 
-warp-contracts@^1.4.18:
-  version "1.4.23"
-  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.23.tgz#173606867b4286f87ab4dcc784ae031d32166155"
-  integrity sha512-1Lm/nC3B+ul3rCd6oDECvyKL5vMFNKUSmoRa21PMK7OKUgWhvNyEzdqTbwY1yW+TyDGv2FDaFgcYrBf1uSUAAQ==
+warp-contracts@1.4.28:
+  version "1.4.28"
+  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.28.tgz#ee8d5331acff3031d2813a8e2372e47daa580cf2"
+  integrity sha512-l6n2Ph2eWVWFHh+ivi6UvZt7RVYIZc07m1FrvkC9L6MZzMoOFeQDPNOinPy1Z7dNZRjlq3q0NI9zgGtgZZFtYA==
   dependencies:
     archiver "^5.3.0"
     arweave "1.13.7"


### PR DESCRIPTION
These logs can be very noisy - particularly when a contract has failed interactions on it. Setting it to fatal should reduce a bit.