### PR TITLE
fix(arns): fix api call to fetch all arns names

### DIFF
--- a/src/names/contract-names-source.ts
+++ b/src/names/contract-names-source.ts
@@ -35,16 +35,18 @@ export class ContractNamesSource implements ArnsNamesSource, ArnsNameList {
   // we don't use height here, but it's required by the interface
   async getAllNames(_height: number): Promise<string[]> {
     let cursor;
-    const namesArray: string[] = [];
+    const namesArray: Set<string> = new Set();
     do {
       const result = await this.contract.getArNSRecords({
         cursor,
         limit: 1000,
       });
+      for (const record of result.items) {
+        namesArray.add(record.name);
+      }
       cursor = result.nextCursor;
-      namesArray.concat(Object.keys(result.items));
     } while (cursor !== undefined);
-    return namesArray.sort();
+    return [...namesArray].sort();
   }
 
   async getName(height: number, index: number): Promise<string> {

--- a/src/names/contract-names-source.ts
+++ b/src/names/contract-names-source.ts
@@ -34,9 +34,17 @@ export class ContractNamesSource implements ArnsNamesSource, ArnsNameList {
 
   // we don't use height here, but it's required by the interface
   async getAllNames(_height: number): Promise<string[]> {
-    const names = await this.contract.getArNSRecords();
-    const namesArray = Object.keys(names).sort();
-    return namesArray;
+    let cursor;
+    const namesArray: string[] = [];
+    do {
+      const result = await this.contract.getArNSRecords({
+        cursor,
+        limit: 1000,
+      });
+      cursor = result.nextCursor;
+      namesArray.concat(Object.keys(result.items));
+    } while (cursor !== undefined);
+    return namesArray.sort();
   }
 
   async getName(height: number, index: number): Promise<string> {


### PR DESCRIPTION
This is a bug causing observers to self prescribe the keys of the response of `getArNSRecords` - which is now paginated and returns `nextCursor`, `items`, `limit`, `hasMore`, etc. You can see that every observer has self-assigned these names even though they are not in the ArNS registry. Interesting enough, because they return 404, every gateway (assuming it was running) likely passed the observation of these names.

An example report can be seen here: https://network-portal.app/#/gateways/1H7WZIWhzwTH9FIcnuMqYkTsoyv1OTfGa_amvuYwrgo/reports/CBrkWxstHkKD_lYyjnLGRhAlHhU2oMu5z6rXJ1LLPNw

<img width="575" alt="image" src="https://github.com/user-attachments/assets/ee87a291-737b-49e4-887f-6e6058951a13">