### PR TITLE
chore(headers): add `Accept-Encoding: identity` to arns resolution he…

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -194,6 +194,7 @@ export async function getArnsResolution({
             responseType: 'buffer',
             headers: {
               Range: `bytes=${range}`,
+              'Accept-Encoding': 'identity',
             },
           }),
         ),

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -134,7 +134,9 @@ export async function getArnsResolution({
 
   const getHashWithinFirstMiB = () => {
     return new Promise<ArnsResolution>((resolve, reject) => {
-      const stream = got.stream.get(url);
+      const stream = got.stream.get(url, {
+        headers: { 'Accept-Encoding': 'identity' },
+      });
       let response: any;
       let streamBytesProcessed = 0;
 


### PR DESCRIPTION
…aders to ensure CDNs of operators do not return different compression types of underlying data