### PR TITLE
feat(info): use loaded wallet address in /ar-io/observer/info

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ import swaggerUi from 'swagger-ui-express';
 import YAML from 'yaml';
 
 import * as config from './config.js';
-import { reportCache } from './system.js';
+import { reportCache, walletAddress } from './system.js';
 
 // HTTP server
 export const app = express();
@@ -80,7 +80,7 @@ app.get('/ar-io/observer/healthcheck', async (_req, res) => {
 
 app.get('/ar-io/observer/info', (_req, res) => {
   res.status(200).send({
-    wallet: config.OBSERVER_WALLET,
+    wallet: walletAddress,
     contractId: config.CONTRACT_ID,
   });
 });

--- a/src/system.ts
+++ b/src/system.ts
@@ -216,6 +216,11 @@ export const arweave = new Arweave({
   protocol: arweaveURL.protocol.replace(':', ''),
 });
 
+export const walletAddress =
+  walletJwk !== undefined
+    ? await arweave.wallets.jwkToAddress(walletJwk)
+    : 'undefined';
+
 const turboReportSink =
   turboClient && signer
     ? new TurboReportSink({

--- a/src/system.ts
+++ b/src/system.ts
@@ -219,7 +219,7 @@ export const arweave = new Arweave({
 export const walletAddress =
   walletJwk !== undefined
     ? await arweave.wallets.jwkToAddress(walletJwk)
-    : 'undefined';
+    : 'INVALID';
 
 const turboReportSink =
   turboClient && signer


### PR DESCRIPTION
`/ar-io/observer/info` endpoint will now display the loaded wallet address or `"undefined"` if it fails to parse wallet file.