### PR TITLE
fix(observer): correctly report failed wallets for shared FQDN gateways

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -308,7 +308,7 @@ async function assessOwnership({
       if (!expectedWallets.includes(resp.wallet)) {
         const result = {
           expectedWallets,
-          observedWallet: null,
+          observedWallet: resp.wallet,
           failureReason: `Wallet mismatch: expected one of ${expectedWallets.join(
             ', ',
           )} but found ${resp.wallet}`,

--- a/src/store/contract-report-sink.test.ts
+++ b/src/store/contract-report-sink.test.ts
@@ -221,5 +221,138 @@ describe('ContractReportSink', function () {
         ),
       ).to.be.true;
     });
+
+    it('should report non-matching wallets as failed even when gateway passes overall', async function () {
+      // Create a report where multiple wallets share the same FQDN, gateway passes, but only one actually controls it
+      const report: ObserverReport = {
+        formatVersion: 2,
+        observerAddress: walletAddress,
+        epochIndex: 1,
+        epochStartTimestamp: 1000000,
+        epochStartHeight: 100,
+        epochEndTimestamp: 2000000,
+        generatedAt: 1500000,
+        gatewayAssessments: {
+          'arns-gateway.com': {
+            ownershipAssessment: {
+              expectedWallets: [
+                'wallet1',
+                'wallet2',
+                'wallet3',
+                'wallet4',
+                'wallet5',
+              ],
+              observedWallet: 'wallet3', // Only wallet3 actually controls this gateway
+              pass: true, // Ownership passed because wallet3 is in the expected list
+            },
+            arnsAssessments: {
+              prescribedNames: {},
+              chosenNames: {},
+              pass: true, // ArNS resolution passed
+            },
+            pass: true, // Overall gateway assessment passed
+          },
+        },
+      };
+
+      const reportInfo = { report, reportTxId: 'test-report-tx-id' };
+      await contractReportSink.saveReport(reportInfo);
+
+      // Verify that all expected wallets except wallet3 are still reported as failed
+      // even though the gateway passed overall
+      const saveObservationsCall = (
+        contractStub.saveObservations as sinon.SinonStub
+      ).getCall(0);
+      const failedGateways = saveObservationsCall.args[0].failedGateways;
+
+      expect(failedGateways).to.deep.equal([
+        'wallet1',
+        'wallet2',
+        'wallet4',
+        'wallet5',
+      ]);
+      expect(failedGateways).to.not.include('wallet3'); // wallet3 legitimately controls the gateway
+    });
+
+    it('should report observed wallet as failed when ownership assessment fails', async function () {
+      // Create a report where ownership assessment explicitly fails
+      const report: ObserverReport = {
+        formatVersion: 2,
+        observerAddress: walletAddress,
+        epochIndex: 1,
+        epochStartTimestamp: 1000000,
+        epochStartHeight: 100,
+        epochEndTimestamp: 2000000,
+        generatedAt: 1500000,
+        gatewayAssessments: {
+          'rogue-gateway.com': {
+            ownershipAssessment: {
+              expectedWallets: ['wallet1'],
+              observedWallet: 'wallet2', // Unexpected wallet observed
+              pass: false, // Ownership failed due to wallet mismatch
+            },
+            arnsAssessments: {
+              prescribedNames: {},
+              chosenNames: {},
+              pass: true,
+            },
+            pass: false, // Overall assessment failed due to ownership
+          },
+        },
+      };
+
+      const reportInfo = { report, reportTxId: 'test-report-tx-id' };
+      await contractReportSink.saveReport(reportInfo);
+
+      // Both wallets should be reported as failed:
+      // - wallet1 because it doesn't actually control the gateway
+      // - wallet2 because it failed ownership assessment (unexpected)
+      const saveObservationsCall = (
+        contractStub.saveObservations as sinon.SinonStub
+      ).getCall(0);
+      const failedGateways = saveObservationsCall.args[0].failedGateways;
+
+      expect(failedGateways).to.deep.equal(['wallet1', 'wallet2']);
+    });
+
+    it('should report all expected wallets as failed when no wallet was observed', async function () {
+      // Test scenario where gateway fails and no wallet was detected
+      const report: ObserverReport = {
+        formatVersion: 2,
+        observerAddress: walletAddress,
+        epochIndex: 1,
+        epochStartTimestamp: 1000000,
+        epochStartHeight: 100,
+        epochEndTimestamp: 2000000,
+        generatedAt: 1500000,
+        gatewayAssessments: {
+          'broken-gateway.com': {
+            ownershipAssessment: {
+              expectedWallets: ['wallet1', 'wallet2'],
+              observedWallet: null, // No wallet was observed (gateway didn't respond)
+              failureReason: 'Connection timeout',
+              pass: false,
+            },
+            arnsAssessments: {
+              prescribedNames: {},
+              chosenNames: {},
+              pass: false,
+            },
+            pass: false,
+          },
+        },
+      };
+
+      const reportInfo = { report, reportTxId: 'test-report-tx-id' };
+      await contractReportSink.saveReport(reportInfo);
+
+      // Verify that all expected wallets are reported as failed when none were observed
+      const saveObservationsCall = (
+        contractStub.saveObservations as sinon.SinonStub
+      ).getCall(0);
+      const failedGateways = saveObservationsCall.args[0].failedGateways;
+
+      expect(failedGateways).to.deep.equal(['wallet1', 'wallet2']);
+    });
   });
 });

--- a/src/store/contract-report-sink.ts
+++ b/src/store/contract-report-sink.ts
@@ -31,11 +31,36 @@ export function getFailedGatewaySummaryFromReport(
   const failedGatewaySummary: Set<string> = new Set();
   Object.values(observerReport.gatewayAssessments).forEach(
     (gatewayAssessment) => {
-      // if the assessment failed, add the expected wallets to the failedGatewaySummary
-      if (gatewayAssessment.pass === false) {
-        // add the expected wallets as failed
-        for (const wallet of gatewayAssessment.ownershipAssessment
-          .expectedWallets) {
+      const {
+        expectedWallets,
+        observedWallet,
+        pass: ownershipPass,
+      } = gatewayAssessment.ownershipAssessment;
+
+      if (observedWallet !== null) {
+        // A wallet was observed - check each expected wallet
+        for (const wallet of expectedWallets) {
+          if (wallet === observedWallet) {
+            // This is the observed wallet - only mark as failed if ownership assessment failed
+            if (!ownershipPass) {
+              failedGatewaySummary.add(wallet);
+            }
+          } else {
+            // This wallet doesn't match the observed wallet - always mark as failed
+            // since it doesn't actually control this gateway
+            failedGatewaySummary.add(wallet);
+          }
+        }
+
+        // If the observed wallet is not in the expected wallets list, mark it as failed too
+        // (it's an unauthorized wallet controlling the gateway)
+        if (!expectedWallets.includes(observedWallet)) {
+          failedGatewaySummary.add(observedWallet);
+        }
+      } else {
+        // No wallet was observed (gateway didn't respond or error occurred)
+        // Mark all expected wallets as failed since we couldn't verify ownership
+        for (const wallet of expectedWallets) {
           failedGatewaySummary.add(wallet);
         }
       }


### PR DESCRIPTION
When multiple wallets share the same FQDN, the observer now correctly identifies which specific wallets failed ownership verification:

- Reports non-matching wallets as failed even when gateway passes overall
- Only reports observed wallet as failed if ownership assessment fails
- Reports unauthorized wallets (not in expected list) as failed
- Handles all scenarios: wallet mismatch, unauthorized wallets, no response

This ensures save-observations contract interactions accurately reflect actual ownership failures rather than incorrectly penalizing all wallets associated with a shared FQDN.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet ownership assessment to properly capture observed wallet values during validation mismatches
  * Enhanced failed wallet reporting to accurately identify unauthorized or mismatched wallet cases

* **Tests**
  * Added comprehensive test coverage for wallet ownership validation scenarios, including mismatch and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->