### PR TITLE
chore(logs): use env var for ar.io/sdk log level

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -20,14 +20,16 @@ import { createLogger, format, transports } from 'winston';
 
 import * as env from './lib/env.js';
 
+// observer internal log level
 const LOG_LEVEL = env.varOrDefault('LOG_LEVEL', 'info');
 const LOG_ALL_STACKTRACES =
   env.varOrDefault('LOG_ALL_STACKTRACES', 'false') === 'true';
 const LOG_FORMAT = env.varOrDefault('LOG_FORMAT', 'simple');
 const INSTANCE_ID = env.varOrUndefined('INSTANCE_ID');
 
-// set ar-io-sdk log level to match the observer log level
-Logger.default.setLogLevel(LOG_LEVEL as any);
+// ar.io/sdk log level, set to 'debug' for more verbose logging
+const AR_IO_SDK_LOG_LEVEL = env.varOrDefault('AR_IO_SDK_LOG_LEVEL', 'none');
+Logger.default.setLogLevel(AR_IO_SDK_LOG_LEVEL as any);
 
 const log = createLogger({
   level: LOG_LEVEL,


### PR DESCRIPTION
We will set this to none by default, as the SDK logs errors and stack traces already logged by the observer.

With `info` on by default in the SDK - operators see
```
{"error":"Unexpected token '<', \"<html><bod\"... is not valid JSON","level":"error","message":"Maximum read attempts exceeded","name":"ar-io-sdk","processId":"qNvAoz0TgcH7DMg8BCVn8jF32QH5L6T29VjHxhHqqGE","stack":"SyntaxError: Unexpected token '<', \"<html><bod\"... is not valid JSON\n    at JSON.parse (<anonymous>)\n    at parseJSONFromBytes (node:internal/deps/undici/undici:4306:19)\n    at successSteps (node:internal/deps/undici/undici:4288:27)\n    at fullyReadBody (node:internal/deps/undici/undici:2724:9)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async consumeBody (node:internal/deps/undici/undici:4297:7)\n    at async file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/node_modules/zod/lib/index.mjs:3351:32\n    at async AOProcess.read (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/node_modules/@ar.io/sdk/lib/esm/common/contracts/ao-process.js:55:26)\n    at async ARIOWriteable.getEpochSettings (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/node_modules/@ar.io/sdk/lib/esm/common/io.js:75:40)\n    at async ContractEpochSource.getEpochSettings (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/src/epochs/contract-epoch-source.ts:35:31)","tags":[{"name":"Action","value":"Epoch-Settings"}],"timestamp":"2025-03-18T17:46:36.165Z","version":"3.9.0-alpha.4"}
error: Error generating report Maximum read attempts exceeded for process qNvAoz0TgcH7DMg8BCVn8jF32QH5L6T29VjHxhHqqGE {"stack":"Error: Maximum read attempts exceeded for process qNvAoz0TgcH7DMg8BCVn8jF32QH5L6T29VjHxhHqqGE\n    at AOProcess.read (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/node_modules/@ar.io/sdk/lib/esm/common/contracts/ao-process.js:74:27)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async ARIOWriteable.getEpochSettings (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/node_modules/@ar.io/sdk/lib/esm/common/io.js:75:40)\n    at async ContractEpochSource.getEpochSettings (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/src/epochs/contract-epoch-source.ts:35:31)\n    at async updateAndSaveCurrentReport (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/src/system.ts:252:45)","timestamp":"2025-03-18T17:46:36.166Z"}
```

With it disabled, they see the error from the observer, 
```
error: Error generating report Maximum read attempts exceeded {"stack":"Error: Maximum read attempts exceeded for process qNvAoz0TgcH7DMg8BCVn8jF32QH5L6T29VjHxhHqqGE\n    at AOProcess.read (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-sdk/lib/esm/common/contracts/ao-process.js:75:27)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async ARIOWriteable.getEpochSettings (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-sdk/lib/esm/common/io.js:75:40)\n    at async ContractEpochSource.getEpochSettings (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/src/epochs/contract-epoch-source.ts:35:31)\n    at async updateAndSaveCurrentReport (file:///Users/dylanfiedler/Documents/ario/ar-io/ar-io-observer/src/system.ts:252:45)","timestamp":"2025-03-18T18:07:05.517Z"}
```