### PR TITLE
feat(observer): only hash the first 1MiB of data retrieved

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707411026,
+        "narHash": "sha256-5qoWWDSVW+AtHCuw1t1SbdbgjaS1PJ+4OpS1KpZ4PL8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "03bd6ed720261ab38c6e2c9445f2d3d5d328c0a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "AR.IO Observer";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = (import nixpkgs { inherit system; });
+      in {
+        devShells = {
+          default = pkgs.mkShell {
+            name = "ar-io-node-shell";
+            buildInputs = with pkgs; [
+              nodejs_18
+              yarn
+              nodePackages.typescript-language-server
+            ];
+          };
+        };
+      });
+
+  nixConfig.bash-prompt = "\\e[32m[ar-io-observer-shell]$\\e[0m ";
+}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-unicorn": "^45.0.2",
     "mocha": "^10.0.0",
     "mocha-multi": "^1.1.7",
+    "nock": "^13.5.1",
     "prettier": "^2.6.2",
     "rimraf": "^3.0.2",
     "sinon": "^14.0.0",

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -1,0 +1,120 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { expect } from 'chai';
+import nock from 'nock';
+import crypto from 'node:crypto';
+
+import { getArnsResolution } from './observer.js';
+
+const OneMiB = 1048576;
+
+describe('getArnsResolution', function () {
+  const host = 'example.com';
+  const arnsName = 'test';
+  const baseURL = `https://${arnsName}.${host}`;
+
+  const defaultContentType = 'application/octet-stream';
+  const defaultArnsResolvedId = '12345';
+  const defaultArnsTtlSeconds = '300';
+
+  beforeEach(function () {
+    nock.cleanAll();
+  });
+
+  it('should correctly hash data for responses under 1MiB', async function () {
+    const data = Buffer.alloc(100, 'a').toString();
+    nock(baseURL)
+      .get('/')
+      .reply(200, data, {
+        'Content-Type': defaultContentType,
+        'x-arns-resolved-id': defaultArnsResolvedId,
+        'x-arns-ttl-seconds': defaultArnsTtlSeconds,
+        'Content-Length': String(data.length),
+      });
+    const expectedHash = crypto
+      .createHash('sha256')
+      .update(data)
+      .digest('base64url');
+
+    const result = await getArnsResolution({ host, arnsName });
+
+    expect(result.statusCode).to.equal(200);
+    expect(result.resolvedId).to.equal(defaultArnsResolvedId);
+    expect(result.ttlSeconds).to.equal(defaultArnsTtlSeconds);
+    expect(result.contentType).to.equal(defaultContentType);
+    expect(result.contentLength).to.equal(String(data.length));
+    expect(result.dataHashDigest).to.equal(expectedHash);
+    expect(result.timings).to.be.a.string;
+  });
+
+  it('should only process the first 1MiB of data', async function () {
+    const oneMiBData = Buffer.alloc(OneMiB, 'a').toString();
+    const oneMiBPlusData = oneMiBData + 'extra data';
+    nock(baseURL)
+      .get('/')
+      .reply(200, oneMiBPlusData, {
+        'Content-Type': defaultContentType,
+        'x-arns-resolved-id': defaultArnsResolvedId,
+        'x-arns-ttl-seconds': defaultArnsTtlSeconds,
+        'Content-Length': String(oneMiBPlusData.length),
+      });
+    const expectedHash = crypto
+      .createHash('sha256')
+      .update(Buffer.alloc(OneMiB, 'a'))
+      .digest('base64url');
+
+    const result = await getArnsResolution({
+      host,
+      arnsName,
+    });
+
+    expect(result.statusCode).to.equal(200);
+    expect(result.resolvedId).to.equal(defaultArnsResolvedId);
+    expect(result.ttlSeconds).to.equal(defaultArnsTtlSeconds);
+    expect(result.contentType).to.equal(defaultContentType);
+    expect(result.contentLength).to.equal(String(oneMiBPlusData.length));
+    expect(result.dataHashDigest).to.equal(expectedHash);
+    expect(result.timings).to.be.a.string;
+  });
+
+  it('should resolve with correct properties on a 404 response', async function () {
+    nock(baseURL).get('/').reply(404);
+
+    const result = await getArnsResolution({ host, arnsName });
+
+    expect(result.statusCode).to.equal(404);
+    expect(result.resolvedId).to.be.null;
+    expect(result.ttlSeconds).to.be.null;
+    expect(result.contentType).to.be.null;
+    expect(result.contentLength).to.be.null;
+    expect(result.dataHashDigest).to.be.null;
+    expect(result.timings).to.be.null;
+  });
+
+  it('should handle non-404 errors appropriately', async function () {
+    nock(baseURL).get('/').reply(500);
+
+    try {
+      await getArnsResolution({ host, arnsName });
+    } catch (error: any) {
+      expect(error).to.exist;
+      expect(error.response).to.exist;
+      expect(error.response.statusCode).to.equal(500);
+    }
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3493,6 +3493,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json-stringify-safe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
+
 json5@^2.1.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -4047,6 +4052,15 @@ nise@^5.1.2:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
+nock@^13.5.1:
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.5.1.tgz#4e40f9877ad0d43b7cdb474261c190f3715dd806"
+  integrity sha512-+s7b73fzj5KnxbKH4Oaqz07tQ8degcMilU4rrmnKvI//b0JMBU4wEXFQ8zqr+3+L4eWSfU3H/UoIVGUV0tue1Q==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    propagate "^2.0.0"
+
 node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
@@ -4432,6 +4446,11 @@ prometheus-gc-stats@^0.6.2:
     optional "^0.1.3"
   optionalDependencies:
     gc-stats "^1.4.0"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proxy-addr@~2.0.7:
   version "2.0.7"


### PR DESCRIPTION
`getArnsResolution` will only hash the fist 1MiB of data instead of the whole data.