### PR TITLE
feat(ao): allow AO env variables to point process evaluation against …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --ignore-engines
       - run: yarn
       - run: yarn ${{ matrix.step }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN yarn install --ignore-engines \
     && yarn build \
     && rm -rf node_modules \
-    && yarn install --production 
+    && yarn install --production --ignore-engines
 
 # Runtime
 FROM gcr.io/distroless/nodejs${NODE_VERSION_SHORT}-debian11

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ FROM node:${NODE_VERSION}-bullseye-slim AS builder
 WORKDIR /app
 RUN apt-get update && apt-get install build-essential python3 -y
 COPY . .
-RUN yarn install \
+RUN yarn install --ignore-engines \
     && yarn build \
     && rm -rf node_modules \
-    && yarn install --production
+    && yarn install --production 
 
 # Runtime
 FROM gcr.io/distroless/nodejs${NODE_VERSION_SHORT}-debian11

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^2.0.0",
+    "@ar.io/sdk": "^2.0.2",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.0.1",
+    "@permaweb/aoconnect": "^0.0.56",
     "ajv": "^8.12.0",
     "arbundles": "0.11.0",
     "arweave": "1.13.7",

--- a/src/config.ts
+++ b/src/config.ts
@@ -116,3 +116,10 @@ export const REPORT_GENERATION_INTERVAL_MS = +env.varOrDefault(
 );
 
 export const AR_IO_NODE_RELEASE = env.varOrDefault('AR_IO_NODE_RELEASE', 'dev');
+
+// AO
+
+export const AO_MU_URL = env.varOrUndefined('AO_MU_URL');
+export const AO_CU_URL = env.varOrUndefined('AO_CU_URL');
+export const AO_GRAPHQL_URL = env.varOrUndefined('AO_GRAPHQL_URL');
+export const AO_GATEWAY_URL = env.varOrUndefined('AO_GATEWAY_URL');

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,16 +52,6 @@ export const ARWEAVE_URL = env.varOrDefault(
   'https://arweave.net',
 );
 
-export const CONTRACT_CACHE_URL = env.varOrDefault(
-  'CONTRACT_CACHE_URL',
-  'https://dev.arns.app',
-);
-
-export const CONTRACT_ID = env.varOrDefault(
-  'CONTRACT_ID',
-  'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U',
-);
-
 export const IO_PROCESS_ID = env.varOrDefault(
   'IO_PROCESS_ID',
   'agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA',
@@ -107,8 +97,6 @@ export const JWK = env.varOrUndefined('OBSERVER_JWK');
 
 export const SUBMIT_CONTRACT_INTERACTIONS =
   env.varOrDefault('SUBMIT_CONTRACT_INTERACTIONS', 'false') === 'true';
-
-export const WARP_LOG_LEVEL = env.varOrDefault('WARP_LOG_LEVEL', 'fatal');
 
 export const REPORT_GENERATION_INTERVAL_MS = +env.varOrDefault(
   'REPORT_GENERATION_INTERVAL_MS',

--- a/src/system.ts
+++ b/src/system.ts
@@ -15,12 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { IO, IOWriteable, WeightedObserver } from '@ar.io/sdk/node';
+import { AOProcess, IO, IOWriteable, WeightedObserver } from '@ar.io/sdk/node';
 import {
   TurboAuthenticatedClient,
   TurboFactory,
   defaultTurboConfiguration,
 } from '@ardrive/turbo-sdk/node';
+import { connect } from '@permaweb/aoconnect';
 import { ArweaveSigner, JWKInterface } from 'arbundles/node';
 import Arweave from 'arweave';
 import { default as NodeCache } from 'node-cache';
@@ -95,8 +96,17 @@ const signer =
   walletJwk !== undefined ? new ArweaveSigner(walletJwk) : undefined;
 
 const networkContract = IO.init({
-  processId: config.IO_PROCESS_ID,
-  signer,
+  ...(signer !== undefined ? { signer } : {}),
+  process: new AOProcess({
+    processId: config.IO_PROCESS_ID,
+    ao: connect({
+      // @permaweb/aoconnect defaults will be used if these are not provided
+      MU_URL: config.AO_MU_URL,
+      CU_URL: config.AO_CU_URL,
+      GRAPHQL_URL: config.AO_GATEWAY_URL,
+      GATEWAY_URL: config.AO_GATEWAY_URL,
+    }),
+  }),
 });
 
 log.info(

--- a/src/system.ts
+++ b/src/system.ts
@@ -103,7 +103,7 @@ const networkContract = IO.init({
       // @permaweb/aoconnect defaults will be used if these are not provided
       MU_URL: config.AO_MU_URL,
       CU_URL: config.AO_CU_URL,
-      GRAPHQL_URL: config.AO_GATEWAY_URL,
+      GRAPHQL_URL: config.AO_GRAPHQL_URL,
       GATEWAY_URL: config.AO_GATEWAY_URL,
     }),
   }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,9 +18,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "skipLibCheck": true,
-    "paths": {
-      "warp-contracts-lmdb": ["./node_modules/warp-contracts-lmdb/lib/types/index.d.ts"]
-    }
   },
   "ts-node": {
     "swc": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,10 +32,10 @@
     call-me-maybe "^1.0.1"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-2.0.0.tgz#8725d1ece71b19dd7bfe44e846190bd458164206"
-  integrity sha512-at40lht1K6BOegoHoTezgL3z8y+Wj3VTEHMjNcoAywAV4R5l69xOTkJqEDL1uyLahspmxYGgX7rf50XFaVxMOw==
+"@ar.io/sdk@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-2.0.2.tgz#64aa7c4e6b30bbe36d7cc7d450f32d100ee731b3"
+  integrity sha512-DGSHo9Bf90Pe2m4lBEJPFuUageAaoO+nA42nhGJ2vCn6dKVM/y3aSqCJ+H5enHjidx0H1MmsgysiBQGEBElMHg==
   dependencies:
     "@permaweb/aoconnect" "^0.0.55"
     arbundles "0.11.0"
@@ -765,6 +765,20 @@
   version "0.0.55"
   resolved "https://registry.yarnpkg.com/@permaweb/aoconnect/-/aoconnect-0.0.55.tgz#d856a078d3702154ac58541d09478d25ed3acf2c"
   integrity sha512-W2GtLZedVseuDkCKk4CmM9SFmi0DdrMKqvhMBm9xo65z+Mzr/t1TEjMJKRNzEA2qh5IdwM43sWJ5fmbBYLg6TQ==
+  dependencies:
+    "@permaweb/ao-scheduler-utils" "~0.0.16"
+    buffer "^6.0.3"
+    debug "^4.3.4"
+    hyper-async "^1.1.2"
+    mnemonist "^0.39.8"
+    ramda "^0.29.1"
+    warp-arbundles "^1.0.4"
+    zod "^3.22.4"
+
+"@permaweb/aoconnect@^0.0.56":
+  version "0.0.56"
+  resolved "https://registry.yarnpkg.com/@permaweb/aoconnect/-/aoconnect-0.0.56.tgz#28dcf1a094a2b1c1cbaa246d63eeb08a5a0c7269"
+  integrity sha512-Eu4AC1KeX2EOIS9ihWkwPJs7rK+/+XV43QwOJ9DCQAu6EhjanlT3UfV2wSpGiFK/dT/B1YsQyTcxNrmQaXn81g==
   dependencies:
     "@permaweb/ao-scheduler-utils" "~0.0.16"
     buffer "^6.0.3"


### PR DESCRIPTION
…specific AO infrastrucutre

The defaults are reccomended, but this gives operators the ability to point the resolvers dryRuns to specific AO infrastructure. Useful for testing and if you are running any part of an AO stack yourself to avoid rate-limiting/network issues.