### PR TITLE
fix(deps): upgrade ar-io-sdk to v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^2.2.0",
+    "@ar.io/sdk": "^3.0.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.17.0",
     "@dha-team/arbundles": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^3.0.0",
+    "@ar.io/sdk": "^3.1.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.17.0",
     "@dha-team/arbundles": "^1.0.1",

--- a/src/epochs/contract-epoch-source.ts
+++ b/src/epochs/contract-epoch-source.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { AoIORead, IO } from '@ar.io/sdk';
+import { AoARIORead, ARIO } from '@ar.io/sdk/node';
 import winston from 'winston';
 
 import * as config from '../config.js';
@@ -24,19 +24,19 @@ import { BlockSource, EpochTimestampParams, HeightSource } from '../types.js';
 import { EpochTimestampSource as IEpochTimestampSource } from '../types.js';
 
 export class ContractEpochSource implements IEpochTimestampSource {
-  private contract: AoIORead;
+  private contract: AoARIORead;
   private blockSource: BlockSource;
   private heightSource: HeightSource;
   private epochParams: EpochTimestampParams | undefined;
   private log: winston.Logger;
 
   constructor({
-    contract = IO.init({ processId: config.IO_PROCESS_ID }),
+    contract = ARIO.init({ processId: config.IO_PROCESS_ID }),
     blockSource,
     heightSource,
     log = defaultLogger,
   }: {
-    contract?: AoIORead;
+    contract?: AoARIORead;
     blockSource: BlockSource;
     heightSource: HeightSource;
     log?: winston.Logger;

--- a/src/epochs/contract-epoch-source.ts
+++ b/src/epochs/contract-epoch-source.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { AoARIORead, ARIO } from '@ar.io/sdk/node';
+import { ARIO, AoARIORead } from '@ar.io/sdk/node';
 import winston from 'winston';
 
 import * as config from '../config.js';

--- a/src/hosts/contract-hosts-source.ts
+++ b/src/hosts/contract-hosts-source.ts
@@ -15,21 +15,21 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { AoIORead } from '@ar.io/sdk';
+import { AoARIORead } from '@ar.io/sdk/node';
 import winston from 'winston';
 
 import defaultLogger from '../log.js';
 import { GatewayHost, GatewayHostsSource } from '../types.js';
 
 export class ContractHostsSource implements GatewayHostsSource {
-  private contract: AoIORead;
+  private contract: AoARIORead;
   private log: winston.Logger;
 
   constructor({
     contract,
     log = defaultLogger,
   }: {
-    contract: AoIORead;
+    contract: AoARIORead;
     log?: winston.Logger;
   }) {
     this.contract = contract;

--- a/src/log.ts
+++ b/src/log.ts
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { Logger } from '@ar.io/sdk/node';
 import { createLogger, format, transports } from 'winston';
 
 import * as env from './lib/env.js';
@@ -24,6 +25,9 @@ const LOG_ALL_STACKTRACES =
   env.varOrDefault('LOG_ALL_STACKTRACES', 'false') === 'true';
 const LOG_FORMAT = env.varOrDefault('LOG_FORMAT', 'simple');
 const INSTANCE_ID = env.varOrUndefined('INSTANCE_ID');
+
+// set ar-io-sdk log level to match the observer log level
+Logger.default.setLogLevel(LOG_LEVEL as any);
 
 const log = createLogger({
   level: LOG_LEVEL,

--- a/src/names/contract-names-source.ts
+++ b/src/names/contract-names-source.ts
@@ -15,13 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { AoIORead } from '@ar.io/sdk';
+import { AoARIORead } from '@ar.io/sdk/node';
 
 import { ArnsNameList, ArnsNamesSource } from '../types.js';
 
 export class ContractNamesSource implements ArnsNamesSource, ArnsNameList {
-  private contract: AoIORead;
-  constructor({ contract }: { contract: AoIORead }) {
+  private contract: AoARIORead;
+  constructor({ contract }: { contract: AoARIORead }) {
     this.contract = contract;
   }
 

--- a/src/store/contract-report-sink.ts
+++ b/src/store/contract-report-sink.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { AOProcess, AoIORead, AoIOWrite, IO } from '@ar.io/sdk/node';
+import { AOProcess, AoARIOWrite, ARIO, AoARIORead } from '@ar.io/sdk/node';
 import { connect } from '@permaweb/aoconnect';
 import { Tag } from 'arweave/node/lib/transaction.js';
 import * as winston from 'winston';
@@ -48,7 +48,7 @@ export async function interactionAlreadySaved({
   observerWallet,
   epochIndex,
   failedGatewaySummaries,
-  contract = IO.init({
+  contract = ARIO.init({
     process: new AOProcess({
       processId: config.IO_PROCESS_ID,
       ao: connect({
@@ -63,7 +63,7 @@ export async function interactionAlreadySaved({
   observerWallet: string;
   epochIndex: number;
   failedGatewaySummaries: string[];
-  contract?: AoIORead;
+  contract?: AoARIORead;
 }): Promise<boolean> {
   const observations = await contract.getObservations({
     epochIndex,
@@ -124,7 +124,7 @@ function splitArrayBySize(array: string[], maxSizeInBytes: number): string[][] {
 export class ContractReportSink implements ReportSink {
   // Dependencies
   private log: winston.Logger;
-  private contract: AoIOWrite;
+  private contract: AoARIOWrite;
   private readonly walletAddress: string;
 
   constructor({
@@ -133,7 +133,7 @@ export class ContractReportSink implements ReportSink {
     walletAddress,
   }: {
     log: winston.Logger;
-    contract: AoIOWrite;
+    contract: AoARIOWrite;
     walletAddress: string;
   }) {
     this.log = log;

--- a/src/store/contract-report-sink.ts
+++ b/src/store/contract-report-sink.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { AOProcess, AoARIOWrite, ARIO, AoARIORead } from '@ar.io/sdk/node';
+import { AOProcess, ARIO, AoARIORead, AoARIOWrite } from '@ar.io/sdk/node';
 import { connect } from '@permaweb/aoconnect';
 import { Tag } from 'arweave/node/lib/transaction.js';
 import * as winston from 'winston';

--- a/src/system.ts
+++ b/src/system.ts
@@ -17,9 +17,10 @@
  */
 import {
   AOProcess,
+  ARIO,
+  ARIOWriteable,
   AoWeightedObserver,
-  IO,
-  IOWriteable,
+  Logger,
 } from '@ar.io/sdk/node';
 import {
   TurboAuthenticatedClient,
@@ -100,7 +101,7 @@ const chainSource = new ChainSource({
 const signer =
   walletJwk !== undefined ? new ArweaveSigner(walletJwk) : undefined;
 
-const networkContract = IO.init({
+const networkContract = ARIO.init({
   ...(signer !== undefined ? { signer } : {}),
   process: new AOProcess({
     processId: config.IO_PROCESS_ID,
@@ -239,7 +240,7 @@ if (turboReportSink !== undefined) {
 }
 
 export const contractReportSink =
-  networkContract !== undefined && networkContract instanceof IOWriteable
+  networkContract !== undefined && networkContract instanceof ARIOWriteable
     ? new ContractReportSink({
         log,
         contract: networkContract,

--- a/src/system.ts
+++ b/src/system.ts
@@ -20,7 +20,6 @@ import {
   ARIO,
   ARIOWriteable,
   AoWeightedObserver,
-  Logger,
 } from '@ar.io/sdk/node';
 import {
   TurboAuthenticatedClient,

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,18 +37,20 @@
     call-me-maybe "^1.0.1"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^2.2.0":
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-2.2.5.tgz#fa62cf851fc8761f35eb64342d35c42a083c135b"
-  integrity sha512-6vLVGGEW/WGeHm4gbmDeAqw6Jpj40mJDmO9CITDDJLbb8VFdxFnPVo1eyFGwQpOy/dGeoUCcmtRYcf7zqeQTHQ==
+"@ar.io/sdk@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.0.0.tgz#68cfc4dcf32b894c7a519b8958ff9405fb71e204"
+  integrity sha512-EIplLoLrMnCSqRX5Z3cruGwe41b3TCfwAM0YmEC4yxFmin3hYhjvx8aNhf3jn/c0HEdGpRcESYYHvfPLUpvHpg==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"
     arweave "1.14.4"
-    axios "1.7.7"
+    axios "1.7.8"
     axios-retry "^4.3.0"
+    commander "^12.1.0"
     eventemitter3 "^5.0.1"
     plimit-lit "^3.0.1"
+    prompts "^2.4.2"
     winston "^3.13.0"
     zod "^3.23.8"
 
@@ -2044,10 +2046,10 @@ axios@1.4.0:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@1.7.7, axios@^1.6.0:
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
-  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+axios@1.7.8:
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.8.tgz#1997b1496b394c21953e68c14aaa51b7b5de3d6e"
+  integrity sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -2060,6 +2062,15 @@ axios@^0.27.2:
   dependencies:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
+
+axios@^1.6.0:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
+  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,15 +37,15 @@
     call-me-maybe "^1.0.1"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.0.0.tgz#68cfc4dcf32b894c7a519b8958ff9405fb71e204"
-  integrity sha512-EIplLoLrMnCSqRX5Z3cruGwe41b3TCfwAM0YmEC4yxFmin3hYhjvx8aNhf3jn/c0HEdGpRcESYYHvfPLUpvHpg==
+"@ar.io/sdk@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.1.0.tgz#adb95ec64627f73c2b7c76db5e0afbc34ac18361"
+  integrity sha512-ePtvVcffzJcU+LoHqjL0RwJeS/3dCgEolWw7/ywIWwXvzYbbhASdNdBEb6/Liz8baMO/GYsaUGVSpnjmVKC0aw==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"
     arweave "1.14.4"
-    axios "1.7.8"
+    axios "1.7.9"
     axios-retry "^4.3.0"
     commander "^12.1.0"
     eventemitter3 "^5.0.1"
@@ -2046,10 +2046,10 @@ axios@1.4.0:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@1.7.8:
-  version "1.7.8"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.8.tgz#1997b1496b394c21953e68c14aaa51b7b5de3d6e"
-  integrity sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==
+axios@1.7.9:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
+  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
Updates to ARIO classes exposed in v3+ of the ar-io-sdk. Adds log level support for process interactions.

Related: https://github.com/ar-io/ar-io-node/pull/256