### PR TITLE
feat: add option to always save reports PE-7886

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # macOS
 .DS_Store
+
+# Aider
+.aider*

--- a/src/config.ts
+++ b/src/config.ts
@@ -130,3 +130,7 @@ export const AO_GATEWAY_URL = env.varOrUndefined('AO_GATEWAY_URL');
 // Whether to enable the LogReportSink that logs assessment details at info level
 export const ENABLE_LOG_REPORT_SINK =
   env.varOrDefault('ENABLE_LOG_REPORT_SINK', 'false') === 'true';
+
+// Whether to always save reports regardless of other conditions
+export const ALWAYS_SAVE_REPORTS =
+  env.varOrDefault('ALWAYS_SAVE_REPORTS', 'false') === 'true';

--- a/src/system.ts
+++ b/src/system.ts
@@ -403,7 +403,12 @@ export async function updateAndSaveCurrentReport() {
     const block = await chainSource.getBlockByHeight(currentHeight);
     const currentBlockTimestamp = block.timestamp * 1000;
 
-    if (!observers.includes(config.OBSERVER_WALLET)) {
+    if (config.ALWAYS_SAVE_REPORTS) {
+      log.verbose(
+        'Always save reports enabled - saving report regardless of conditions',
+      );
+      reportSink.saveReport({ report });
+    } else if (!observers.includes(config.OBSERVER_WALLET)) {
       log.verbose('Not saving report - not selected as an observer');
     } else if (
       currentBlockTimestamp >


### PR DESCRIPTION
Adds support for an `ALWAYS_SAVE_REPORTS` environment variable that when set bypasses other logic and always saves observation reports. This is intended primarily for use with the LogReportSink for network monitoring.