### PR TITLE
fix(sdk): bump ar.io/sdk to v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^1.1.0",
+    "@ar.io/sdk": "1.1.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.0.1",
     "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^1.1.0-alpha.8",
+    "@ar.io/sdk": "^1.1.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.0.1",
     "ajv": "^8.12.0",

--- a/src/store/contract-report-sink.test.ts
+++ b/src/store/contract-report-sink.test.ts
@@ -19,10 +19,7 @@ import { ArIO, ArIOState, RemoteContract } from '@ar.io/sdk';
 import { expect } from 'chai';
 import nock from 'nock';
 
-
-
 import { interactionAlreadySaved } from './contract-report-sink.js';
-
 
 const observerWallet = 'test';
 const epochStartHeight = 1234567890;

--- a/src/store/contract-report-sink.test.ts
+++ b/src/store/contract-report-sink.test.ts
@@ -19,7 +19,10 @@ import { ArIO, ArIOState, RemoteContract } from '@ar.io/sdk';
 import { expect } from 'chai';
 import nock from 'nock';
 
+
+
 import { interactionAlreadySaved } from './contract-report-sink.js';
+
 
 const observerWallet = 'test';
 const epochStartHeight = 1234567890;
@@ -167,8 +170,21 @@ describe('interactionAlreadySaved', function () {
     expect(result).to.be.false;
   });
 
+  // by default the SDK will retry 5 times
   it('should gracefully handle network errors', async function () {
-    nock(contractCacheUrl).get(networkCallPath).replyWithError('Network error');
+    nock(contractCacheUrl)
+      .get(networkCallPath)
+      .replyWithError('Network error')
+      .get(networkCallPath)
+      .replyWithError('Network error')
+      .get(networkCallPath)
+      .replyWithError('Network error')
+      .get(networkCallPath)
+      .replyWithError('Network error')
+      .get(networkCallPath)
+      .replyWithError('Network error')
+      .get(networkCallPath)
+      .replyWithError('Network error');
 
     try {
       await interactionAlreadySaved({

--- a/src/system.ts
+++ b/src/system.ts
@@ -112,6 +112,10 @@ const networkContract = ArIO.init({
   signer,
 });
 
+log.info(`Using contract ${config.CONTRACT_ID} to fetch contract information`, {
+  contractId: config.CONTRACT_ID,
+});
+
 // Attempt to read the start height and epoch block length from the contract - default to constants if it fails
 const { epochZeroStartHeight, epochBlockLength } = await networkContract
   .getCurrentEpoch()
@@ -130,6 +134,11 @@ const { epochZeroStartHeight, epochBlockLength } = await networkContract
       epochBlockLength: EPOCH_BLOCK_LENGTH,
     };
   });
+
+log.info('Using epoch start height and block length from contract cache', {
+  epochZeroStartHeight,
+  epochBlockLength,
+});
 
 export const epochHeightSelector = new EpochHeightSource({
   heightSource: chainSource,

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,14 +32,15 @@
     call-me-maybe "^1.0.1"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^1.1.0-alpha.8":
-  version "1.1.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-1.1.0-alpha.8.tgz#4062f5c9e90d983f18cfa6e6ff0b07587ee0b9e2"
-  integrity sha512-Fdr2cbg+9a6ays8sbpDTlzx91ECF3O9CUMUEpsk0mVGfox7F/rkOGsTO361MFIG8jZX/WLSXFpLrIRfpvmgT0Q==
+"@ar.io/sdk@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-1.1.0.tgz#b9519823f3f43c6be694d99900687eeb68774b8b"
+  integrity sha512-f/GAG0bSsrFj9NuSYar5WIXl8Tsgq+hV8svgzdaP3a9iTxjcYdV9sEOyujiNjFPlp8TqREKKl381n7IcHBYOgg==
   dependencies:
     arbundles "0.11.0"
     arweave "1.14.4"
     axios "1.6.0"
+    axios-retry "^4.3.0"
     bunyan "^1.8.15"
     warp-contracts "1.4.45"
 
@@ -1677,6 +1678,13 @@ axios-retry@^3.7.0:
   integrity sha512-uK9K/GnlExfShu9dB4GuK0j+iGkIR+LRus3ILhE0zSVXY2q6Dxpemr50NPMs5kP7eOKv9Pz4VvUO40ps1F67dA==
   dependencies:
     "@babel/runtime" "^7.15.4"
+    is-retry-allowed "^2.2.0"
+
+axios-retry@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-4.3.0.tgz#43d10bb3675286d116e0a37350ff73aec36ebb80"
+  integrity sha512-vUAQ3bi02Q++b8aAn3fuM03qRKFLZ6BPcqSVsOpgWeww2jrYFpu9SKb9VuctvxrJuRCWM/voDuuRAD7v3A1G5g==
+  dependencies:
     is-retry-allowed "^2.2.0"
 
 axios@1.6.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,7 +32,7 @@
     call-me-maybe "^1.0.1"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^1.1.0":
+"@ar.io/sdk@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-1.1.0.tgz#b9519823f3f43c6be694d99900687eeb68774b8b"
   integrity sha512-f/GAG0bSsrFj9NuSYar5WIXl8Tsgq+hV8svgzdaP3a9iTxjcYdV9sEOyujiNjFPlp8TqREKKl381n7IcHBYOgg==


### PR DESCRIPTION
Validated the release.

Observation: https://viewblock.io/arweave/tx/YdnZTvlrX15gxUlZ2gNNiv2Fqdpki_8W3h-fCqXVN_s 
<img width="1307" alt="image" src="https://github.com/ar-io/ar-io-observer/assets/12800001/6b40da0f-93ef-4b1e-9a8a-f52b92f78cb3">

```
info: Observation interactions saved {"interactionIds":["Gja5lxZCZM8P-gh5Q2XMWNB1dtj3w9WHB23NLaywMoQ","1q4w0p8qMQr0M8q2d1dS9tV-pMyqYCqyNDj5DVFctlI"],"timestamp":"2024-06-03T19:21:45.206Z"}
```
<img width="1278" alt="image" src="https://github.com/ar-io/ar-io-observer/assets/12800001/f09e4931-5e78-46e6-abd5-866abdd4e896">
