### PR TITLE
perf: port chunk verification optimizations from ar-io-node (PE-8782)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "typescript": "^5.3.0"
   },
   "scripts": {
-    "build": "yarn clean && npx tsc --project ./tsconfig.prod.json",
+    "build": "yarn clean && npx tsc --project ./tsconfig.prod.json && cp -r src/data dist/",
     "clean": "npx rimraf [ .nyc_output coverage dist ]",
     "observe": "NODE_OPTIONS=\"--no-warnings --loader ts-node/esm\" node src/cli.ts",
     "service": "NODE_OPTIONS=\"--no-warnings --loader ts-node/esm\" node src/service.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@
  */
 import dotenv from 'dotenv';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
@@ -181,7 +182,15 @@ export const TX_PATH_PARSING_ENABLED =
 export const BLOCK_OFFSET_MAPPING_ENABLED =
   env.varOrDefault('BLOCK_OFFSET_MAPPING_ENABLED', 'true') === 'true';
 
+// Resolve path relative to this module (works in both src/ and dist/)
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_BLOCK_OFFSET_MAPPING_FILE = path.join(
+  __dirname,
+  'data',
+  'offset-block-mapping.json',
+);
+
 export const BLOCK_OFFSET_MAPPING_FILE = env.varOrDefault(
   'BLOCK_OFFSET_MAPPING_FILE',
-  './src/data/offset-block-mapping.json',
+  DEFAULT_BLOCK_OFFSET_MAPPING_FILE,
 );

--- a/src/config.ts
+++ b/src/config.ts
@@ -170,3 +170,18 @@ export const OFFSET_SAMPLE_COUNT = +env.varOrDefault(
 
 export const OFFSET_OBSERVATION_ENFORCEMENT_ENABLED =
   env.varOrDefault('OFFSET_OBSERVATION_ENFORCEMENT_ENABLED', 'true') === 'true';
+
+// TX path parsing optimization - extracts transaction boundaries from tx_path
+// without expensive binary search through transactions
+export const TX_PATH_PARSING_ENABLED =
+  env.varOrDefault('TX_PATH_PARSING_ENABLED', 'true') === 'true';
+
+// Block offset mapping optimization - narrows binary search bounds using
+// pre-computed offset-to-block mapping
+export const BLOCK_OFFSET_MAPPING_ENABLED =
+  env.varOrDefault('BLOCK_OFFSET_MAPPING_ENABLED', 'true') === 'true';
+
+export const BLOCK_OFFSET_MAPPING_FILE = env.varOrDefault(
+  'BLOCK_OFFSET_MAPPING_FILE',
+  './src/data/offset-block-mapping.json',
+);

--- a/src/data/offset-block-mapping.json
+++ b/src/data/offset-block-mapping.json
@@ -1,0 +1,281 @@
+{
+  "version": "1.0",
+  "generatedAt": "2025-11-24T20:36:28.637Z",
+  "currentHeight": 1801982,
+  "currentWeaveSize": 373698117017846,
+  "intervalBytes": 5497558138880,
+  "intervals": [
+    {
+      "offset": 0,
+      "blockHeight": 0
+    },
+    {
+      "offset": 5497558138880,
+      "blockHeight": 642449
+    },
+    {
+      "offset": 10995116277760,
+      "blockHeight": 731523
+    },
+    {
+      "offset": 16492674416640,
+      "blockHeight": 779014
+    },
+    {
+      "offset": 21990232555520,
+      "blockHeight": 791467
+    },
+    {
+      "offset": 27487790694400,
+      "blockHeight": 807172
+    },
+    {
+      "offset": 32985348833280,
+      "blockHeight": 818085
+    },
+    {
+      "offset": 38482906972160,
+      "blockHeight": 831225
+    },
+    {
+      "offset": 43980465111040,
+      "blockHeight": 844593
+    },
+    {
+      "offset": 49478023249920,
+      "blockHeight": 863584
+    },
+    {
+      "offset": 54975581388800,
+      "blockHeight": 879470
+    },
+    {
+      "offset": 60473139527680,
+      "blockHeight": 893614
+    },
+    {
+      "offset": 65970697666560,
+      "blockHeight": 913045
+    },
+    {
+      "offset": 71468255805440,
+      "blockHeight": 929262
+    },
+    {
+      "offset": 76965813944320,
+      "blockHeight": 940368
+    },
+    {
+      "offset": 82463372083200,
+      "blockHeight": 956487
+    },
+    {
+      "offset": 87960930222080,
+      "blockHeight": 974405
+    },
+    {
+      "offset": 93458488360960,
+      "blockHeight": 992646
+    },
+    {
+      "offset": 98956046499840,
+      "blockHeight": 1013278
+    },
+    {
+      "offset": 104453604638720,
+      "blockHeight": 1031922
+    },
+    {
+      "offset": 109951162777600,
+      "blockHeight": 1045269
+    },
+    {
+      "offset": 115448720916480,
+      "blockHeight": 1050361
+    },
+    {
+      "offset": 120946279055360,
+      "blockHeight": 1066470
+    },
+    {
+      "offset": 126443837194240,
+      "blockHeight": 1095545
+    },
+    {
+      "offset": 131941395333120,
+      "blockHeight": 1119828
+    },
+    {
+      "offset": 137438953472000,
+      "blockHeight": 1148263
+    },
+    {
+      "offset": 142936511610880,
+      "blockHeight": 1194563
+    },
+    {
+      "offset": 148434069749760,
+      "blockHeight": 1251458
+    },
+    {
+      "offset": 153931627888640,
+      "blockHeight": 1297893
+    },
+    {
+      "offset": 159429186027520,
+      "blockHeight": 1326492
+    },
+    {
+      "offset": 164926744166400,
+      "blockHeight": 1346932
+    },
+    {
+      "offset": 170424302305280,
+      "blockHeight": 1361738
+    },
+    {
+      "offset": 175921860444160,
+      "blockHeight": 1384594
+    },
+    {
+      "offset": 181419418583040,
+      "blockHeight": 1410850
+    },
+    {
+      "offset": 186916976721920,
+      "blockHeight": 1431593
+    },
+    {
+      "offset": 192414534860800,
+      "blockHeight": 1446171
+    },
+    {
+      "offset": 197912092999680,
+      "blockHeight": 1460437
+    },
+    {
+      "offset": 203409651138560,
+      "blockHeight": 1472428
+    },
+    {
+      "offset": 208907209277440,
+      "blockHeight": 1484906
+    },
+    {
+      "offset": 214404767416320,
+      "blockHeight": 1502464
+    },
+    {
+      "offset": 219902325555200,
+      "blockHeight": 1517866
+    },
+    {
+      "offset": 225399883694080,
+      "blockHeight": 1532276
+    },
+    {
+      "offset": 230897441832960,
+      "blockHeight": 1544282
+    },
+    {
+      "offset": 236394999971840,
+      "blockHeight": 1556821
+    },
+    {
+      "offset": 241892558110720,
+      "blockHeight": 1567329
+    },
+    {
+      "offset": 247390116249600,
+      "blockHeight": 1575413
+    },
+    {
+      "offset": 252887674388480,
+      "blockHeight": 1583537
+    },
+    {
+      "offset": 258385232527360,
+      "blockHeight": 1591529
+    },
+    {
+      "offset": 263882790666240,
+      "blockHeight": 1599833
+    },
+    {
+      "offset": 269380348805120,
+      "blockHeight": 1606768
+    },
+    {
+      "offset": 274877906944000,
+      "blockHeight": 1612353
+    },
+    {
+      "offset": 280375465082880,
+      "blockHeight": 1616891
+    },
+    {
+      "offset": 285873023221760,
+      "blockHeight": 1621995
+    },
+    {
+      "offset": 291370581360640,
+      "blockHeight": 1627583
+    },
+    {
+      "offset": 296868139499520,
+      "blockHeight": 1631221
+    },
+    {
+      "offset": 302365697638400,
+      "blockHeight": 1634702
+    },
+    {
+      "offset": 307863255777280,
+      "blockHeight": 1642326
+    },
+    {
+      "offset": 313360813916160,
+      "blockHeight": 1653725
+    },
+    {
+      "offset": 318858372055040,
+      "blockHeight": 1660527
+    },
+    {
+      "offset": 324355930193920,
+      "blockHeight": 1663914
+    },
+    {
+      "offset": 329853488332800,
+      "blockHeight": 1666480
+    },
+    {
+      "offset": 335351046471680,
+      "blockHeight": 1670434
+    },
+    {
+      "offset": 340848604610560,
+      "blockHeight": 1686005
+    },
+    {
+      "offset": 346346162749440,
+      "blockHeight": 1702704
+    },
+    {
+      "offset": 351843720888320,
+      "blockHeight": 1717633
+    },
+    {
+      "offset": 357341279027200,
+      "blockHeight": 1732234
+    },
+    {
+      "offset": 362838837166080,
+      "blockHeight": 1748032
+    },
+    {
+      "offset": 368336395304960,
+      "blockHeight": 1771195
+    }
+  ]
+}

--- a/src/lib/block-offset-mapping.test.ts
+++ b/src/lib/block-offset-mapping.test.ts
@@ -1,0 +1,145 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect } from 'chai';
+import fs from 'node:fs';
+import path from 'node:path';
+import { BlockOffsetMapping } from './block-offset-mapping.js';
+
+describe('BlockOffsetMapping', function () {
+  describe('constructor', function () {
+    it('should load mapping from valid file', function () {
+      const mapping = new BlockOffsetMapping({
+        filePath: path.join(
+          process.cwd(),
+          'src/data/offset-block-mapping.json',
+        ),
+      });
+
+      expect(mapping.isLoaded()).to.be.true;
+      const data = mapping.getMapping();
+      expect(data).to.not.be.undefined;
+      expect(data!.version).to.equal('1.0');
+      expect(data!.intervals.length).to.be.greaterThan(2);
+    });
+
+    it('should handle missing file gracefully', function () {
+      const mapping = new BlockOffsetMapping({
+        filePath: '/nonexistent/path/mapping.json',
+      });
+
+      expect(mapping.isLoaded()).to.be.false;
+      expect(mapping.getMapping()).to.be.undefined;
+    });
+
+    it('should handle no file path provided', function () {
+      const mapping = new BlockOffsetMapping({});
+
+      expect(mapping.isLoaded()).to.be.false;
+      expect(mapping.getMapping()).to.be.undefined;
+    });
+  });
+
+  describe('getSearchBounds', function () {
+    let mapping: BlockOffsetMapping;
+
+    before(function () {
+      mapping = new BlockOffsetMapping({
+        filePath: path.join(
+          process.cwd(),
+          'src/data/offset-block-mapping.json',
+        ),
+      });
+    });
+
+    it('should return undefined when mapping not loaded', function () {
+      const emptyMapping = new BlockOffsetMapping({});
+      const bounds = emptyMapping.getSearchBounds(1000000, 2000000);
+      expect(bounds).to.be.undefined;
+    });
+
+    it('should return bounds for offset at genesis (before first interval)', function () {
+      // Target offset before first non-genesis interval
+      const bounds = mapping.getSearchBounds(1000, 2000000);
+
+      expect(bounds).to.not.be.undefined;
+      expect(bounds!.lowHeight).to.equal(0);
+      // highHeight should be first interval's block height
+      expect(bounds!.highHeight).to.be.greaterThan(0);
+    });
+
+    it('should return bounds for offset in middle of range', function () {
+      // Use an offset that falls within the mapped range
+      // ~100TB offset (around interval index 18)
+      const targetOffset = 100000000000000; // 100 TB
+
+      const bounds = mapping.getSearchBounds(targetOffset, 2000000);
+
+      expect(bounds).to.not.be.undefined;
+      expect(bounds!.lowHeight).to.be.greaterThan(0);
+      expect(bounds!.highHeight).to.be.greaterThan(bounds!.lowHeight);
+      // Range should be much smaller than full range
+      const range = bounds!.highHeight - bounds!.lowHeight;
+      expect(range).to.be.lessThan(100000);
+    });
+
+    it('should return bounds for offset beyond last mapped interval', function () {
+      // Use an offset beyond the last mapped interval
+      const targetOffset = 400000000000000; // 400 TB (beyond current mapping)
+      const currentHeight = 2000000;
+
+      const bounds = mapping.getSearchBounds(targetOffset, currentHeight);
+
+      expect(bounds).to.not.be.undefined;
+      // lowHeight should be from last interval
+      expect(bounds!.lowHeight).to.be.greaterThan(1700000);
+      // highHeight should be currentHeight
+      expect(bounds!.highHeight).to.equal(currentHeight);
+    });
+
+    it('should narrow search range significantly compared to full range', function () {
+      // Test with various offsets to ensure narrowing works
+      const currentHeight = 1800000;
+      const testOffsets = [
+        10000000000000, // ~10 TB
+        50000000000000, // ~50 TB
+        100000000000000, // ~100 TB
+        200000000000000, // ~200 TB
+        300000000000000, // ~300 TB
+      ];
+
+      for (const offset of testOffsets) {
+        const bounds = mapping.getSearchBounds(offset, currentHeight);
+        if (bounds) {
+          const narrowedRange = bounds.highHeight - bounds.lowHeight;
+          const fullRange = currentHeight;
+          const reductionPercent =
+            ((fullRange - narrowedRange) / fullRange) * 100;
+
+          // Should reduce search range by at least 95%
+          expect(reductionPercent).to.be.greaterThan(95);
+        }
+      }
+    });
+
+    it('should handle boundary conditions correctly', function () {
+      const data = mapping.getMapping();
+      if (!data || data.intervals.length < 3) {
+        this.skip();
+        return;
+      }
+
+      // Test at exact interval boundary
+      const secondInterval = data.intervals[1];
+      const bounds = mapping.getSearchBounds(secondInterval.offset, 2000000);
+
+      expect(bounds).to.not.be.undefined;
+      // At exact boundary, should return bracketing intervals
+      expect(bounds!.lowHeight).to.equal(secondInterval.blockHeight);
+    });
+  });
+});

--- a/src/lib/block-offset-mapping.ts
+++ b/src/lib/block-offset-mapping.ts
@@ -1,0 +1,202 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import fs from 'node:fs';
+import log from '../log.js';
+
+/**
+ * Schema for the offset-to-block mapping JSON file.
+ */
+export interface OffsetBlockMapping {
+  version: string;
+  generatedAt: string;
+  currentHeight: number;
+  currentWeaveSize: number;
+  intervalBytes: number;
+  intervals: Array<{
+    offset: number;
+    blockHeight: number;
+  }>;
+}
+
+/**
+ * Search bounds returned by getSearchBounds().
+ */
+export interface BlockSearchBounds {
+  lowHeight: number;
+  highHeight: number;
+}
+
+/**
+ * Static offset-to-block mapping for optimizing binary search.
+ *
+ * Loads a JSON file containing offset-to-block-height mappings at startup.
+ * Used to narrow the initial search bounds in binarySearchBlocks().
+ *
+ * The mapping file contains intervals at regular offset increments (e.g., 5TB).
+ * Given a target offset, this class finds the bracketing interval to narrow
+ * the block search range from the full blockchain to a smaller window.
+ */
+export class BlockOffsetMapping {
+  private mapping?: OffsetBlockMapping;
+
+  constructor({ filePath }: { filePath?: string }) {
+    if (filePath !== undefined) {
+      this.loadMapping(filePath);
+    }
+  }
+
+  /**
+   * Load and validate the mapping file.
+   */
+  private loadMapping(filePath: string): void {
+    try {
+      if (!fs.existsSync(filePath)) {
+        log.warn('Offset mapping file not found, using full range search', {
+          filePath,
+        });
+        return;
+      }
+
+      const data = fs.readFileSync(filePath, 'utf-8');
+      const mapping = JSON.parse(data) as OffsetBlockMapping;
+
+      // Validate required fields
+      if (
+        mapping.version === undefined ||
+        mapping.intervals === undefined ||
+        !Array.isArray(mapping.intervals)
+      ) {
+        log.warn('Invalid mapping file format, using full range search', {
+          filePath,
+        });
+        return;
+      }
+
+      // Validate intervals are non-empty and monotonically increasing
+      if (mapping.intervals.length < 2) {
+        log.warn(
+          'Mapping file has insufficient intervals, using full range search',
+          {
+            filePath,
+            intervalCount: mapping.intervals.length,
+          },
+        );
+        return;
+      }
+
+      for (let i = 1; i < mapping.intervals.length; i++) {
+        if (mapping.intervals[i].offset <= mapping.intervals[i - 1].offset) {
+          log.warn(
+            'Mapping intervals not monotonically increasing, using full range search',
+            {
+              filePath,
+            },
+          );
+          return;
+        }
+        if (
+          mapping.intervals[i].blockHeight <=
+          mapping.intervals[i - 1].blockHeight
+        ) {
+          log.warn(
+            'Mapping block heights not monotonically increasing, using full range search',
+            {
+              filePath,
+            },
+          );
+          return;
+        }
+      }
+
+      this.mapping = mapping;
+
+      log.info('Loaded offset-block mapping', {
+        version: mapping.version,
+        generatedAt: mapping.generatedAt,
+        intervalCount: mapping.intervals.length,
+        intervalBytes: mapping.intervalBytes,
+        currentHeight: mapping.currentHeight,
+        currentWeaveSize: mapping.currentWeaveSize,
+      });
+    } catch (error: any) {
+      log.warn('Failed to load offset mapping, using full range search', {
+        filePath,
+        error: error.message,
+      });
+    }
+  }
+
+  /**
+   * Check if the mapping was successfully loaded.
+   */
+  isLoaded(): boolean {
+    return this.mapping !== undefined;
+  }
+
+  /**
+   * Get the mapping data (for testing/debugging).
+   */
+  getMapping(): OffsetBlockMapping | undefined {
+    return this.mapping;
+  }
+
+  /**
+   * Get narrowed search bounds for a target offset.
+   *
+   * Uses binary search on the mapping intervals to find the two intervals
+   * that bracket the target offset, returning the corresponding block heights.
+   *
+   * @param targetOffset - The weave offset to search for
+   * @param currentHeight - The current blockchain height (used for offsets beyond mapped range)
+   * @returns Search bounds, or undefined if mapping not loaded
+   */
+  getSearchBounds(
+    targetOffset: number,
+    currentHeight: number,
+  ): BlockSearchBounds | undefined {
+    if (!this.mapping || this.mapping.intervals.length < 2) {
+      return undefined;
+    }
+
+    const intervals = this.mapping.intervals;
+
+    // If target is before first interval, use genesis to first interval
+    if (targetOffset < intervals[0].offset) {
+      return {
+        lowHeight: 0,
+        highHeight: intervals[0].blockHeight,
+      };
+    }
+
+    // If target is at or beyond last interval, use last interval to current height
+    const lastInterval = intervals[intervals.length - 1];
+    if (targetOffset >= lastInterval.offset) {
+      return {
+        lowHeight: lastInterval.blockHeight,
+        highHeight: currentHeight,
+      };
+    }
+
+    // Binary search to find bracketing interval
+    let low = 0;
+    let high = intervals.length - 1;
+
+    while (low < high - 1) {
+      const mid = Math.floor((low + high) / 2);
+      if (targetOffset < intervals[mid].offset) {
+        high = mid;
+      } else {
+        low = mid;
+      }
+    }
+
+    return {
+      lowHeight: intervals[low].blockHeight,
+      highHeight: intervals[high].blockHeight,
+    };
+  }
+}

--- a/src/lib/encoding.ts
+++ b/src/lib/encoding.ts
@@ -1,0 +1,20 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Decode a base64url-encoded string to a Buffer.
+ */
+export function fromB64Url(input: string): Buffer {
+  return Buffer.from(input, 'base64');
+}
+
+/**
+ * Encode a Buffer to a base64url string.
+ */
+export function toB64Url(buffer: Buffer): string {
+  return buffer.toString('base64url');
+}

--- a/src/lib/encoding.ts
+++ b/src/lib/encoding.ts
@@ -9,7 +9,7 @@
  * Decode a base64url-encoded string to a Buffer.
  */
 export function fromB64Url(input: string): Buffer {
-  return Buffer.from(input, 'base64');
+  return Buffer.from(input, 'base64url');
 }
 
 /**

--- a/src/lib/tx-path-parser.test.ts
+++ b/src/lib/tx-path-parser.test.ts
@@ -1,0 +1,547 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect } from 'chai';
+import crypto from 'node:crypto';
+import {
+  parseTxPath,
+  safeBigIntToNumber,
+  sortTxIdsByBinary,
+  extractDataRootFromTxPath,
+  extractTxEndOffsetFromTxPath,
+} from './tx-path-parser.js';
+import { toB64Url } from './encoding.js';
+
+// Helper to convert bigint to 32-byte buffer (big-endian)
+function bigIntToBuffer(value: bigint): Buffer {
+  const buffer = Buffer.alloc(32);
+  let remaining = value;
+  for (let i = 31; i >= 0 && remaining > BigInt(0); i--) {
+    buffer[i] = Number(remaining & BigInt(0xff));
+    remaining = remaining >> BigInt(8);
+  }
+  return buffer;
+}
+
+// Helper to create a hash
+async function hash(data: Buffer | Buffer[]): Promise<Buffer> {
+  const hasher = crypto.createHash('sha256');
+  if (Array.isArray(data)) {
+    for (const chunk of data) {
+      hasher.update(chunk);
+    }
+  } else {
+    hasher.update(data);
+  }
+  return hasher.digest();
+}
+
+// Create a valid TX leaf node (dataRoot + txEndOffset)
+async function createTxLeafNode(
+  dataRoot: Buffer,
+  txEndOffset: bigint,
+): Promise<{ hash: Buffer; path: Buffer }> {
+  const offsetBuffer = bigIntToBuffer(txEndOffset);
+  const leafHash = await hash([await hash(dataRoot), await hash(offsetBuffer)]);
+  return {
+    hash: leafHash,
+    path: Buffer.concat([dataRoot, offsetBuffer]),
+  };
+}
+
+// Create a valid TX branch node
+async function createTxBranchNode(
+  leftHash: Buffer,
+  rightHash: Buffer,
+  boundary: bigint,
+): Promise<{ hash: Buffer; path: Buffer }> {
+  const boundaryBuffer = bigIntToBuffer(boundary);
+  const branchHash = await hash([
+    await hash(leftHash),
+    await hash(rightHash),
+    await hash(boundaryBuffer),
+  ]);
+  return {
+    hash: branchHash,
+    path: Buffer.concat([leftHash, rightHash, boundaryBuffer]),
+  };
+}
+
+describe('tx-path-parser', function () {
+  describe('parseTxPath', function () {
+    it('should parse a single-TX block path (leaf only)', async function () {
+      const dataRoot = crypto.randomBytes(32);
+      const prevBlockWeaveSize = BigInt(1000000);
+      const blockWeaveSize = BigInt(1100000);
+      const txEndOffset = blockWeaveSize;
+      // tx_path stores RELATIVE offsets within the block
+      const relativeEndOffset = txEndOffset - prevBlockWeaveSize;
+
+      const leaf = await createTxLeafNode(dataRoot, relativeEndOffset);
+
+      const { result } = await parseTxPath({
+        txRoot: leaf.hash,
+        txPath: leaf.path,
+        targetOffset: BigInt(1050000), // Absolute weave offset within TX range
+        blockWeaveSize,
+        prevBlockWeaveSize,
+      });
+
+      expect(result).to.not.be.null;
+      expect(result!.validated).to.equal(true);
+      // Result txEndOffset is converted back to absolute
+      expect(result!.txEndOffset).to.equal(txEndOffset);
+      expect(result!.txStartOffset).to.equal(prevBlockWeaveSize);
+      expect(result!.txSize).to.equal(txEndOffset - prevBlockWeaveSize);
+      expect(result!.dataRoot.equals(dataRoot)).to.be.true;
+    });
+
+    it('should track index correctly in two-TX block (left subtree)', async function () {
+      // Create two transactions
+      const dataRoot1 = crypto.randomBytes(32);
+      const dataRoot2 = crypto.randomBytes(32);
+      const prevBlockWeaveSize = BigInt(1000000);
+      const tx1EndOffset = BigInt(1050000); // TX 1 ends here (absolute)
+      const tx2EndOffset = BigInt(1100000); // TX 2 ends here (absolute)
+      const blockWeaveSize = tx2EndOffset;
+
+      // tx_path stores RELATIVE offsets within the block
+      const relativeTx1EndOffset = tx1EndOffset - prevBlockWeaveSize;
+      const relativeTx2EndOffset = tx2EndOffset - prevBlockWeaveSize;
+
+      // Build the tree: branch -> [leaf1, leaf2]
+      const leaf1 = await createTxLeafNode(dataRoot1, relativeTx1EndOffset);
+      const leaf2 = await createTxLeafNode(dataRoot2, relativeTx2EndOffset);
+      const branch = await createTxBranchNode(
+        leaf1.hash,
+        leaf2.hash,
+        relativeTx1EndOffset, // Boundary at TX 1's end offset (relative)
+      );
+
+      // Path for TX 1 (left subtree): branch + leaf1
+      const path1 = Buffer.concat([branch.path, leaf1.path]);
+      const { result: result1 } = await parseTxPath({
+        txRoot: branch.hash,
+        txPath: path1,
+        targetOffset: BigInt(1025000), // Within TX 1 (absolute)
+        blockWeaveSize,
+        prevBlockWeaveSize,
+      });
+
+      expect(result1).to.not.be.null;
+      // Results are converted back to absolute offsets
+      expect(result1!.txEndOffset).to.equal(tx1EndOffset);
+      expect(result1!.txStartOffset).to.equal(prevBlockWeaveSize);
+      expect(result1!.dataRoot.equals(dataRoot1)).to.be.true;
+    });
+
+    it('should track index correctly in two-TX block (right subtree)', async function () {
+      const dataRoot1 = crypto.randomBytes(32);
+      const dataRoot2 = crypto.randomBytes(32);
+      const prevBlockWeaveSize = BigInt(1000000);
+      const tx1EndOffset = BigInt(1050000); // Absolute
+      const tx2EndOffset = BigInt(1100000); // Absolute
+      const blockWeaveSize = tx2EndOffset;
+
+      // tx_path stores RELATIVE offsets within the block
+      const relativeTx1EndOffset = tx1EndOffset - prevBlockWeaveSize;
+      const relativeTx2EndOffset = tx2EndOffset - prevBlockWeaveSize;
+
+      const leaf1 = await createTxLeafNode(dataRoot1, relativeTx1EndOffset);
+      const leaf2 = await createTxLeafNode(dataRoot2, relativeTx2EndOffset);
+      const branch = await createTxBranchNode(
+        leaf1.hash,
+        leaf2.hash,
+        relativeTx1EndOffset, // Relative boundary
+      );
+
+      // Path for TX 2 (right subtree): branch + leaf2
+      const path2 = Buffer.concat([branch.path, leaf2.path]);
+      const { result: result2 } = await parseTxPath({
+        txRoot: branch.hash,
+        txPath: path2,
+        targetOffset: BigInt(1075000), // Within TX 2 (absolute)
+        blockWeaveSize,
+        prevBlockWeaveSize,
+      });
+
+      expect(result2).to.not.be.null;
+      // Results are converted back to absolute offsets
+      expect(result2!.txEndOffset).to.equal(tx2EndOffset);
+      expect(result2!.txStartOffset).to.equal(tx1EndOffset);
+      expect(result2!.dataRoot.equals(dataRoot2)).to.be.true;
+    });
+
+    it('should track index correctly in four-TX block', async function () {
+      // Build a balanced tree with 4 transactions
+      const dataRoots = [
+        crypto.randomBytes(32),
+        crypto.randomBytes(32),
+        crypto.randomBytes(32),
+        crypto.randomBytes(32),
+      ];
+      const prevBlockWeaveSize = BigInt(1000000);
+      // Absolute offsets for each TX's end
+      const absoluteOffsets = [
+        BigInt(1025000),
+        BigInt(1050000),
+        BigInt(1075000),
+        BigInt(1100000),
+      ];
+      const blockWeaveSize = absoluteOffsets[3];
+
+      // tx_path stores RELATIVE offsets within the block
+      const relativeOffsets = absoluteOffsets.map(
+        (o) => o - prevBlockWeaveSize,
+      );
+
+      // Create leaves with relative offsets
+      const leaves = await Promise.all(
+        dataRoots.map((dr, i) => createTxLeafNode(dr, relativeOffsets[i])),
+      );
+
+      // Create level 1 branches (left: tx0+tx1, right: tx2+tx3)
+      const leftBranch = await createTxBranchNode(
+        leaves[0].hash,
+        leaves[1].hash,
+        relativeOffsets[0], // Boundary between tx0 and tx1 (relative)
+      );
+      const rightBranch = await createTxBranchNode(
+        leaves[2].hash,
+        leaves[3].hash,
+        relativeOffsets[2], // Boundary between tx2 and tx3 (relative)
+      );
+
+      // Create root branch
+      const root = await createTxBranchNode(
+        leftBranch.hash,
+        rightBranch.hash,
+        relativeOffsets[1], // Boundary between left and right subtrees (relative)
+      );
+
+      // Test TX 0 (leftmost)
+      const path0 = Buffer.concat([root.path, leftBranch.path, leaves[0].path]);
+      const { result: result0 } = await parseTxPath({
+        txRoot: root.hash,
+        txPath: path0,
+        targetOffset: BigInt(1010000), // Within TX 0 (absolute)
+        blockWeaveSize,
+        prevBlockWeaveSize,
+      });
+      expect(result0).to.not.be.null;
+
+      // Test TX 1
+      const path1 = Buffer.concat([root.path, leftBranch.path, leaves[1].path]);
+      const { result: result1 } = await parseTxPath({
+        txRoot: root.hash,
+        txPath: path1,
+        targetOffset: BigInt(1035000), // Within TX 1 (absolute)
+        blockWeaveSize,
+        prevBlockWeaveSize,
+      });
+      expect(result1).to.not.be.null;
+
+      // Test TX 2
+      const path2 = Buffer.concat([
+        root.path,
+        rightBranch.path,
+        leaves[2].path,
+      ]);
+      const { result: result2 } = await parseTxPath({
+        txRoot: root.hash,
+        txPath: path2,
+        targetOffset: BigInt(1060000), // Within TX 2 (absolute)
+        blockWeaveSize,
+        prevBlockWeaveSize,
+      });
+      expect(result2).to.not.be.null;
+
+      // Test TX 3 (rightmost)
+      const path3 = Buffer.concat([
+        root.path,
+        rightBranch.path,
+        leaves[3].path,
+      ]);
+      const { result: result3 } = await parseTxPath({
+        txRoot: root.hash,
+        txPath: path3,
+        targetOffset: BigInt(1090000), // Within TX 3 (absolute)
+        blockWeaveSize,
+        prevBlockWeaveSize,
+      });
+      expect(result3).to.not.be.null;
+    });
+
+    it('should reject path with invalid hash', async function () {
+      const dataRoot = crypto.randomBytes(32);
+      const leaf = await createTxLeafNode(dataRoot, BigInt(1100000));
+      const wrongRoot = crypto.randomBytes(32); // Wrong tx_root
+
+      const { result } = await parseTxPath({
+        txRoot: wrongRoot,
+        txPath: leaf.path,
+        targetOffset: BigInt(1050000),
+        blockWeaveSize: BigInt(1100000),
+        prevBlockWeaveSize: BigInt(1000000),
+      });
+
+      expect(result).to.be.null;
+    });
+
+    it('should reject path with tampered branch hash', async function () {
+      const dataRoot1 = crypto.randomBytes(32);
+      const dataRoot2 = crypto.randomBytes(32);
+      const prevBlockWeaveSize = BigInt(1000000);
+      const tx1EndOffset = BigInt(1050000);
+      const tx2EndOffset = BigInt(1100000);
+
+      const leaf1 = await createTxLeafNode(dataRoot1, tx1EndOffset);
+      const leaf2 = await createTxLeafNode(dataRoot2, tx2EndOffset);
+      const branch = await createTxBranchNode(
+        leaf1.hash,
+        leaf2.hash,
+        tx1EndOffset,
+      );
+
+      // Tamper with the branch path (flip a bit)
+      const tamperedPath = Buffer.concat([branch.path, leaf1.path]);
+      tamperedPath[0] ^= 0xff;
+
+      const { result } = await parseTxPath({
+        txRoot: branch.hash,
+        txPath: tamperedPath,
+        targetOffset: BigInt(1025000),
+        blockWeaveSize: tx2EndOffset,
+        prevBlockWeaveSize,
+      });
+
+      expect(result).to.be.null;
+    });
+
+    it('should return null for path shorter than minimum', async function () {
+      const { result } = await parseTxPath({
+        txRoot: crypto.randomBytes(32),
+        txPath: Buffer.alloc(32), // Too short (minimum is 64)
+        targetOffset: BigInt(1050000),
+        blockWeaveSize: BigInt(1100000),
+        prevBlockWeaveSize: BigInt(1000000),
+      });
+
+      expect(result).to.be.null;
+    });
+
+    it('should return null for misaligned path', async function () {
+      const { result } = await parseTxPath({
+        txRoot: crypto.randomBytes(32),
+        txPath: Buffer.alloc(100), // Not aligned (not 64 + n*96)
+        targetOffset: BigInt(1050000),
+        blockWeaveSize: BigInt(1100000),
+        prevBlockWeaveSize: BigInt(1000000),
+      });
+
+      expect(result).to.be.null;
+    });
+
+    it('should handle large offsets exceeding Number.MAX_SAFE_INTEGER', async function () {
+      const dataRoot = crypto.randomBytes(32);
+      // Use an offset larger than Number.MAX_SAFE_INTEGER (2^53 - 1)
+      const largeOffset = BigInt('10000000000000000000'); // ~10 exabytes (absolute)
+      const prevBlockWeaveSize = largeOffset - BigInt(100000);
+      const blockWeaveSize = largeOffset;
+
+      // tx_path stores RELATIVE offsets within the block
+      const relativeEndOffset = largeOffset - prevBlockWeaveSize;
+      const leaf = await createTxLeafNode(dataRoot, relativeEndOffset);
+
+      const { result } = await parseTxPath({
+        txRoot: leaf.hash,
+        txPath: leaf.path,
+        targetOffset: largeOffset - BigInt(50000), // Within the TX range (absolute)
+        blockWeaveSize,
+        prevBlockWeaveSize,
+      });
+
+      expect(result).to.not.be.null;
+      expect(result!.validated).to.equal(true);
+      // Results are converted back to absolute offsets
+      expect(result!.txEndOffset).to.equal(largeOffset);
+      expect(result!.txStartOffset).to.equal(prevBlockWeaveSize);
+      expect(result!.txSize).to.equal(largeOffset - prevBlockWeaveSize);
+      expect(result!.dataRoot.equals(dataRoot)).to.be.true;
+    });
+
+    it('should parse real tx_path from arweave.net chunk at offset 345449412246841', async function () {
+      // Real data from arweave.net for chunk at offset 345449412246841
+      // Block 1700011 contains this transaction
+      const txPathB64 =
+        'sTUh0vO-WLCLcQBmJkiSaNN-MCr9MSudPr7rhTQ-hzuIIWuarkgoxV4-ZG7MzmUie_vPGyxodraOp6to0dH9NgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAxCjY5HaedJPJPmvGXXHnWwRIq2BosulRQvXHHeIiMBR5r2wV8qJ_S2-5b_p6hCiFW8W3UfISIaW4TMCO-XM5m4kQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYjJxDxTVQX0-XYx0t0NmC_tJRl6eF2lq1SCHIGcS8w1Ck9tWmpN30eCOs-iDpR91EbW0lrv3eH8KWdmSjRa3d5df7PwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAThTrsCmpaQ1sosO568-yWsS3gACQQ5TwiH__4tZ7A6CErLzsj6S5_HEi62u3PYqFDUJrS9mDRHGsfD9jIV6rp_2vazgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATiAAAym3Ru53ltXtgk-N00MCQ1NR84NkafeheORYNYg58dLYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGIycQw';
+
+      const txRootB64 = '7ROH2BJvqVL8exgIBxpVD7YCoAE8DhjFaWHttze-Gyg';
+
+      // Block 1700011 info:
+      // - weave_size: 345449412468982
+      // - Previous block (1700010) weave_size: 345449000378614
+      // - txs count: 35
+      const blockWeaveSize = BigInt('345449412468982');
+      const prevBlockWeaveSize = BigInt('345449000378614');
+      const targetOffset = BigInt('345449412246841');
+
+      const txPath = Buffer.from(txPathB64, 'base64url');
+      const txRoot = Buffer.from(txRootB64, 'base64url');
+
+      const { result, rejectionReason, branchCount } = await parseTxPath({
+        txRoot,
+        txPath,
+        targetOffset,
+        blockWeaveSize,
+        prevBlockWeaveSize,
+      });
+
+      // Debug info if it fails
+      if (result === null) {
+        console.log('Rejection reason:', rejectionReason);
+        console.log('Branch count:', branchCount);
+        console.log('txPath length:', txPath.length);
+      }
+
+      expect(result).to.not.be.null;
+      expect(result!.validated).to.equal(true);
+
+      // The dataRoot from the tx_path should be:
+      // ym3Ru53ltXtgk-N00MCQ1NR84NkafeheORYNYg58dLY (from the chunk response)
+      const expectedDataRoot = Buffer.from(
+        'ym3Ru53ltXtgk-N00MCQ1NR84NkafeheORYNYg58dLY',
+        'base64url',
+      );
+      expect(result!.dataRoot.equals(expectedDataRoot)).to.be.true;
+
+      // The txEndOffset from the leaf is the TX's end offset (relative 411868227 + prevBlockWeaveSize)
+      expect(result!.txEndOffset).to.equal(BigInt('345449412246841'));
+    });
+  });
+
+  describe('sortTxIdsByBinary', function () {
+    it('should return empty array for empty input', function () {
+      const result = sortTxIdsByBinary([]);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('should return same array for single element', function () {
+      const txId = toB64Url(crypto.randomBytes(32));
+      const result = sortTxIdsByBinary([txId]);
+      expect(result).to.deep.equal([txId]);
+    });
+
+    it('should sort by binary representation', function () {
+      // Create TX IDs with known binary values for predictable sorting
+      const buf1 = Buffer.alloc(32, 0x00); // All zeros (smallest)
+      const buf2 = Buffer.alloc(32, 0x80); // Mid value
+      const buf3 = Buffer.alloc(32, 0xff); // All ones (largest)
+
+      const txIds = [
+        toB64Url(buf3), // Largest first
+        toB64Url(buf1), // Smallest
+        toB64Url(buf2), // Middle
+      ];
+
+      const sorted = sortTxIdsByBinary(txIds);
+
+      expect(sorted[0]).to.equal(toB64Url(buf1));
+      expect(sorted[1]).to.equal(toB64Url(buf2));
+      expect(sorted[2]).to.equal(toB64Url(buf3));
+    });
+
+    it('should not modify original array', function () {
+      const buf1 = Buffer.alloc(32, 0xff);
+      const buf2 = Buffer.alloc(32, 0x00);
+      const original = [toB64Url(buf1), toB64Url(buf2)];
+      const originalCopy = [...original];
+
+      sortTxIdsByBinary(original);
+
+      expect(original).to.deep.equal(originalCopy);
+    });
+  });
+
+  describe('extractDataRootFromTxPath', function () {
+    it('should extract dataRoot from valid path', async function () {
+      const dataRoot = crypto.randomBytes(32);
+      const leaf = await createTxLeafNode(dataRoot, BigInt(1000000));
+
+      const extracted = extractDataRootFromTxPath(leaf.path);
+      expect(extracted.equals(dataRoot)).to.be.true;
+    });
+
+    it('should extract dataRoot from path with branches', async function () {
+      const dataRoot = crypto.randomBytes(32);
+      const leaf = await createTxLeafNode(dataRoot, BigInt(1000000));
+      const branch = await createTxBranchNode(
+        leaf.hash,
+        crypto.randomBytes(32),
+        BigInt(500000),
+      );
+      const fullPath = Buffer.concat([branch.path, leaf.path]);
+
+      const extracted = extractDataRootFromTxPath(fullPath);
+      expect(extracted.equals(dataRoot)).to.be.true;
+    });
+
+    it('should throw for path too short', function () {
+      expect(() => extractDataRootFromTxPath(Buffer.alloc(32))).to.throw(
+        /too short/,
+      );
+    });
+  });
+
+  describe('extractTxEndOffsetFromTxPath', function () {
+    it('should extract txEndOffset from valid path', async function () {
+      const dataRoot = crypto.randomBytes(32);
+      const txEndOffset = BigInt(12345678);
+      const leaf = await createTxLeafNode(dataRoot, txEndOffset);
+
+      const extracted = extractTxEndOffsetFromTxPath(leaf.path);
+      expect(extracted).to.equal(txEndOffset);
+    });
+
+    it('should extract large txEndOffset exceeding Number.MAX_SAFE_INTEGER', async function () {
+      const dataRoot = crypto.randomBytes(32);
+      const txEndOffset = BigInt('10000000000000000000'); // ~10 exabytes
+      const leaf = await createTxLeafNode(dataRoot, txEndOffset);
+
+      const extracted = extractTxEndOffsetFromTxPath(leaf.path);
+      expect(extracted).to.equal(txEndOffset);
+    });
+
+    it('should throw for path too short', function () {
+      expect(() => extractTxEndOffsetFromTxPath(Buffer.alloc(32))).to.throw(
+        /too short/,
+      );
+    });
+  });
+
+  describe('safeBigIntToNumber', function () {
+    it('should convert small bigint to number', function () {
+      const result = safeBigIntToNumber(BigInt(12345), 'test');
+      expect(result).to.equal(12345);
+    });
+
+    it('should convert Number.MAX_SAFE_INTEGER to number', function () {
+      const result = safeBigIntToNumber(
+        BigInt(Number.MAX_SAFE_INTEGER),
+        'test',
+      );
+      expect(result).to.equal(Number.MAX_SAFE_INTEGER);
+    });
+
+    it('should throw for value exceeding Number.MAX_SAFE_INTEGER', function () {
+      const largeValue = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1);
+      expect(() => safeBigIntToNumber(largeValue, 'testField')).to.throw(
+        /testField exceeds safe integer range/,
+      );
+    });
+  });
+});

--- a/src/lib/tx-path-parser.test.ts
+++ b/src/lib/tx-path-parser.test.ts
@@ -401,13 +401,6 @@ describe('tx-path-parser', function () {
         prevBlockWeaveSize,
       });
 
-      // Debug info if it fails
-      if (result === null) {
-        console.log('Rejection reason:', rejectionReason);
-        console.log('Branch count:', branchCount);
-        console.log('txPath length:', txPath.length);
-      }
-
       expect(result).to.not.be.null;
       expect(result!.validated).to.equal(true);
 

--- a/src/lib/tx-path-parser.ts
+++ b/src/lib/tx-path-parser.ts
@@ -386,9 +386,14 @@ export async function parseTxPath(params: {
  */
 export function sortTxIdsByBinary(txIds: string[]): string[] {
   return [...txIds].sort((a, b) => {
-    const bufA = fromB64Url(a);
-    const bufB = fromB64Url(b);
-    return Buffer.compare(bufA, bufB);
+    try {
+      const bufA = fromB64Url(a);
+      const bufB = fromB64Url(b);
+      return Buffer.compare(bufA, bufB);
+    } catch {
+      // Fallback to string comparison if decoding fails
+      return a.localeCompare(b);
+    }
   });
 }
 

--- a/src/lib/tx-path-parser.ts
+++ b/src/lib/tx-path-parser.ts
@@ -1,0 +1,429 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import crypto from 'node:crypto';
+
+import { fromB64Url } from './encoding.js';
+
+// Constants from Arweave merkle implementation (same as merkle-path-parser.ts)
+const HASH_SIZE = 32;
+const NOTE_SIZE = 32;
+const BRANCH_SIZE = HASH_SIZE * 2 + NOTE_SIZE; // 96 bytes
+const LEAF_SIZE = HASH_SIZE + NOTE_SIZE; // 64 bytes
+
+/**
+ * Result of parsing a tx_path Merkle proof.
+ *
+ * Note: Offset fields use bigint to avoid precision loss for large weave offsets
+ * that may exceed Number.MAX_SAFE_INTEGER (~9 petabytes).
+ */
+export interface ParsedTxPath {
+  /** Transaction's data_root extracted from the leaf node */
+  dataRoot: Buffer;
+  /** Transaction end offset in weave (from leaf) */
+  txEndOffset: bigint;
+  /** Transaction start offset (calculated from path traversal) */
+  txStartOffset: bigint;
+  /** Transaction size (txEndOffset - txStartOffset) */
+  txSize: bigint;
+  /** Whether the path was cryptographically validated against tx_root */
+  validated: boolean;
+}
+
+/**
+ * Context for tracking bounds during Merkle tree traversal.
+ */
+interface TxPathValidationContext {
+  leftBound: bigint; // Current left bound (relative to block start)
+  rightBound: bigint; // Current right bound (relative to block start)
+}
+
+/**
+ * Convert buffer to BigInt (big-endian).
+ * Uses BigInt to avoid precision loss for large offsets (> Number.MAX_SAFE_INTEGER).
+ */
+function bufferToBigInt(buffer: Buffer): bigint {
+  let value = BigInt(0);
+  for (let i = 0; i < buffer.length; i++) {
+    value = value * BigInt(256) + BigInt(buffer[i]);
+  }
+  return value;
+}
+
+/**
+ * BigInt-aware minimum function.
+ */
+function bigIntMin(a: bigint, b: bigint): bigint {
+  return a < b ? a : b;
+}
+
+/**
+ * BigInt-aware maximum function.
+ */
+function bigIntMax(a: bigint, b: bigint): bigint {
+  return a > b ? a : b;
+}
+
+/**
+ * Safely convert BigInt to number, throwing if value exceeds safe integer range.
+ *
+ * @param value - The bigint value to convert
+ * @param fieldName - Name of the field (for error messages)
+ * @returns The value as a number
+ * @throws Error if value exceeds Number.MAX_SAFE_INTEGER or Number.MIN_SAFE_INTEGER
+ */
+export function safeBigIntToNumber(value: bigint, fieldName: string): number {
+  if (
+    value > BigInt(Number.MAX_SAFE_INTEGER) ||
+    value < BigInt(Number.MIN_SAFE_INTEGER)
+  ) {
+    throw new Error(
+      `${fieldName} exceeds safe integer range: ${value.toString()}`,
+    );
+  }
+  return Number(value);
+}
+
+/**
+ * Hash function matching Arweave's implementation.
+ * Same implementation as merkle-path-parser.ts.
+ */
+async function hash(data: Buffer | Buffer[]): Promise<Buffer> {
+  const hasher = crypto.createHash('sha256');
+  if (Array.isArray(data)) {
+    for (const chunk of data) {
+      hasher.update(chunk);
+    }
+  } else {
+    hasher.update(data);
+  }
+  return hasher.digest();
+}
+
+/**
+ * Compare two buffers for equality.
+ * Same implementation as merkle-path-parser.ts.
+ */
+function buffersEqual(a: Buffer, b: Buffer): boolean {
+  return a.length === b.length && a.compare(b) === 0;
+}
+
+/**
+ * Walk the TX Merkle path to determine transaction boundaries and index.
+ *
+ * Unlike data_path, tx_path walks from tx_root to find:
+ * - Transaction boundaries (start/end offset in weave)
+ * - Transaction index (position in sorted TX list)
+ * - Data root (from leaf node)
+ *
+ * The TX Merkle tree is built from transactions sorted by binary ID.
+ * We track index bounds during traversal to determine the final TX index.
+ */
+/**
+ * Result with rejection reason for debugging.
+ */
+interface WalkResult {
+  result: ParsedTxPath | null;
+  rejectionReason?: string;
+  branchCount?: number;
+}
+
+async function walkTxMerklePath(params: {
+  rootHash: Buffer;
+  targetOffset: bigint;
+  path: Buffer;
+  context: TxPathValidationContext;
+}): Promise<WalkResult> {
+  const { rootHash, targetOffset, path, context } = params;
+
+  // Validate inputs
+  if (context.rightBound <= BigInt(0)) {
+    return { result: null, rejectionReason: 'rightBound <= 0' };
+  }
+
+  let currentLeftBound = context.leftBound;
+  let currentRightBound = context.rightBound;
+  let currentHash = rootHash;
+  let pathOffset = 0;
+
+  let branchCount = 0;
+
+  // Process branch nodes
+  while (path.length - pathOffset > LEAF_SIZE) {
+    if (pathOffset + BRANCH_SIZE > path.length) {
+      return {
+        result: null,
+        rejectionReason: `path too short at branch ${branchCount}`,
+        branchCount,
+      };
+    }
+
+    // Extract branch components
+    const leftHash = path.slice(pathOffset, pathOffset + HASH_SIZE);
+    const rightHash = path.slice(
+      pathOffset + HASH_SIZE,
+      pathOffset + HASH_SIZE * 2,
+    );
+    const offsetBuffer = path.slice(
+      pathOffset + HASH_SIZE * 2,
+      pathOffset + BRANCH_SIZE,
+    );
+    pathOffset += BRANCH_SIZE;
+
+    // Calculate branch hash and validate
+    const branchOffset = bufferToBigInt(offsetBuffer);
+    const calculatedHash = await hash([
+      await hash(leftHash),
+      await hash(rightHash),
+      await hash(offsetBuffer),
+    ]);
+
+    if (!buffersEqual(calculatedHash, currentHash)) {
+      return {
+        result: null,
+        rejectionReason: `hash mismatch at branch ${branchCount}`,
+        branchCount,
+      };
+    }
+
+    // Determine which side contains our target (BigInt comparison)
+    // Matches Arweave's ar_merkle.erl: case Dest < Note of true -> left; false -> right
+    if (targetOffset < branchOffset) {
+      // Target is in left subtree
+      currentHash = leftHash;
+      currentRightBound = bigIntMin(currentRightBound, branchOffset);
+    } else {
+      // Target is in right subtree
+      currentHash = rightHash;
+      currentLeftBound = bigIntMax(currentLeftBound, branchOffset);
+    }
+    branchCount++;
+  }
+
+  // Process leaf node
+  if (pathOffset + LEAF_SIZE !== path.length) {
+    return {
+      result: null,
+      rejectionReason: `path length mismatch (pathOffset=${pathOffset}, pathLength=${path.length})`,
+      branchCount,
+    };
+  }
+
+  const leafDataRoot = path.slice(pathOffset, pathOffset + HASH_SIZE);
+  const leafOffsetBuffer = path.slice(
+    pathOffset + HASH_SIZE,
+    pathOffset + LEAF_SIZE,
+  );
+  const leafOffset = bufferToBigInt(leafOffsetBuffer);
+
+  // Validate leaf hash
+  const expectedLeafHash = await hash([
+    await hash(leafDataRoot),
+    await hash(leafOffsetBuffer),
+  ]);
+
+  if (!buffersEqual(expectedLeafHash, currentHash)) {
+    return {
+      result: null,
+      rejectionReason: 'leaf hash mismatch',
+      branchCount,
+    };
+  }
+
+  return {
+    result: {
+      dataRoot: leafDataRoot,
+      txEndOffset: leafOffset,
+      txStartOffset: currentLeftBound,
+      txSize: leafOffset - currentLeftBound,
+      validated: true,
+    },
+    branchCount,
+  };
+}
+
+/**
+ * Parses an Arweave tx_path to extract transaction boundaries and validate
+ * the proof against the block's tx_root.
+ *
+ * The tx_path is a Merkle proof that proves a transaction's position within
+ * a block. By validating this proof against the block's tx_root, we can
+ * cryptographically verify transaction boundaries without doing an expensive
+ * binary search through the block's transactions.
+ *
+ * @param params - Parsing parameters
+ * @param params.txRoot - The block's transaction Merkle root
+ * @param params.txPath - The Merkle proof path to parse
+ * @param params.targetOffset - The absolute weave offset being requested (bigint for precision)
+ * @param params.blockWeaveSize - Current block's weave_size (bigint for precision)
+ * @param params.prevBlockWeaveSize - Previous block's weave_size (bigint for precision)
+ *
+ * @returns Parsed tx_path with boundaries, or null on validation failure
+ *
+ * @remarks
+ * The returned `ParsedTxPath` contains:
+ * - `dataRoot` - Transaction's data merkle root (32 bytes)
+ * - `txEndOffset` - Absolute weave offset where transaction data ends (bigint)
+ * - `txStartOffset` - Absolute weave offset where transaction data starts (bigint)
+ * - `txSize` - Size of transaction data in bytes (bigint)
+ * - `validated` - Whether the proof was cryptographically verified
+ *
+ * Returns `null` on any validation failure, which should trigger a fallback
+ * to the traditional binary search approach.
+ *
+ * @example
+ * ```typescript
+ * const parsed = await parseTxPath({
+ *   txRoot: block.tx_root,
+ *   txPath: chunk.tx_path,
+ *   targetOffset: BigInt(absoluteOffset),
+ *   blockWeaveSize: BigInt(block.weave_size),
+ *   prevBlockWeaveSize: BigInt(prevBlock.weave_size),
+ * });
+ *
+ * if (parsed) {
+ *   console.log(`TX boundaries: ${parsed.txStartOffset}-${parsed.txEndOffset}`);
+ *   console.log(`TX data_root: ${parsed.dataRoot.toString('hex')}`);
+ * }
+ * ```
+ */
+/**
+ * Result type for parseTxPath that includes rejection reason for debugging.
+ */
+export interface ParseTxPathResult {
+  result: ParsedTxPath | null;
+  rejectionReason?: string;
+  branchCount?: number;
+}
+
+export async function parseTxPath(params: {
+  txRoot: Buffer;
+  txPath: Buffer;
+  targetOffset: bigint;
+  blockWeaveSize: bigint;
+  prevBlockWeaveSize: bigint;
+}): Promise<ParseTxPathResult> {
+  const { txRoot, txPath, targetOffset, blockWeaveSize, prevBlockWeaveSize } =
+    params;
+
+  // Validate path structure
+  if (txPath.length < LEAF_SIZE) {
+    return {
+      result: null,
+      rejectionReason: `path too short (${txPath.length} < ${LEAF_SIZE})`,
+    };
+  }
+
+  // Path must be leaf (64 bytes) + N branches (96 bytes each)
+  if ((txPath.length - LEAF_SIZE) % BRANCH_SIZE !== 0) {
+    return {
+      result: null,
+      rejectionReason: `invalid path length (${txPath.length} != 64 + n*96)`,
+    };
+  }
+
+  // IMPORTANT: tx_path uses offsets RELATIVE to the block start, not absolute weave offsets.
+  // Convert to relative offsets for tree traversal.
+  const blockSize = blockWeaveSize - prevBlockWeaveSize;
+
+  // Arweave uses (Offset - BlockStart - 1) for validation, matching how tx_path is generated
+  // with (TXEndOffset - 1). This ensures we validate with an offset INSIDE the TX/chunk,
+  // not at the boundary. See ar_data_sync.erl line 2048: ChunkOffset = Offset - BlockStart - 1
+  let relativeTargetOffset = targetOffset - prevBlockWeaveSize - BigInt(1);
+
+  // Clamp target offset to valid range [0, blockSize - 1]
+  if (relativeTargetOffset >= blockSize) {
+    relativeTargetOffset = blockSize - BigInt(1);
+  } else if (relativeTargetOffset < BigInt(0)) {
+    relativeTargetOffset = BigInt(0);
+  }
+
+  // Initialize context with block boundaries (relative)
+  const context: TxPathValidationContext = {
+    leftBound: BigInt(0), // Relative start of block
+    rightBound: blockSize, // Relative end of block
+  };
+
+  const walkResult = await walkTxMerklePath({
+    rootHash: txRoot,
+    targetOffset: relativeTargetOffset,
+    path: txPath,
+    context,
+  });
+
+  // Convert result offsets back to absolute weave offsets
+  if (walkResult.result !== null) {
+    walkResult.result.txEndOffset += prevBlockWeaveSize;
+    walkResult.result.txStartOffset += prevBlockWeaveSize;
+  }
+
+  return walkResult;
+}
+
+/**
+ * Sort transaction IDs by their binary representation.
+ *
+ * This matches Arweave's Merkle tree ordering for transactions.
+ * Transactions are sorted by their base64url-decoded binary representation
+ * using lexicographic comparison.
+ *
+ * Note: This assumes all transactions are format-2 (post fork 2.0, April 2020).
+ * For mixed format-1/format-2 blocks, the actual Merkle tree order may differ
+ * because Arweave sorts by full TX record tuple, which sorts by format first.
+ * The dataRoot validation step will catch these mismatches.
+ *
+ * @param txIds - Array of base64url-encoded transaction IDs
+ * @returns New array sorted by binary representation
+ *
+ * @example
+ * ```typescript
+ * const sortedTxIds = sortTxIdsByBinary(block.txs);
+ * ```
+ */
+export function sortTxIdsByBinary(txIds: string[]): string[] {
+  return [...txIds].sort((a, b) => {
+    const bufA = fromB64Url(a);
+    const bufB = fromB64Url(b);
+    return Buffer.compare(bufA, bufB);
+  });
+}
+
+/**
+ * Extract the data_root from a tx_path leaf node.
+ *
+ * The leaf is the last 64 bytes of the path:
+ * - data_root (32 bytes)
+ * - tx_end_offset (32 bytes)
+ *
+ * This is a convenience function for cases where you need the data_root
+ * without full path validation.
+ *
+ * @param txPath - The tx_path buffer
+ * @returns The data_root buffer (32 bytes)
+ * @throws Error if txPath is too short
+ */
+export function extractDataRootFromTxPath(txPath: Buffer): Buffer {
+  if (txPath.length < LEAF_SIZE) {
+    throw new Error('tx_path too short to contain leaf node');
+  }
+  // Leaf is at the end, data_root is first 32 bytes of leaf
+  return txPath.slice(txPath.length - LEAF_SIZE, txPath.length - NOTE_SIZE);
+}
+
+/**
+ * Extract the tx_end_offset from a tx_path leaf node.
+ *
+ * @param txPath - The tx_path buffer
+ * @returns The tx_end_offset as a bigint (for precision with large offsets)
+ * @throws Error if txPath is too short
+ */
+export function extractTxEndOffsetFromTxPath(txPath: Buffer): bigint {
+  if (txPath.length < LEAF_SIZE) {
+    throw new Error('tx_path too short to contain leaf node');
+  }
+  return bufferToBigInt(txPath.slice(txPath.length - NOTE_SIZE));
+}

--- a/src/lib/tx-path-parser.ts
+++ b/src/lib/tx-path-parser.ts
@@ -92,7 +92,7 @@ export function safeBigIntToNumber(value: bigint, fieldName: string): number {
  * Hash function matching Arweave's implementation.
  * Same implementation as merkle-path-parser.ts.
  */
-async function hash(data: Buffer | Buffer[]): Promise<Buffer> {
+function hash(data: Buffer | Buffer[]): Buffer {
   const hasher = crypto.createHash('sha256');
   if (Array.isArray(data)) {
     for (const chunk of data) {
@@ -132,12 +132,12 @@ interface WalkResult {
   branchCount?: number;
 }
 
-async function walkTxMerklePath(params: {
+function walkTxMerklePath(params: {
   rootHash: Buffer;
   targetOffset: bigint;
   path: Buffer;
   context: TxPathValidationContext;
-}): Promise<WalkResult> {
+}): WalkResult {
   const { rootHash, targetOffset, path, context } = params;
 
   // Validate inputs
@@ -176,10 +176,10 @@ async function walkTxMerklePath(params: {
 
     // Calculate branch hash and validate
     const branchOffset = bufferToBigInt(offsetBuffer);
-    const calculatedHash = await hash([
-      await hash(leftHash),
-      await hash(rightHash),
-      await hash(offsetBuffer),
+    const calculatedHash = hash([
+      hash(leftHash),
+      hash(rightHash),
+      hash(offsetBuffer),
     ]);
 
     if (!buffersEqual(calculatedHash, currentHash)) {
@@ -221,10 +221,7 @@ async function walkTxMerklePath(params: {
   const leafOffset = bufferToBigInt(leafOffsetBuffer);
 
   // Validate leaf hash
-  const expectedLeafHash = await hash([
-    await hash(leafDataRoot),
-    await hash(leafOffsetBuffer),
-  ]);
+  const expectedLeafHash = hash([hash(leafDataRoot), hash(leafOffsetBuffer)]);
 
   if (!buffersEqual(expectedLeafHash, currentHash)) {
     return {
@@ -348,7 +345,7 @@ export async function parseTxPath(params: {
     rightBound: blockSize, // Relative end of block
   };
 
-  const walkResult = await walkTxMerklePath({
+  const walkResult = walkTxMerklePath({
     rootHash: txRoot,
     targetOffset: relativeTargetOffset,
     path: txPath,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -91,3 +91,19 @@ export const offsetValidationHistogram = new Histogram({
   buckets: [1, 2, 4, 8, 15, 30],
   registers: [register],
 });
+
+// TX path parsing optimization metrics
+export const txPathParsingCounter = new Counter({
+  name: 'observer_tx_path_parsing_total',
+  help: 'TX path parsing attempts and outcomes',
+  labelNames: ['status'], // 'success', 'failure', 'skipped'
+  registers: [register],
+});
+
+// Block search iterations histogram (to compare with/without offset mapping)
+export const blockSearchIterationsHistogram = new Histogram({
+  name: 'observer_block_search_iterations',
+  help: 'Number of iterations in block binary search',
+  buckets: [5, 10, 15, 20, 25, 30],
+  registers: [register],
+});

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -25,6 +25,8 @@ import pMap from 'p-map';
 
 import { MAX_FORK_DEPTH } from './arweave.js';
 import * as config from './config.js';
+import { BlockOffsetMapping } from './lib/block-offset-mapping.js';
+import { parseTxPath, safeBigIntToNumber } from './lib/tx-path-parser.js';
 import log from './log.js';
 import * as metrics from './metrics.js';
 
@@ -61,6 +63,7 @@ interface ArnsResolution {
 interface ArweaveBlock {
   height: number;
   weave_size: string;
+  tx_root?: string;
   txs: string[];
 }
 
@@ -381,7 +384,7 @@ export class Observer {
   // cache efficiency is much higher due to shared search space
   private blockCache = new LRUCache<
     string,
-    { weave_size: string; txIds: string[] }
+    { weave_size: string; tx_root?: string; txIds: string[] }
   >({
     max: 2000, // Base cache size: blocks accessed during binary search, larger memory per entry
   });
@@ -394,6 +397,7 @@ export class Observer {
   private transactionCache = new LRUCache<string, { data_root: string }>({
     max: 10000, // 5x blocks: minimal memory per entry, same transactions accessed repeatedly for offset validation
   });
+  private blockOffsetMapping?: BlockOffsetMapping;
 
   constructor({
     observerAddress,
@@ -434,6 +438,13 @@ export class Observer {
     this.gotClient = client.extend({
       headers: { 'X-AR-IO-Node-Release': this.nodeReleaseVersion },
     });
+
+    // Initialize block offset mapping for optimized binary search
+    if (config.BLOCK_OFFSET_MAPPING_ENABLED) {
+      this.blockOffsetMapping = new BlockOffsetMapping({
+        filePath: config.BLOCK_OFFSET_MAPPING_FILE,
+      });
+    }
   }
 
   private async getBlockByHeight(
@@ -460,6 +471,7 @@ export class Observer {
       return {
         height,
         weave_size: cachedBlock.weave_size,
+        tx_root: cachedBlock.tx_root,
         txs: cachedBlock.txIds,
       };
     }
@@ -484,6 +496,7 @@ export class Observer {
       // Cache only the minimal data we need to reduce memory usage
       const lightweightBlock = {
         weave_size: block.weave_size,
+        tx_root: block.tx_root,
         txIds: block.txs, // txs is already string[] according to our interface
       };
       this.blockCache.set(cacheKey, lightweightBlock);
@@ -649,18 +662,47 @@ export class Observer {
     minHeight: number,
     maxHeight: number,
   ): Promise<number> {
+    // Use offset mapping to narrow search bounds if available
+    let effectiveMinHeight = minHeight;
+    let effectiveMaxHeight = maxHeight;
+
+    if (this.blockOffsetMapping?.isLoaded()) {
+      const bounds = this.blockOffsetMapping.getSearchBounds(
+        targetOffset,
+        maxHeight,
+      );
+      if (bounds) {
+        effectiveMinHeight = Math.max(minHeight, bounds.lowHeight);
+        effectiveMaxHeight = Math.min(maxHeight, bounds.highHeight);
+
+        log.debug('Using narrowed search bounds from offset mapping', {
+          targetOffset,
+          originalRange: `${minHeight}-${maxHeight}`,
+          narrowedRange: `${effectiveMinHeight}-${effectiveMaxHeight}`,
+          reductionPercent: (
+            (1 -
+              (effectiveMaxHeight - effectiveMinHeight) /
+                (maxHeight - minHeight)) *
+            100
+          ).toFixed(1),
+        });
+      }
+    }
+
     log.debug('Starting binary search for blocks', {
       targetHost,
       targetOffset,
-      minHeight,
-      maxHeight,
-      range: maxHeight - minHeight,
+      minHeight: effectiveMinHeight,
+      maxHeight: effectiveMaxHeight,
+      range: effectiveMaxHeight - effectiveMinHeight,
     });
 
-    let left = minHeight;
-    let right = maxHeight;
+    let left = effectiveMinHeight;
+    let right = effectiveMaxHeight;
+    let iterations = 0;
 
     while (left <= right) {
+      iterations++;
       const mid = Math.floor((left + right) / 2);
 
       log.debug('Binary search iteration - checking block', {
@@ -669,6 +711,7 @@ export class Observer {
         currentHeight: mid,
         left,
         right,
+        iteration: iterations,
       });
 
       try {
@@ -682,14 +725,16 @@ export class Observer {
         // Check if this is the containing block
         if (targetOffset <= weaveSizeNum) {
           // Check if the previous block (if it exists) has a smaller weave_size
-          if (mid === minHeight) {
+          if (mid === effectiveMinHeight) {
             // This is the first block we're checking, it contains the offset
             log.debug('Found containing block (first in range)', {
               targetHost,
               targetOffset,
               blockHeight: mid,
               weaveSizeNum,
+              iterations,
             });
+            metrics.blockSearchIterationsHistogram.observe(iterations);
             return mid;
           }
 
@@ -710,7 +755,9 @@ export class Observer {
                 blockHeight: mid,
                 weaveSizeNum,
                 prevWeaveSizeNum,
+                iterations,
               });
+              metrics.blockSearchIterationsHistogram.observe(iterations);
               return mid;
             } else {
               // Target offset is in an earlier block
@@ -726,8 +773,10 @@ export class Observer {
                 blockHeight: mid,
                 weaveSizeNum,
                 prevBlockError: (prevBlockError as any)?.message,
+                iterations,
               },
             );
+            metrics.blockSearchIterationsHistogram.observe(iterations);
             return mid;
           }
         } else {
@@ -751,7 +800,7 @@ export class Observer {
     }
 
     throw new Error(
-      `Could not find block containing offset ${targetOffset} in range ${minHeight}-${maxHeight}`,
+      `Could not find block containing offset ${targetOffset} in range ${effectiveMinHeight}-${effectiveMaxHeight}`,
     );
   }
 
@@ -951,6 +1000,107 @@ export class Observer {
         stack: error?.stack,
       });
       throw error;
+    }
+  }
+
+  /**
+   * Attempts to parse the tx_path Merkle proof to extract transaction boundaries
+   * and data_root without expensive binary search through transactions.
+   *
+   * Returns null if parsing fails, allowing fallback to binary search.
+   */
+  private async tryParseTxPath(params: {
+    txPath: string;
+    targetOffset: number;
+    containingBlockHeight: number;
+  }): Promise<{
+    dataRoot: Buffer;
+    txStartOffset: number;
+    txEndOffset: number;
+  } | null> {
+    const { txPath, targetOffset, containingBlockHeight } = params;
+
+    if (!config.TX_PATH_PARSING_ENABLED) {
+      metrics.txPathParsingCounter.inc({ status: 'skipped' });
+      return null;
+    }
+
+    try {
+      // Get current block for tx_root and weave_size
+      const block = await this.getBlockByHeight(
+        this.referenceGatewayHost,
+        containingBlockHeight,
+      );
+
+      if (
+        block.tx_root === undefined ||
+        block.tx_root === null ||
+        block.tx_root.length === 0
+      ) {
+        log.debug('TX path parsing skipped: block has no tx_root', {
+          blockHeight: containingBlockHeight,
+        });
+        metrics.txPathParsingCounter.inc({ status: 'skipped' });
+        return null;
+      }
+
+      // Get previous block weave_size for relative offset calculation
+      let prevBlockWeaveSize = BigInt(0);
+      if (containingBlockHeight > 0) {
+        const prevBlock = await this.getBlockByHeight(
+          this.referenceGatewayHost,
+          containingBlockHeight - 1,
+        );
+        prevBlockWeaveSize = BigInt(prevBlock.weave_size);
+      }
+
+      const txPathBuffer = Buffer.from(txPath, 'base64url');
+      const txRootBuffer = Buffer.from(block.tx_root, 'base64url');
+
+      const { result, rejectionReason } = await parseTxPath({
+        txRoot: txRootBuffer,
+        txPath: txPathBuffer,
+        targetOffset: BigInt(targetOffset),
+        blockWeaveSize: BigInt(block.weave_size),
+        prevBlockWeaveSize,
+      });
+
+      if (result === null) {
+        log.debug('TX path parsing failed', {
+          targetOffset,
+          blockHeight: containingBlockHeight,
+          rejectionReason,
+        });
+        metrics.txPathParsingCounter.inc({ status: 'failure' });
+        return null;
+      }
+
+      log.debug('TX path parsing succeeded', {
+        targetOffset,
+        blockHeight: containingBlockHeight,
+        txStartOffset: result.txStartOffset.toString(),
+        txEndOffset: result.txEndOffset.toString(),
+        txSize: result.txSize.toString(),
+      });
+
+      metrics.txPathParsingCounter.inc({ status: 'success' });
+
+      return {
+        dataRoot: result.dataRoot,
+        txStartOffset: safeBigIntToNumber(
+          result.txStartOffset,
+          'txStartOffset',
+        ),
+        txEndOffset: safeBigIntToNumber(result.txEndOffset, 'txEndOffset'),
+      };
+    } catch (error: any) {
+      log.debug('TX path parsing threw error', {
+        targetOffset,
+        blockHeight: containingBlockHeight,
+        error: error?.message,
+      });
+      metrics.txPathParsingCounter.inc({ status: 'failure' });
+      return null;
     }
   }
 
@@ -1171,13 +1321,65 @@ export class Observer {
             }
           })(),
 
-          // Get the data_root for validation using binary search
+          // Get the data_root for validation - try TX path parsing first, then binary search
           (async (): Promise<{
             effectiveDataRoot?: Uint8Array;
             txStartOffset?: number;
             txEndOffset?: number;
           }> => {
             try {
+              // Step 1: Find the containing block (with offset mapping optimization)
+              log.debug('Finding containing block for offset', {
+                targetHost,
+                offset,
+              });
+
+              const containingBlockHeight = await this.binarySearchBlocks(
+                targetHost,
+                offset,
+                1,
+                maxSearchHeight,
+              );
+
+              // Step 2: Try TX path parsing if tx_path is present
+              if (
+                chunkResponse.tx_path !== undefined &&
+                chunkResponse.tx_path.length > 0
+              ) {
+                const txPathResult = await this.tryParseTxPath({
+                  txPath: chunkResponse.tx_path,
+                  targetOffset: offset,
+                  containingBlockHeight,
+                });
+
+                if (txPathResult) {
+                  log.debug(
+                    'TX path parsing succeeded, skipping transaction binary search',
+                    {
+                      targetHost,
+                      offset,
+                      txStartOffset: txPathResult.txStartOffset,
+                      txEndOffset: txPathResult.txEndOffset,
+                    },
+                  );
+
+                  return {
+                    effectiveDataRoot: txPathResult.dataRoot,
+                    txStartOffset: txPathResult.txStartOffset,
+                    txEndOffset: txPathResult.txEndOffset,
+                  };
+                }
+
+                log.debug(
+                  'TX path parsing failed, falling back to binary search',
+                  {
+                    targetHost,
+                    offset,
+                  },
+                );
+              }
+
+              // Step 3: Fall back to full binary search
               log.debug('Finding transaction for offset using binary search', {
                 targetHost,
                 offset,
@@ -1209,7 +1411,7 @@ export class Observer {
                 txEndOffset: transactionInfo.txEndOffset,
               };
             } catch (searchError: any) {
-              log.debug('Binary search for transaction failed', {
+              log.debug('Transaction search failed', {
                 targetHost,
                 offset,
                 error: searchError?.message,

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -675,16 +675,21 @@ export class Observer {
         effectiveMinHeight = Math.max(minHeight, bounds.lowHeight);
         effectiveMaxHeight = Math.min(maxHeight, bounds.highHeight);
 
+        const originalRange = maxHeight - minHeight;
+        const reductionPercent =
+          originalRange > 0
+            ? (
+                (1 -
+                  (effectiveMaxHeight - effectiveMinHeight) / originalRange) *
+                100
+              ).toFixed(1)
+            : '0.0';
+
         log.debug('Using narrowed search bounds from offset mapping', {
           targetOffset,
           originalRange: `${minHeight}-${maxHeight}`,
           narrowedRange: `${effectiveMinHeight}-${effectiveMaxHeight}`,
-          reductionPercent: (
-            (1 -
-              (effectiveMaxHeight - effectiveMinHeight) /
-                (maxHeight - minHeight)) *
-            100
-          ).toFixed(1),
+          reductionPercent,
         });
       }
     }

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -26,7 +26,11 @@ import pMap from 'p-map';
 import { MAX_FORK_DEPTH } from './arweave.js';
 import * as config from './config.js';
 import { BlockOffsetMapping } from './lib/block-offset-mapping.js';
-import { parseTxPath, safeBigIntToNumber } from './lib/tx-path-parser.js';
+import {
+  parseTxPath,
+  safeBigIntToNumber,
+  sortTxIdsByBinary,
+} from './lib/tx-path-parser.js';
 import log from './log.js';
 import * as metrics from './metrics.js';
 
@@ -104,27 +108,6 @@ export function customHashPRNG(seed: Buffer) {
     const int = currentHash.readBigUInt64BE(0);
     return Number(int) / 2 ** 64;
   };
-}
-
-function sortTransactionIdsByBinary(txIds: string[]): string[] {
-  return [...txIds].sort((a, b) => {
-    try {
-      // Decode base64url to binary for proper comparison (same as Arweave does)
-      const decodeB64Url = (str: string): Buffer => {
-        // Add padding if needed and convert to base64
-        const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
-        const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
-        return Buffer.from(padded, 'base64');
-      };
-
-      const bufA = decodeB64Url(a);
-      const bufB = decodeB64Url(b);
-      return Buffer.compare(bufA, bufB);
-    } catch (error) {
-      // Fallback to string comparison if decoding fails
-      return a.localeCompare(b);
-    }
-  });
 }
 
 export function generateRandomRanges({
@@ -821,7 +804,7 @@ export class Observer {
     });
 
     // Sort transaction IDs by their binary representation (same as Arweave does)
-    const sortedTxIds = sortTransactionIdsByBinary(txIds);
+    const sortedTxIds = sortTxIdsByBinary(txIds);
 
     log.debug('Transaction IDs sorted for binary search', {
       targetHost,
@@ -904,6 +887,7 @@ export class Observer {
     targetHost: string,
     targetOffset: number,
     maxSearchHeight: number,
+    preFoundBlockHeight?: number,
   ): Promise<{
     txId: string;
     dataRoot: string;
@@ -913,28 +897,41 @@ export class Observer {
     log.debug('Starting transaction search for offset', {
       targetHost,
       targetOffset,
+      preFoundBlockHeight,
     });
 
     try {
-      // Use pre-calculated stable search range for consistency and cache efficiency
-      const minHeight = 1;
-      const maxHeight = maxSearchHeight;
+      // Use pre-found block height if available, otherwise binary search
+      let containingBlockHeight: number;
 
-      log.debug('Using pre-calculated block search range', {
-        targetHost,
-        targetOffset,
-        minHeight,
-        maxHeight,
-        searchRange: maxHeight - minHeight,
-      });
+      if (preFoundBlockHeight !== undefined) {
+        containingBlockHeight = preFoundBlockHeight;
+        log.debug('Using pre-found block height, skipping block search', {
+          targetHost,
+          targetOffset,
+          containingBlockHeight,
+        });
+      } else {
+        // Use pre-calculated stable search range for consistency and cache efficiency
+        const minHeight = 1;
+        const maxHeight = maxSearchHeight;
 
-      // Binary search for the containing block
-      const containingBlockHeight = await this.binarySearchBlocks(
-        targetHost,
-        targetOffset,
-        minHeight,
-        maxHeight,
-      );
+        log.debug('Using pre-calculated block search range', {
+          targetHost,
+          targetOffset,
+          minHeight,
+          maxHeight,
+          searchRange: maxHeight - minHeight,
+        });
+
+        // Binary search for the containing block
+        containingBlockHeight = await this.binarySearchBlocks(
+          targetHost,
+          targetOffset,
+          minHeight,
+          maxHeight,
+        );
+      }
 
       // Get the block data using reference gateway
       const block = await this.getBlockByHeight(
@@ -1384,16 +1381,18 @@ export class Observer {
                 );
               }
 
-              // Step 3: Fall back to full binary search
+              // Step 3: Fall back to transaction binary search (reuse block we already found)
               log.debug('Finding transaction for offset using binary search', {
                 targetHost,
                 offset,
+                containingBlockHeight,
               });
 
               const transactionInfo = await this.findTransactionForOffset(
                 targetHost,
                 offset,
                 maxSearchHeight,
+                containingBlockHeight,
               );
 
               const effectiveDataRoot = Buffer.from(


### PR DESCRIPTION
## Summary

Ports two performance optimizations from ar-io-node to improve chunk validation efficiency during offset observations:

- **TX Path Merkle Proof Parsing**: Extracts transaction boundaries directly from `tx_path`, eliminating 7-10 API calls per chunk by skipping the transaction binary search
- **Block Offset Mapping**: Pre-computed offset-to-block mapping at 5TB intervals, reducing binary search range by 97-99% (from ~1.8M blocks to ~26K blocks)

## Changes

### New Files
| File | Description |
|------|-------------|
| `src/lib/encoding.ts` | Base64 encoding utilities |
| `src/lib/tx-path-parser.ts` | TX path Merkle proof validation |
| `src/lib/block-offset-mapping.ts` | Offset-to-block mapping class |
| `src/data/offset-block-mapping.json` | Static mapping data (68 intervals) |
| `src/lib/tx-path-parser.test.ts` | TX path parser tests (23 cases) |
| `src/lib/block-offset-mapping.test.ts` | Block offset mapping tests (9 cases) |

### Modified Files
| File | Changes |
|------|---------|
| `src/config.ts` | Added 3 config options for enabling/disabling optimizations |
| `src/metrics.ts` | Added 2 Prometheus metrics for performance tracking |
| `src/observer.ts` | Integrated optimizations into chunk validation flow |

### Configuration Options (all enabled by default)
- `TX_PATH_PARSING_ENABLED` - Enable TX path Merkle proof parsing
- `BLOCK_OFFSET_MAPPING_ENABLED` - Enable block offset mapping optimization
- `BLOCK_OFFSET_MAPPING_FILE` - Path to mapping JSON file

### Prometheus Metrics
- `observer_tx_path_parsing_total` - Counter with labels: success, failure, skipped
- `observer_block_search_iterations` - Histogram of binary search iterations

## Test plan

- [x] TX path parser unit tests pass (23 tests)
- [x] Block offset mapping unit tests pass (9 tests)
- [x] All existing tests pass (91 total)
- [x] `yarn lint:check` passes
- [x] `yarn build` succeeds
- [x] Manual observation run verifies optimizations working:
  - TX path parsing succeeds and skips binary search
  - Offset mapping reduces search range by 97-99%

## Related

- Jira: PE-8782
- GitHub: #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TX path parsing to accelerate transaction lookups with automatic fallback to prior search.
  * Precomputed offset→block mapping to narrow block search ranges.
  * Transaction roots now exposed in lightweight block responses.

* **Configuration**
  * Toggles to enable/disable TX path parsing and block-offset mapping; configurable mapping file path.

* **Monitoring**
  * Metrics for TX path parsing outcomes and block search iterations.

* **Data & Tests**
  * Added a versioned offset-to-block mapping dataset and comprehensive tests for parsing and mapping.

* **Build**
  * Build now includes mapping data in the distribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->