### PR TITLE
chore(yarn): add .yarnrc file to avoid having to pass around --ignore…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache --ignore-engines
-      - run: yarn
+      - run: yarn --immutable --immutable-cache
       - run: yarn ${{ matrix.step }}
 
   push:

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-engines true

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ FROM node:${NODE_VERSION}-bullseye-slim AS builder
 WORKDIR /app
 RUN apt-get update && apt-get install build-essential python3 -y
 COPY . .
-RUN yarn install --ignore-engines \
+RUN yarn install \
     && yarn build \
     && rm -rf node_modules \
-    && yarn install --production --ignore-engines
+    && yarn install --production
 
 # Runtime
 FROM gcr.io/distroless/nodejs${NODE_VERSION_SHORT}-debian11


### PR DESCRIPTION
…-engines everywhere

This is required bc aoconnect encourages the use of npm over yarn.