### PR TITLE
Add environment variable for secure key storage

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -98,6 +98,7 @@ export const NAME_ASSESSMENT_CONCURRENCY = +env.varOrDefault(
 
 // Wallet used to upload reports and interact with the contract
 export const KEY_FILE = './wallets/' + OBSERVER_WALLET + '.json';
+export const JWK = env.varOrUndefined('OBSERVER_JWK');
 
 export const SUBMIT_CONTRACT_INTERACTIONS =
   env.varOrDefault('SUBMIT_CONTRACT_INTERACTIONS', 'false') === 'true';

--- a/src/system.ts
+++ b/src/system.ts
@@ -172,6 +172,18 @@ const fsReportStore = new FsReportStore({
 
 log.info(`Using wallet ${config.OBSERVER_WALLET}`);
 export const walletJwk: JWKInterface | undefined = (() => {
+  if(config.JWK) {
+    try {
+      const jwk = JSON.parse(config.JWK);
+      log.info('Key loaded from environment');
+      return jwk;
+    } catch (error: any) {
+      log.error('Unable to load key from environment:', {
+        message: error.message,
+      });
+    }
+  }
+
   try {
     log.info('Loading key file...', {
       keyFile: config.KEY_FILE,
@@ -185,9 +197,10 @@ export const walletJwk: JWKInterface | undefined = (() => {
     log.error('Unable to load key file:', {
       message: error.message,
     });
-    log.warn('Reports will not be published to Arweave');
-    return undefined;
   }
+
+  log.warn('Reports will not be published to Arweave');
+  return undefined;
 })();
 
 export const turboClient: TurboAuthenticatedClient | undefined = (() => {


### PR DESCRIPTION
This PR adds the `OBSERVER_JWK` environment variable, simplifying the encrypted storage of the observer key/wallet in a secure vault.