### PR TITLE
feat(observer): send X-AR-IO-Node-Release header on requests to the reference gateway

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -109,4 +109,4 @@ export const REPORT_GENERATION_INTERVAL_MS = +env.varOrDefault(
   `${1000 * 60 * 60}`, // 1 hour
 );
 
-export const AR_IO_NODE_RELEASE = env.varOrDefault('AR_IO_NODE_RELEASE', '0');
+export const AR_IO_NODE_RELEASE = env.varOrDefault('AR_IO_NODE_RELEASE', 'dev');

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,3 +108,5 @@ export const REPORT_GENERATION_INTERVAL_MS = +env.varOrDefault(
   'REPORT_GENERATION_INTERVAL_MS',
   `${1000 * 60 * 60}`, // 1 hour
 );
+
+export const AR_IO_NODE_RELEASE = env.varOrDefault('AR_IO_NODE_RELEASE', '0');

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -117,4 +117,49 @@ describe('getArnsResolution', function () {
       expect(error.response.statusCode).to.equal(500);
     }
   });
+
+  it('should add "X-AR-IO-Node-Release" header when making a request to a reference gateway', async function () {
+    const data = Buffer.alloc(100, 'a').toString();
+    const scope = nock(baseURL, {
+      reqheaders: {
+        'X-AR-IO-Node-Release': 'test',
+      },
+    })
+      .get('/')
+      .reply(200, data, {
+        'Content-Type': defaultContentType,
+        'x-arns-resolved-id': defaultArnsResolvedId,
+        'x-arns-ttl-seconds': defaultArnsTtlSeconds,
+        'Content-Length': String(data.length),
+      });
+
+    await getArnsResolution({
+      host,
+      arnsName,
+      nodeReleaseVersion: 'test',
+    });
+
+    expect(scope.isDone()).to.be.true;
+  });
+
+  it('should not add "X-AR-IO-Node-Release" header when assessing a gateway', async function () {
+    const data = Buffer.alloc(100, 'a').toString();
+    const scope = nock(baseURL, {
+      badheaders: ['X-AR-IO-Node-Release'],
+    })
+      .get('/')
+      .reply(200, data, {
+        'Content-Type': defaultContentType,
+        'x-arns-resolved-id': defaultArnsResolvedId,
+        'x-arns-ttl-seconds': defaultArnsTtlSeconds,
+        'Content-Length': String(data.length),
+      });
+
+    await getArnsResolution({
+      host,
+      arnsName,
+    });
+
+    expect(scope.isDone()).to.be.true;
+  });
 });

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -20,6 +20,7 @@ import got, { RequestError } from 'got';
 import crypto from 'node:crypto';
 import pMap from 'p-map';
 
+import { AR_IO_NODE_RELEASE } from './config.js';
 import {
   ArnsNameAssessment,
   ArnsNameAssessments,
@@ -49,11 +50,18 @@ interface ArnsResolution {
 export function getArnsResolution({
   host,
   arnsName,
+  nodeReleaseVersion,
 }: {
   host: string;
   arnsName: string;
+  nodeReleaseVersion?: string;
 }): Promise<ArnsResolution> {
   const url = `https://${arnsName}.${host}/`;
+  const nodeReleaseHeader =
+    nodeReleaseVersion !== undefined
+      ? { 'X-AR-IO-Node-Release': nodeReleaseVersion }
+      : {};
+
   const stream = got.stream.get(url, {
     timeout: {
       lookup: 5000,
@@ -61,6 +69,7 @@ export function getArnsResolution({
       secureConnect: 2000,
       socket: 1000,
     },
+    headers: nodeReleaseHeader,
   });
   const dataHash = crypto.createHash('sha256');
 
@@ -233,6 +242,7 @@ export class Observer {
     const referenceResolution = await getArnsResolution({
       host: this.referenceGatewayHost,
       arnsName,
+      nodeReleaseVersion: AR_IO_NODE_RELEASE,
     });
 
     const gatewayResolution = await getArnsResolution({

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -20,7 +20,6 @@ import got, { RequestError } from 'got';
 import crypto from 'node:crypto';
 import pMap from 'p-map';
 
-import { AR_IO_NODE_RELEASE } from './config.js';
 import {
   ArnsNameAssessment,
   ArnsNameAssessments,
@@ -201,6 +200,7 @@ export class Observer {
   private chosenNamesSource: ArnsNamesSource;
   private gatewayAsessementConcurrency: number;
   private nameAssessmentConcurrency: number;
+  private nodeReleaseVersion: string;
 
   constructor({
     observerAddress,
@@ -211,6 +211,7 @@ export class Observer {
     observedGatewayHostList,
     gatewayAssessmentConcurrency,
     nameAssessmentConcurrency,
+    nodeReleaseVersion,
   }: {
     observerAddress: string;
     referenceGatewayHost: string;
@@ -220,6 +221,7 @@ export class Observer {
     chosenNamesSource: ArnsNamesSource;
     gatewayAssessmentConcurrency: number;
     nameAssessmentConcurrency: number;
+    nodeReleaseVersion: string;
   }) {
     this.observerAddress = observerAddress;
     this.referenceGatewayHost = referenceGatewayHost;
@@ -229,6 +231,7 @@ export class Observer {
     this.chosenNamesSource = chosenNamesSource;
     this.gatewayAsessementConcurrency = gatewayAssessmentConcurrency;
     this.nameAssessmentConcurrency = nameAssessmentConcurrency;
+    this.nodeReleaseVersion = nodeReleaseVersion;
   }
 
   async assessArnsName({
@@ -242,7 +245,7 @@ export class Observer {
     const referenceResolution = await getArnsResolution({
       host: this.referenceGatewayHost,
       arnsName,
-      nodeReleaseVersion: AR_IO_NODE_RELEASE,
+      nodeReleaseVersion: this.nodeReleaseVersion,
     });
 
     const gatewayResolution = await getArnsResolution({

--- a/src/system.ts
+++ b/src/system.ts
@@ -164,6 +164,7 @@ export const observer = new Observer({
   chosenNamesSource,
   gatewayAssessmentConcurrency: config.GATEWAY_ASSESSMENT_CONCURRENCY,
   nameAssessmentConcurrency: config.NAME_ASSESSMENT_CONCURRENCY,
+  nodeReleaseVersion: config.AR_IO_NODE_RELEASE,
 });
 
 export const reportCache = new NodeCache({


### PR DESCRIPTION
`getArnsResolution` will now send X-AR-IO-Node-Release header when the value is passed as argument.
AR_IO_NODE_RELEASE is used as argument on requests to the reference gateway and defaults to "0".