### PR TITLE
fix(PE-6512): more accurate query for report tx ids when checking if report is submitted

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.0.1",
     "@permaweb/aoconnect": "^0.0.56",
-    "ajv": "^8.12.0",
     "arbundles": "0.11.0",
     "arweave": "1.13.7",
     "cors": "^2.8.5",
@@ -29,7 +28,6 @@
     "p-map": "^6.0.0",
     "prom-client": "^14.0.1",
     "swagger-ui-express": "^5.0.0",
-    "wait": "^0.4.2",
     "winston": "^3.7.2",
     "yaml": "^2.3.1",
     "yargs": "^17.7.2"

--- a/src/store/turbo-report-sink.ts
+++ b/src/store/turbo-report-sink.ts
@@ -162,41 +162,32 @@ export class TurboReportSink implements ReportSink {
     const epochStartHeight = report.epochStartHeight;
     const epochIndex = report.epochIndex;
 
-    // Find the first report TX ID for the given epoch start height
+    // Find the first report TX ID for the given epoch start height and format version
     const queryObject = {
       query: `{
-  transactions(
-    sort: HEIGHT_ASC,
-    first:1,
-    owners: [ "${this.walletAddress}" ],
-    tags: [
-      {
-        name: "AR-IO-Epoch-Start-Height",
-        values: [ "${epochStartHeight}" ]
-      },
-      {
-        name: "AR-IO-Epoch-Index",
-        values: [ "${epochIndex}" ]
-      }
-      {
-        name: "AR-IO-Epoch-Start-Timestamp",
-        values: [ "${epochStartTimestamp}" ]
-      },
-      {
-        name: "App-Name",
-        values: ["AR-IO Observer"]
-      }
-    ]
-  ) 
-  {
-    edges {
-      node {
-        id
-      }
-    }
-  }
-}`,
+        transactions(
+          sort: HEIGHT_ASC,
+          first:1,
+          owners: [ "${this.walletAddress}" ],
+          tags: [
+            { name: "App-Name", values: ["AR-IO Observer"] },
+            { name: "Content-Type", values: [ "application/json" ] },
+            { name: "AR-IO-Epoch-Start-Height", values: [ "${epochStartHeight}" ]},
+            { name: "AR-IO-Epoch-Index", values: [ "${epochIndex}" ] }
+            { name: "AR-IO-Epoch-Start-Timestamp", values: [ "${epochStartTimestamp}" ]},
+            { name: "AR-IO-Observer-Report-Version", values: [ "${REPORT_FORMAT_VERSION}" ] }
+          ]
+        ) 
+        {
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }`,
     };
+
     const response = await this.arweave.api.post('/graphql', queryObject);
 
     // Return the first report TX ID if it exists

--- a/yarn.lock
+++ b/yarn.lock
@@ -1404,7 +1404,7 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.11.2, ajv@^8.12.0:
+ajv@^8.0.0, ajv@^8.11.2:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
@@ -5127,11 +5127,6 @@ vlq@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-2.0.4.tgz#6057b85729245b9829e3cc7755f95b228d4fe041"
   integrity sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA==
-
-wait@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/wait/-/wait-0.4.2.tgz#d7d932ea72a57a78b526d168322457d2d7e4ae33"
-  integrity sha512-g4Uu25y9MJ3jtBcrRDDXeI/f7lBNtVmNUM3Xd78S19tm1gZutDkL/f6UEcMi/NqWvKZ74Mhrb+4LwpYbjG6XYA==
 
 warp-arbundles@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
We have some overlap in tags used for `Save-Observation` and reports submitted to arweave, causing some observers to provide incorrect report tx ids when they find those interactions from GQL. This update ensures we search for json reports of a specific format version for reports.
