### PR TITLE
feat(observer): cache reference gateway arns resolution

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -350,6 +350,8 @@ export class Observer {
     arnsName: string;
     entropy: Buffer;
   }): Promise<ArnsNameAssessment> {
+    // TODO instantiate cache in constructor
+    // Currently not possible because we only have access to epochStartHeight in generateReport
     if (this.referenceGatewayResolutionCache === undefined) {
       throw new Error('Reference gateway resolution cache not set');
     }


### PR DESCRIPTION
Add a cache for the reference gateway arns resolution so it will only resolve once instead of multiple times (one per assessed gateway)