### PR TITLE
fix(epoch): use epochZeroStartTimestamp to determine if you should tr…

### DIFF
--- a/src/epochs/contract-epoch-source.ts
+++ b/src/epochs/contract-epoch-source.ts
@@ -20,7 +20,12 @@ import winston from 'winston';
 
 import * as config from '../config.js';
 import defaultLogger from '../log.js';
-import { BlockSource, EpochTimestampParams, HeightSource } from '../types.js';
+import {
+  BlockSource,
+  EpochSettings,
+  EpochTimestampParams,
+  HeightSource,
+} from '../types.js';
 import { EpochTimestampSource as IEpochTimestampSource } from '../types.js';
 
 export class ContractEpochSource implements IEpochTimestampSource {
@@ -45,6 +50,14 @@ export class ContractEpochSource implements IEpochTimestampSource {
     this.blockSource = blockSource;
     this.heightSource = heightSource;
     this.log = log.child({ class: 'ContractEpochSource' });
+  }
+
+  async getEpochSettings(): Promise<EpochSettings> {
+    const epochSettings = await this.contract.getEpochSettings();
+    return {
+      epochZeroStartTimestamp: epochSettings.epochZeroStartTimestamp,
+      durationMs: epochSettings.durationMs,
+    };
   }
 
   async getEpochParams(): Promise<EpochTimestampParams> {

--- a/src/epochs/contract-epoch-source.ts
+++ b/src/epochs/contract-epoch-source.ts
@@ -62,6 +62,7 @@ export class ContractEpochSource implements IEpochTimestampSource {
 
   async getEpochParams(): Promise<EpochTimestampParams> {
     // cache the epoch params for the duration of the epoch to avoid unnecessary contract calls
+    // TODO: check the epochs have started, requires type change on this interface
     const height = await this.heightSource.getHeight();
     const block = await this.blockSource.getBlockByHeight(height);
     const networkTimestamp = block.timestamp * 1000;

--- a/src/system.ts
+++ b/src/system.ts
@@ -321,8 +321,8 @@ const START_HEIGHT_END_OFFSET_MS = 2 * MAX_FORK_DEPTH * AVERAGE_BLOCK_TIME_MS;
 export async function updateAndSaveCurrentReport() {
   try {
     // check that epochs have started
-    const epochIndex = await epochSource.getEpochIndex();
-    if (epochIndex === undefined) {
+    const { epochZeroStartTimestamp } = await epochSource.getEpochSettings();
+    if (Date.now() < epochZeroStartTimestamp) {
       log.info('First epoch has not started yet. Not generating report.');
       return;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,11 @@ export interface HeightSource {
 // Epochs
 //
 
+export interface EpochSettings {
+  epochZeroStartTimestamp: number;
+  durationMs: number;
+}
+
 export interface EpochTimestampParams {
   epochStartTimestamp: number;
   epochStartHeight: number;
@@ -45,6 +50,7 @@ export interface EpochHeightSource {
 }
 
 export interface EpochTimestampSource {
+  getEpochSettings(): Promise<EpochSettings>;
   getEpochStartHeight(): Promise<number>;
   getEpochStartTimestamp(): Promise<number>;
   getEpochEndTimestamp(): Promise<number>;


### PR DESCRIPTION
…y and submit a report

The current error:
```
info: Listening on port 5050 {"timestamp":"2025-02-20T07:07:12.583Z"}
info: Generating report... {"timestamp":"2025-02-20T07:07:13.237Z"}
error: Error generating report Cannot destructure property 'startTimestamp' of '(intermediate value)' as it is undefined. {"stack":"TypeError: Cannot destructure property 'startTimestamp' of '(intermediate value)' as it is undefined.\n    at ContractEpochSource.getEpochParams (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/src/epochs/contract-epoch-source.ts:49:17)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Observer.generateReport (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/src/observer.ts:279:37)\n    at async updateAndSaveCurrentReport (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/src/system.ts:259:24)","timestamp":"2025-02-20T07:07:13.941Z"}
```

This happens because we expect epoch to be defined in the ContractSource. If we have not created any epochs, the destructing of the empty epoch throws the error.

Checking the epochZeroStartTimestamp is a better way to indicate if/when epochs should be created.

With the fix:
```bash
info: Using wallet 1H7WZIWhzwTH9FIcnuMqYkTsoyv1OTfGa_amvuYwrgo {"timestamp":"2025-02-20T07:07:47.527Z"}
info: Loading key file... {"keyFile":"wallets/1H7WZIWhzwTH9FIcnuMqYkTsoyv1OTfGa_amvuYwrgo.json","timestamp":"2025-02-20T07:07:47.530Z"}
info: Key file loaded {"keyFile":"wallets/1H7WZIWhzwTH9FIcnuMqYkTsoyv1OTfGa_amvuYwrgo.json","timestamp":"2025-02-20T07:07:47.530Z"}
info: Using process PklI5-ORsL310QNAwh-LMcFycFxPkJ67MmoriUCaL3I to fetch contract information {"processId":"PklI5-ORsL310QNAwh-LMcFycFxPkJ67MmoriUCaL3I","timestamp":"2025-02-20T07:07:47.543Z"}
info: SUBMIT_CONTRACT_INTERACTIONS is false - contract interactions will not be saved {"timestamp":"2025-02-20T07:07:47.552Z"}
info: Listening on port 5050 {"timestamp":"2025-02-20T07:07:47.604Z"}
info: First epoch has not started yet. Not generating report. {"timestamp":"2025-02-20T07:07:48.261Z"}
```