### PR TITLE
fix(epochs): handle when first epoch has not started yet.

### DIFF
--- a/src/epochs/contract-epoch-source.ts
+++ b/src/epochs/contract-epoch-source.ts
@@ -61,7 +61,22 @@ export class ContractEpochSource implements IEpochTimestampSource {
     const { startTimestamp, startHeight, endTimestamp, epochIndex } =
       await this.contract.getCurrentEpoch();
 
-    this.log.info('Updating epoch params.', {
+    // if they are undefined, we are before the first epoch
+    if (
+      startTimestamp === undefined &&
+      startHeight === undefined &&
+      endTimestamp === undefined &&
+      epochIndex === undefined
+    ) {
+      this.log.info('No epoch data available.');
+      return {
+        epochStartTimestamp: startTimestamp,
+        epochStartHeight: startHeight,
+        epochEndTimestamp: endTimestamp,
+        epochIndex: epochIndex,
+      };
+    }
+    this.log.info('Setting epoch params.', {
       startTimestamp: startTimestamp,
       startHeight: startHeight,
       endTimestamp: endTimestamp,

--- a/src/system.ts
+++ b/src/system.ts
@@ -266,6 +266,12 @@ export async function updateAndSaveCurrentReport() {
   try {
     log.info('Generating report...');
     const reportStartTime = Date.now();
+    // check that epochs have started
+    const epochIndex = await epochSource.getEpochIndex();
+    if (epochIndex === undefined) {
+      log.info('First epoch has not started yet. Not generating report.');
+      return;
+    }
     const report = await observer.generateReport();
     log.info(`Report generated in ${Date.now() - reportStartTime}ms`);
     reportCache.set('current', report);

--- a/src/system.ts
+++ b/src/system.ts
@@ -264,14 +264,14 @@ const START_HEIGHT_END_OFFSET_MS = 2 * MAX_FORK_DEPTH * AVERAGE_BLOCK_TIME_MS;
 
 export async function updateAndSaveCurrentReport() {
   try {
-    log.info('Generating report...');
-    const reportStartTime = Date.now();
     // check that epochs have started
     const epochIndex = await epochSource.getEpochIndex();
     if (epochIndex === undefined) {
       log.info('First epoch has not started yet. Not generating report.');
       return;
     }
+    log.info('Generating report...');
+    const reportStartTime = Date.now();
     const report = await observer.generateReport();
     log.info(`Report generated in ${Date.now() - reportStartTime}ms`);
     reportCache.set('current', report);


### PR DESCRIPTION
Epochs may start in the future, in this case no epoch data will be returned. Instead of trying to generate a report we will gracefully exit the report generation and try again on the next interval.
```
info: No epoch data available. {"class":"ContractEpochSource","timestamp":"2024-06-24T22:01:47.723Z"}
info: First epoch has not started yet. Not generating report. {"timestamp":"2024-06-24T22:01:47.723Z"}
```