### PR TITLE
feat(observer): skip offset chain search via reference chunk headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "build": "yarn clean && npx tsc --project ./tsconfig.prod.json && cp -r src/data dist/",
     "clean": "npx rimraf [ .nyc_output coverage dist ]",
     "observe": "NODE_OPTIONS=\"--no-warnings --loader ts-node/esm\" node src/cli.ts",
+    "summarize": "NODE_OPTIONS=\"--no-warnings --loader ts-node/esm\" node src/summarize-report.ts",
     "service": "NODE_OPTIONS=\"--no-warnings --loader ts-node/esm\" node src/service.ts",
     "start:watch": "NODE_OPTIONS=\"--no-warnings --loader ts-node/esm\" nodemon --watch src --ext ts --exec ts-node -r dotenv/config src/service.ts",
     "test": "mocha --no-warnings",

--- a/src/lib/chunk-header-parser.test.ts
+++ b/src/lib/chunk-header-parser.test.ts
@@ -94,4 +94,14 @@ describe('parseChunkHeaderMetadata', function () {
     expect(parsed).to.not.equal(null);
     expect(parsed!.txId).to.equal('first-tx-id');
   });
+
+  it('accepts zero for chunkRelativeStartOffset (first chunk of a tx)', function () {
+    const zero = {
+      ...completeHeaders,
+      'x-arweave-chunk-relative-start-offset': '0',
+    };
+    const parsed = parseChunkHeaderMetadata(zero);
+    expect(parsed).to.not.equal(null);
+    expect(parsed!.chunkRelativeStartOffset).to.equal(0n);
+  });
 });

--- a/src/lib/chunk-header-parser.test.ts
+++ b/src/lib/chunk-header-parser.test.ts
@@ -18,17 +18,7 @@
 import { expect } from 'chai';
 
 import { parseChunkHeaderMetadata } from './chunk-header-parser.js';
-
-const completeHeaders = {
-  'x-arweave-chunk-tx-id': 'T3DcnZlZg_FqOQUf9MSZXQ5j7_ETc04OEqbkX-MZRnc',
-  'x-arweave-chunk-tx-start-offset': '108631448658167',
-  'x-arweave-chunk-tx-data-size': '42724169',
-  'x-arweave-chunk-data-root': 'qoQEdVyTqjLpkybZAgkIgtNawXUHUd5TJZwkWx0Vo-A',
-  'x-arweave-chunk-data-path': 'E2OKmVV7k4k',
-  'x-arweave-chunk-tx-path': 'H9gNFx8dbHj',
-  'x-arweave-chunk-start-offset': '108631449706743',
-  'x-arweave-chunk-relative-start-offset': '1048576',
-};
+import { completeHeaders } from './chunk-header.fixtures.js';
 
 describe('parseChunkHeaderMetadata', function () {
   it('parses a complete set of headers', function () {

--- a/src/lib/chunk-header-parser.test.ts
+++ b/src/lib/chunk-header-parser.test.ts
@@ -1,0 +1,97 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { expect } from 'chai';
+
+import { parseChunkHeaderMetadata } from './chunk-header-parser.js';
+
+const completeHeaders = {
+  'x-arweave-chunk-tx-id': 'T3DcnZlZg_FqOQUf9MSZXQ5j7_ETc04OEqbkX-MZRnc',
+  'x-arweave-chunk-tx-start-offset': '108631448658167',
+  'x-arweave-chunk-tx-data-size': '42724169',
+  'x-arweave-chunk-data-root': 'qoQEdVyTqjLpkybZAgkIgtNawXUHUd5TJZwkWx0Vo-A',
+  'x-arweave-chunk-data-path': 'E2OKmVV7k4k',
+  'x-arweave-chunk-tx-path': 'H9gNFx8dbHj',
+  'x-arweave-chunk-start-offset': '108631449706743',
+  'x-arweave-chunk-relative-start-offset': '1048576',
+};
+
+describe('parseChunkHeaderMetadata', function () {
+  it('parses a complete set of headers', function () {
+    const parsed = parseChunkHeaderMetadata(completeHeaders);
+    expect(parsed).to.not.equal(null);
+    expect(parsed!.txId).to.equal(completeHeaders['x-arweave-chunk-tx-id']);
+    expect(parsed!.txStartOffset).to.equal(108631448658167n);
+    expect(parsed!.txDataSize).to.equal(42724169n);
+    expect(parsed!.chunkStartOffset).to.equal(108631449706743n);
+    expect(parsed!.chunkRelativeStartOffset).to.equal(1048576n);
+    expect(parsed!.dataRoot).to.equal(
+      completeHeaders['x-arweave-chunk-data-root'],
+    );
+    expect(parsed!.dataPath).to.equal(
+      completeHeaders['x-arweave-chunk-data-path'],
+    );
+    expect(parsed!.txPath).to.equal(completeHeaders['x-arweave-chunk-tx-path']);
+  });
+
+  it('returns null when a required string header is missing', function () {
+    const { ['x-arweave-chunk-tx-id']: _omit, ...missing } = completeHeaders;
+    expect(parseChunkHeaderMetadata(missing)).to.equal(null);
+  });
+
+  it('returns null when a required string header is empty', function () {
+    const empty = { ...completeHeaders, 'x-arweave-chunk-data-root': '' };
+    expect(parseChunkHeaderMetadata(empty)).to.equal(null);
+  });
+
+  it('returns null when a numeric header is not parseable', function () {
+    const malformed = {
+      ...completeHeaders,
+      'x-arweave-chunk-tx-start-offset': 'not-a-number',
+    };
+    expect(parseChunkHeaderMetadata(malformed)).to.equal(null);
+  });
+
+  it('returns null when a numeric header is negative', function () {
+    const negative = {
+      ...completeHeaders,
+      'x-arweave-chunk-tx-data-size': '-1',
+    };
+    expect(parseChunkHeaderMetadata(negative)).to.equal(null);
+  });
+
+  it('preserves precision for offsets beyond Number.MAX_SAFE_INTEGER', function () {
+    const huge = '9007199254740993'; // MAX_SAFE_INTEGER + 2
+    const headers = {
+      ...completeHeaders,
+      'x-arweave-chunk-tx-start-offset': huge,
+    };
+    const parsed = parseChunkHeaderMetadata(headers);
+    expect(parsed).to.not.equal(null);
+    expect(parsed!.txStartOffset).to.equal(BigInt(huge));
+  });
+
+  it('takes the first value when a header is an array', function () {
+    const arr = {
+      ...completeHeaders,
+      'x-arweave-chunk-tx-id': ['first-tx-id', 'second-tx-id'],
+    };
+    const parsed = parseChunkHeaderMetadata(arr);
+    expect(parsed).to.not.equal(null);
+    expect(parsed!.txId).to.equal('first-tx-id');
+  });
+});

--- a/src/lib/chunk-header-parser.ts
+++ b/src/lib/chunk-header-parser.ts
@@ -1,0 +1,87 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ChunkHeaderMetadata } from '../types.js';
+
+type RawHeaders = Record<string, string | string[] | undefined>;
+
+function firstValue(headers: RawHeaders, name: string): string | undefined {
+  const v = headers[name];
+  if (v === undefined) return undefined;
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function parseBigIntHeader(raw: string | undefined): bigint | undefined {
+  if (raw === undefined || raw === '') return undefined;
+  try {
+    const v = BigInt(raw);
+    if (v < 0n) return undefined;
+    return v;
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseChunkHeaderMetadata(
+  headers: RawHeaders,
+): ChunkHeaderMetadata | null {
+  const txId = firstValue(headers, 'x-arweave-chunk-tx-id');
+  const dataRoot = firstValue(headers, 'x-arweave-chunk-data-root');
+  const dataPath = firstValue(headers, 'x-arweave-chunk-data-path');
+  const txPath = firstValue(headers, 'x-arweave-chunk-tx-path');
+  const txStartOffset = parseBigIntHeader(
+    firstValue(headers, 'x-arweave-chunk-tx-start-offset'),
+  );
+  const txDataSize = parseBigIntHeader(
+    firstValue(headers, 'x-arweave-chunk-tx-data-size'),
+  );
+  const chunkStartOffset = parseBigIntHeader(
+    firstValue(headers, 'x-arweave-chunk-start-offset'),
+  );
+  const chunkRelativeStartOffset = parseBigIntHeader(
+    firstValue(headers, 'x-arweave-chunk-relative-start-offset'),
+  );
+
+  if (
+    txId === undefined ||
+    txId === '' ||
+    dataRoot === undefined ||
+    dataRoot === '' ||
+    dataPath === undefined ||
+    dataPath === '' ||
+    txPath === undefined ||
+    txPath === '' ||
+    txStartOffset === undefined ||
+    txDataSize === undefined ||
+    chunkStartOffset === undefined ||
+    chunkRelativeStartOffset === undefined
+  ) {
+    return null;
+  }
+
+  return {
+    txId,
+    dataRoot,
+    dataPath,
+    txPath,
+    txStartOffset,
+    txDataSize,
+    chunkStartOffset,
+    chunkRelativeStartOffset,
+  };
+}

--- a/src/lib/chunk-header.fixtures.ts
+++ b/src/lib/chunk-header.fixtures.ts
@@ -1,0 +1,42 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import type { ChunkHeaderMetadata } from '../types.js';
+
+export const completeHeaders = {
+  'x-arweave-chunk-tx-id': 'T3DcnZlZg_FqOQUf9MSZXQ5j7_ETc04OEqbkX-MZRnc',
+  'x-arweave-chunk-tx-start-offset': '108631448658167',
+  'x-arweave-chunk-tx-data-size': '42724169',
+  'x-arweave-chunk-data-root': 'qoQEdVyTqjLpkybZAgkIgtNawXUHUd5TJZwkWx0Vo-A',
+  'x-arweave-chunk-data-path': 'E2OKmVV7k4k',
+  'x-arweave-chunk-tx-path': 'H9gNFx8dbHj',
+  'x-arweave-chunk-start-offset': '108631449706743',
+  'x-arweave-chunk-relative-start-offset': '1048576',
+};
+
+export const completeMetadata: ChunkHeaderMetadata = {
+  txId: completeHeaders['x-arweave-chunk-tx-id'],
+  txStartOffset: BigInt(completeHeaders['x-arweave-chunk-tx-start-offset']),
+  txDataSize: BigInt(completeHeaders['x-arweave-chunk-tx-data-size']),
+  dataRoot: completeHeaders['x-arweave-chunk-data-root'],
+  dataPath: completeHeaders['x-arweave-chunk-data-path'],
+  txPath: completeHeaders['x-arweave-chunk-tx-path'],
+  chunkStartOffset: BigInt(completeHeaders['x-arweave-chunk-start-offset']),
+  chunkRelativeStartOffset: BigInt(
+    completeHeaders['x-arweave-chunk-relative-start-offset'],
+  ),
+};

--- a/src/lib/chunk-metadata-anchor.test.ts
+++ b/src/lib/chunk-metadata-anchor.test.ts
@@ -1,0 +1,167 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { expect } from 'chai';
+
+import { ChunkHeaderMetadata } from '../types.js';
+import {
+  ChainAnchorMismatchError,
+  anchorChunkMetadata,
+} from './chunk-metadata-anchor.js';
+
+const txId = 'T3DcnZlZg_FqOQUf9MSZXQ5j7_ETc04OEqbkX-MZRnc';
+const dataRoot = 'qoQEdVyTqjLpkybZAgkIgtNawXUHUd5TJZwkWx0Vo-A';
+
+const txStartOffset = 108631448658167n;
+const txDataSize = 42724169n;
+const txEndOffset = txStartOffset + txDataSize - 1n;
+const sampleOffset = 108631449706743;
+
+const headerMetadata: ChunkHeaderMetadata = {
+  txId,
+  txStartOffset,
+  txDataSize,
+  dataRoot,
+  dataPath: 'ignored',
+  txPath: 'ignored',
+  chunkStartOffset: 108631449706743n,
+  chunkRelativeStartOffset: 1048576n,
+};
+
+const matchingChainOffset = {
+  size: txDataSize.toString(),
+  offset: txEndOffset.toString(),
+};
+
+describe('anchorChunkMetadata', function () {
+  it('returns chain-anchored bounds and decodes dataRoot when everything matches', async function () {
+    let txFetchCount = 0;
+    const result = await anchorChunkMetadata({
+      headerMetadata,
+      offset: sampleOffset,
+      fetchTxOffset: async () => matchingChainOffset,
+      fetchTransaction: async () => {
+        txFetchCount += 1;
+        return { data_root: dataRoot };
+      },
+    });
+
+    expect(txFetchCount).to.equal(1);
+    expect(result.txId).to.equal(txId);
+    expect(result.txStartOffset).to.equal(Number(txStartOffset));
+    expect(result.txEndOffset).to.equal(Number(txEndOffset));
+    expect(result.dataRoot.length).to.be.greaterThan(0);
+  });
+
+  it('skips the /tx fetch when anchorDataRoot is false', async function () {
+    let txFetchCount = 0;
+    await anchorChunkMetadata({
+      headerMetadata,
+      offset: sampleOffset,
+      fetchTxOffset: async () => matchingChainOffset,
+      fetchTransaction: async () => {
+        txFetchCount += 1;
+        return { data_root: dataRoot };
+      },
+      anchorDataRoot: false,
+    });
+
+    expect(txFetchCount).to.equal(0);
+  });
+
+  it('throws when chain-reported size disagrees with header', async function () {
+    try {
+      await anchorChunkMetadata({
+        headerMetadata,
+        offset: sampleOffset,
+        fetchTxOffset: async () => ({
+          size: (txDataSize + 1n).toString(),
+          offset: (txEndOffset + 1n).toString(),
+        }),
+        fetchTransaction: async () => ({ data_root: dataRoot }),
+      });
+      expect.fail('Expected ChainAnchorMismatchError');
+    } catch (error: any) {
+      expect(error).to.be.instanceOf(ChainAnchorMismatchError);
+      expect(error.field).to.equal('txDataSize');
+    }
+  });
+
+  it('throws when chain-derived start offset disagrees with header', async function () {
+    try {
+      await anchorChunkMetadata({
+        headerMetadata,
+        offset: sampleOffset,
+        // Keep size the same, shift the end offset: start no longer matches.
+        fetchTxOffset: async () => ({
+          size: txDataSize.toString(),
+          offset: (txEndOffset + 100n).toString(),
+        }),
+        fetchTransaction: async () => ({ data_root: dataRoot }),
+      });
+      expect.fail('Expected ChainAnchorMismatchError');
+    } catch (error: any) {
+      expect(error).to.be.instanceOf(ChainAnchorMismatchError);
+      expect(error.field).to.equal('txStartOffset');
+    }
+  });
+
+  it('throws when the probed offset is outside the chain-derived tx range', async function () {
+    try {
+      await anchorChunkMetadata({
+        headerMetadata,
+        offset: Number(txEndOffset + 1n),
+        fetchTxOffset: async () => matchingChainOffset,
+        fetchTransaction: async () => ({ data_root: dataRoot }),
+      });
+      expect.fail('Expected ChainAnchorMismatchError');
+    } catch (error: any) {
+      expect(error).to.be.instanceOf(ChainAnchorMismatchError);
+      expect(error.field).to.equal('offsetInRange');
+    }
+  });
+
+  it('throws when chain data_root disagrees with header and anchorDataRoot is on', async function () {
+    try {
+      await anchorChunkMetadata({
+        headerMetadata,
+        offset: sampleOffset,
+        fetchTxOffset: async () => matchingChainOffset,
+        fetchTransaction: async () => ({
+          data_root: 'DIFFERENT-DATA-ROOT',
+        }),
+      });
+      expect.fail('Expected ChainAnchorMismatchError');
+    } catch (error: any) {
+      expect(error).to.be.instanceOf(ChainAnchorMismatchError);
+      expect(error.field).to.equal('dataRoot');
+    }
+  });
+
+  it('requires fetchTransaction when anchorDataRoot is on', async function () {
+    try {
+      await anchorChunkMetadata({
+        headerMetadata,
+        offset: sampleOffset,
+        fetchTxOffset: async () => matchingChainOffset,
+      });
+      expect.fail('Expected error about missing fetchTransaction');
+    } catch (error: any) {
+      expect(error.message).to.include('fetchTransaction');
+    }
+  });
+});

--- a/src/lib/chunk-metadata-anchor.ts
+++ b/src/lib/chunk-metadata-anchor.ts
@@ -1,0 +1,125 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { safeBigIntToNumber } from './tx-path-parser.js';
+import { ChunkHeaderMetadata } from '../types.js';
+
+export interface AnchoredChunkMetadata {
+  txId: string;
+  dataRoot: Buffer;
+  txStartOffset: number;
+  txEndOffset: number;
+}
+
+export class ChainAnchorMismatchError extends Error {
+  readonly field: string;
+  readonly headerValue: string;
+  readonly chainValue: string;
+
+  constructor(params: {
+    field: string;
+    headerValue: string | bigint;
+    chainValue: string | bigint;
+  }) {
+    super(
+      `Chain anchor mismatch on ${params.field}: header=${params.headerValue} chain=${params.chainValue}`,
+    );
+    this.name = 'ChainAnchorMismatchError';
+    this.field = params.field;
+    this.headerValue = String(params.headerValue);
+    this.chainValue = String(params.chainValue);
+  }
+}
+
+/**
+ * Verify reference-gateway chunk header metadata against the chain and
+ * return the chain-anchored view the caller should use for merkle proof
+ * validation.
+ *
+ * The function is pure: it delegates HTTP to the provided fetchers and
+ * performs no I/O of its own. On any disagreement between the header
+ * values and the chain it throws ChainAnchorMismatchError — never silently
+ * trust the reference gateway over the node.
+ */
+export async function anchorChunkMetadata(params: {
+  headerMetadata: ChunkHeaderMetadata;
+  offset: number;
+  fetchTxOffset: (txId: string) => Promise<{ size: string; offset: string }>;
+  fetchTransaction?: (txId: string) => Promise<{ data_root: string }>;
+  anchorDataRoot?: boolean;
+}): Promise<AnchoredChunkMetadata> {
+  const {
+    headerMetadata,
+    offset,
+    fetchTxOffset,
+    fetchTransaction,
+    anchorDataRoot = true,
+  } = params;
+
+  const chainOffset = await fetchTxOffset(headerMetadata.txId);
+  const chainSize = BigInt(chainOffset.size);
+  const chainEnd = BigInt(chainOffset.offset);
+  const chainStart = chainEnd - chainSize + 1n;
+
+  if (chainSize !== headerMetadata.txDataSize) {
+    throw new ChainAnchorMismatchError({
+      field: 'txDataSize',
+      headerValue: headerMetadata.txDataSize,
+      chainValue: chainSize,
+    });
+  }
+
+  if (chainStart !== headerMetadata.txStartOffset) {
+    throw new ChainAnchorMismatchError({
+      field: 'txStartOffset',
+      headerValue: headerMetadata.txStartOffset,
+      chainValue: chainStart,
+    });
+  }
+
+  const offsetBig = BigInt(offset);
+  if (offsetBig < chainStart || offsetBig > chainEnd) {
+    throw new ChainAnchorMismatchError({
+      field: 'offsetInRange',
+      headerValue: offsetBig,
+      chainValue: `[${chainStart}, ${chainEnd}]`,
+    });
+  }
+
+  if (anchorDataRoot) {
+    if (fetchTransaction === undefined) {
+      throw new Error(
+        'anchorDataRoot requested but no fetchTransaction provided',
+      );
+    }
+    const tx = await fetchTransaction(headerMetadata.txId);
+    if (tx.data_root !== headerMetadata.dataRoot) {
+      throw new ChainAnchorMismatchError({
+        field: 'dataRoot',
+        headerValue: headerMetadata.dataRoot,
+        chainValue: tx.data_root,
+      });
+    }
+  }
+
+  return {
+    txId: headerMetadata.txId,
+    dataRoot: Buffer.from(headerMetadata.dataRoot, 'base64url'),
+    txStartOffset: safeBigIntToNumber(chainStart, 'txStartOffset'),
+    txEndOffset: safeBigIntToNumber(chainEnd, 'txEndOffset'),
+  };
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -100,6 +100,20 @@ export const txPathParsingCounter = new Counter({
   registers: [register],
 });
 
+// Chunk metadata anchor (reference-gateway header shortcut) metrics
+export const chunkMetadataAnchorCounter = new Counter({
+  name: 'observer_chunk_metadata_anchor_total',
+  help: 'Outcomes of reference-gateway chunk metadata anchoring',
+  // 'hit' = anchored against chain & used
+  // 'cache_hit' = reused a previously anchored tx
+  // 'metadata_missing' = reference gateway returned no headers
+  // 'mismatch' = header values disagreed with chain (fell back)
+  // 'error' = network/other error fetching metadata or anchoring
+  // 'fallback' = overall path fell back to chain search
+  labelNames: ['result'],
+  registers: [register],
+});
+
 // Block search iterations histogram (to compare with/without offset mapping)
 export const blockSearchIterationsHistogram = new Histogram({
   name: 'observer_block_search_iterations',

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -1108,8 +1108,8 @@ describe('Observer', function () {
           ).resolveTxBoundsViaReferenceHeaders(probeOffset);
 
           expect(result).to.not.equal(null);
-          expect(result.txStartOffset).to.equal(Number(txStartOffset));
-          expect(result.txEndOffset).to.equal(Number(txEndOffset));
+          expect(BigInt(result.txStartOffset)).to.equal(txStartOffset);
+          expect(BigInt(result.txEndOffset)).to.equal(txEndOffset);
           expect(result.effectiveDataRoot.length).to.be.greaterThan(0);
           expect(txOffsetScope.isDone()).to.be.true;
           expect(txScope.isDone()).to.be.true;
@@ -1160,43 +1160,48 @@ describe('Observer', function () {
         });
 
         it('reuses the per-tx cache for a second offset in the same tx', async function () {
-          referenceGatewayStub.getChunkMetadata.resolves({
-            host: 'reference.example.com',
-            metadata: completeMetadata,
-          });
+          nock.disableNetConnect();
+          try {
+            referenceGatewayStub.getChunkMetadata.resolves({
+              host: 'reference.example.com',
+              metadata: completeMetadata,
+            });
 
-          // Only stub the chain calls once — cache hit on the second call
-          // should not require additional network activity.
-          nock('https://arweave.net')
-            .get(`/tx/${txId}/offset`)
-            .reply(200, chainOffsetResponse);
-          nock('https://arweave.net')
-            .get(`/tx/${txId}`)
-            .reply(200, { id: txId, data_root: dataRoot, data_size: '1' });
+            // Only stub the chain calls once — cache hit on the second call
+            // should not require additional network activity.
+            nock('https://arweave.net')
+              .get(`/tx/${txId}/offset`)
+              .reply(200, chainOffsetResponse);
+            nock('https://arweave.net')
+              .get(`/tx/${txId}`)
+              .reply(200, { id: txId, data_root: dataRoot, data_size: '1' });
 
-          const first = await (
-            observer as any
-          ).resolveTxBoundsViaReferenceHeaders(probeOffset);
-          expect(first).to.not.equal(null);
+            const first = await (
+              observer as any
+            ).resolveTxBoundsViaReferenceHeaders(probeOffset);
+            expect(first).to.not.equal(null);
 
-          const secondOffset = probeOffset + 262144;
-          referenceGatewayStub.getChunkMetadata.resolves({
-            host: 'reference.example.com',
-            metadata: {
-              ...completeMetadata,
-              chunkStartOffset: BigInt(secondOffset),
-            },
-          });
+            const secondOffset = probeOffset + 262144;
+            referenceGatewayStub.getChunkMetadata.resolves({
+              host: 'reference.example.com',
+              metadata: {
+                ...completeMetadata,
+                chunkStartOffset: BigInt(secondOffset),
+              },
+            });
 
-          const second = await (
-            observer as any
-          ).resolveTxBoundsViaReferenceHeaders(secondOffset);
+            const second = await (
+              observer as any
+            ).resolveTxBoundsViaReferenceHeaders(secondOffset);
 
-          expect(second).to.not.equal(null);
-          expect(second.txStartOffset).to.equal(first.txStartOffset);
-          // No additional /tx/* activity should be required; nock would
-          // complain on an unexpected request.
-          expect(nock.pendingMocks()).to.deep.equal([]);
+            expect(second).to.not.equal(null);
+            expect(second.txStartOffset).to.equal(first.txStartOffset);
+            // No additional /tx/* activity should be required; any escape
+            // would now throw rather than hit the real network.
+            expect(nock.pendingMocks()).to.deep.equal([]);
+          } finally {
+            nock.enableNetConnect();
+          }
         });
       });
     });

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -1064,6 +1064,130 @@ describe('Observer', function () {
           expect(result.referenceGatewayAvailable).to.be.false; // Should be false on error
         });
       });
+
+      describe('resolveTxBoundsViaReferenceHeaders', function () {
+        const txId = 'T3DcnZlZg_FqOQUf9MSZXQ5j7_ETc04OEqbkX-MZRnc';
+        const dataRoot = 'qoQEdVyTqjLpkybZAgkIgtNawXUHUd5TJZwkWx0Vo-A';
+        const txStartOffset = 108631448658167n;
+        const txDataSize = 42724169n;
+        const txEndOffset = txStartOffset + txDataSize - 1n;
+        const probeOffset = 108631449706743;
+
+        const chainOffsetResponse = {
+          size: txDataSize.toString(),
+          offset: txEndOffset.toString(),
+        };
+
+        const completeMetadata = {
+          txId,
+          txStartOffset,
+          txDataSize,
+          dataRoot,
+          dataPath: 'data-path-ignored',
+          txPath: 'tx-path-ignored',
+          chunkStartOffset: BigInt(probeOffset),
+          chunkRelativeStartOffset: 1048576n,
+        };
+
+        it('returns anchored bounds and hits the chain once on success', async function () {
+          referenceGatewayStub.getChunkMetadata.resolves({
+            host: 'reference.example.com',
+            metadata: completeMetadata,
+          });
+
+          const txOffsetScope = nock('https://arweave.net')
+            .get(`/tx/${txId}/offset`)
+            .reply(200, chainOffsetResponse);
+          const txScope = nock('https://arweave.net')
+            .get(`/tx/${txId}`)
+            .reply(200, { id: txId, data_root: dataRoot, data_size: '1' });
+
+          const result = await (
+            observer as any
+          ).resolveTxBoundsViaReferenceHeaders(probeOffset);
+
+          expect(result).to.not.equal(null);
+          expect(result.txStartOffset).to.equal(Number(txStartOffset));
+          expect(result.txEndOffset).to.equal(Number(txEndOffset));
+          expect(result.effectiveDataRoot.length).to.be.greaterThan(0);
+          expect(txOffsetScope.isDone()).to.be.true;
+          expect(txScope.isDone()).to.be.true;
+        });
+
+        it('returns null when the reference gateway has no metadata', async function () {
+          referenceGatewayStub.getChunkMetadata.resolves({
+            host: 'reference.example.com',
+            metadata: null,
+          });
+
+          const result = await (
+            observer as any
+          ).resolveTxBoundsViaReferenceHeaders(probeOffset);
+
+          expect(result).to.equal(null);
+        });
+
+        it('returns null and does not throw when chain disagrees with headers', async function () {
+          referenceGatewayStub.getChunkMetadata.resolves({
+            host: 'reference.example.com',
+            metadata: completeMetadata,
+          });
+
+          // Chain reports a different size → mismatch
+          nock('https://arweave.net')
+            .get(`/tx/${txId}/offset`)
+            .reply(200, {
+              size: (txDataSize + 1n).toString(),
+              offset: (txEndOffset + 1n).toString(),
+            });
+
+          const result = await (
+            observer as any
+          ).resolveTxBoundsViaReferenceHeaders(probeOffset);
+
+          expect(result).to.equal(null);
+        });
+
+        it('reuses the per-tx cache for a second offset in the same tx', async function () {
+          referenceGatewayStub.getChunkMetadata.resolves({
+            host: 'reference.example.com',
+            metadata: completeMetadata,
+          });
+
+          // Only stub the chain calls once — cache hit on the second call
+          // should not require additional network activity.
+          nock('https://arweave.net')
+            .get(`/tx/${txId}/offset`)
+            .reply(200, chainOffsetResponse);
+          nock('https://arweave.net')
+            .get(`/tx/${txId}`)
+            .reply(200, { id: txId, data_root: dataRoot, data_size: '1' });
+
+          const first = await (
+            observer as any
+          ).resolveTxBoundsViaReferenceHeaders(probeOffset);
+          expect(first).to.not.equal(null);
+
+          const secondOffset = probeOffset + 262144;
+          referenceGatewayStub.getChunkMetadata.resolves({
+            host: 'reference.example.com',
+            metadata: {
+              ...completeMetadata,
+              chunkStartOffset: BigInt(secondOffset),
+            },
+          });
+
+          const second = await (
+            observer as any
+          ).resolveTxBoundsViaReferenceHeaders(secondOffset);
+
+          expect(second).to.not.equal(null);
+          expect(second.txStartOffset).to.equal(first.txStartOffset);
+          // No additional /tx/* activity should be required; nock would
+          // complain on an unexpected request.
+          expect(nock.pendingMocks()).to.deep.equal([]);
+        });
+      });
     });
   });
 });

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -448,6 +448,9 @@ describe('Observer', function () {
       referenceGatewayStub = {
         getArnsResolution: sinon.stub(),
         checkChunkAvailability: sinon.stub(),
+        getChunkMetadata: sinon
+          .stub()
+          .resolves({ host: 'reference.example.com', metadata: null }),
       };
 
       observer = new Observer({

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -23,6 +23,7 @@ import sinon from 'sinon';
 
 import * as config from './config.js';
 import { customHashPRNG } from './lib/prng.js';
+import * as metrics from './metrics.js';
 import {
   generateRandomRanges,
   getArnsResolution,
@@ -1141,11 +1142,21 @@ describe('Observer', function () {
               offset: (txEndOffset + 1n).toString(),
             });
 
-          const result = await (
-            observer as any
-          ).resolveTxBoundsViaReferenceHeaders(probeOffset);
+          const counterStub = sinon.stub(
+            metrics.chunkMetadataAnchorCounter,
+            'inc',
+          );
 
-          expect(result).to.equal(null);
+          try {
+            const result = await (
+              observer as any
+            ).resolveTxBoundsViaReferenceHeaders(probeOffset);
+
+            expect(result).to.equal(null);
+            expect(counterStub.calledWith({ result: 'mismatch' })).to.be.true;
+          } finally {
+            counterStub.restore();
+          }
         });
 
         it('reuses the per-tx cache for a second offset in the same tx', async function () {

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -263,11 +263,16 @@ export async function assessOwnership({
   try {
     const url = `https://${host}/ar-io/info`;
     const resp = await client.get(url).json<any>();
+    const observedRelease =
+      resp?.release === undefined || resp?.release === null
+        ? undefined
+        : String(resp.release);
     if (resp?.wallet) {
       if (!expectedWallets.includes(resp.wallet)) {
         const result = {
           expectedWallets,
           observedWallet: resp.wallet,
+          observedRelease,
           failureReason: `Wallet mismatch: expected one of ${expectedWallets.join(
             ', ',
           )} but found ${resp.wallet}`,
@@ -282,6 +287,7 @@ export async function assessOwnership({
         const result = {
           expectedWallets,
           observedWallet: resp.wallet,
+          observedRelease,
           pass: true,
         };
         metrics.ownershipAssessmentsCounter.inc({
@@ -294,6 +300,7 @@ export async function assessOwnership({
     const result = {
       expectedWallets,
       observedWallet: null,
+      observedRelease,
       failureReason: `No wallet found`,
       pass: false,
     };

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1230,14 +1230,23 @@ export class Observer {
 
     const cached = this.anchoredTxMetadataCache.get(metadata.txId);
     if (cached !== undefined) {
+      const cachedTxStartOffset = BigInt(cached.txStartOffset);
+      const cachedTxDataSize =
+        BigInt(cached.txEndOffset) - cachedTxStartOffset + 1n;
       if (
         offset < cached.txStartOffset ||
         offset > cached.txEndOffset ||
+        metadata.txStartOffset !== cachedTxStartOffset ||
+        metadata.txDataSize !== cachedTxDataSize ||
         cached.dataRoot.toString('base64url') !== metadata.dataRoot
       ) {
         log.warn('Cached anchored metadata inconsistent with new headers', {
           offset,
           txId: metadata.txId.slice(0, 12) + '...',
+          headerTxStartOffset: metadata.txStartOffset.toString(),
+          cachedTxStartOffset: cachedTxStartOffset.toString(),
+          headerTxDataSize: metadata.txDataSize.toString(),
+          cachedTxDataSize: cachedTxDataSize.toString(),
         });
         metrics.chunkMetadataAnchorCounter.inc({ result: 'mismatch' });
         return null;

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -25,6 +25,11 @@ import pMap from 'p-map';
 import { MAX_FORK_DEPTH } from './arweave.js';
 import * as config from './config.js';
 import { BlockOffsetMapping } from './lib/block-offset-mapping.js';
+import {
+  AnchoredChunkMetadata,
+  ChainAnchorMismatchError,
+  anchorChunkMetadata,
+} from './lib/chunk-metadata-anchor.js';
 import { customHashPRNG } from './lib/prng.js';
 import {
   parseTxPath,
@@ -361,6 +366,14 @@ export class Observer {
   private transactionCache = new LRUCache<string, { data_root: string }>({
     max: 10000, // 5x blocks: minimal memory per entry, same transactions accessed repeatedly for offset validation
   });
+  // Chain-anchored metadata per tx: caches the cross-check of reference-gateway
+  // chunk headers against /tx/{id}/offset (+ optional /tx/{id}) so repeated
+  // offsets inside the same tx pay zero additional node calls.
+  private anchoredTxMetadataCache = new LRUCache<string, AnchoredChunkMetadata>(
+    {
+      max: 10000,
+    },
+  );
   private blockOffsetMapping?: BlockOffsetMapping;
 
   constructor({
@@ -1176,6 +1189,240 @@ export class Observer {
     return { isValid: true };
   }
 
+  /**
+   * Resolve the transaction containing `offset` to yield its data_root and
+   * weave bounds, anchored against the chain.
+   *
+   * Fast path: HEAD the reference gateway's `/chunk/{offset}/data`, read
+   * the `x-arweave-chunk-*` headers, and cross-check them against the
+   * Arweave node via `/tx/{id}/offset` (plus `/tx/{id}` for data_root).
+   * On success this costs one HEAD and one O(1) node lookup per unique
+   * tx, versus ~20-30 node calls for the binary-search fallback.
+   *
+   * On any mismatch or when the reference gateway omits the headers the
+   * method logs and returns null so the caller falls back to the
+   * existing chain-search path. The reference gateway's headers are
+   * never trusted over the chain.
+   */
+  private async resolveTxBoundsViaReferenceHeaders(offset: number): Promise<{
+    effectiveDataRoot: Uint8Array;
+    txStartOffset: number;
+    txEndOffset: number;
+  } | null> {
+    let metadata;
+    try {
+      const result = await this.referenceGateway.getChunkMetadata({ offset });
+      metadata = result.metadata;
+    } catch (error: any) {
+      log.debug('Reference chunk metadata fetch failed', {
+        offset,
+        error: error?.message,
+      });
+      metrics.chunkMetadataAnchorCounter.inc({ result: 'error' });
+      return null;
+    }
+
+    if (metadata === null) {
+      metrics.chunkMetadataAnchorCounter.inc({ result: 'metadata_missing' });
+      return null;
+    }
+
+    const cached = this.anchoredTxMetadataCache.get(metadata.txId);
+    if (cached !== undefined) {
+      if (
+        offset < cached.txStartOffset ||
+        offset > cached.txEndOffset ||
+        cached.dataRoot.toString('base64url') !== metadata.dataRoot
+      ) {
+        log.warn('Cached anchored metadata inconsistent with new headers', {
+          offset,
+          txId: metadata.txId.slice(0, 12) + '...',
+        });
+        metrics.chunkMetadataAnchorCounter.inc({ result: 'mismatch' });
+        return null;
+      }
+      metrics.chunkMetadataAnchorCounter.inc({ result: 'cache_hit' });
+      return {
+        effectiveDataRoot: cached.dataRoot,
+        txStartOffset: cached.txStartOffset,
+        txEndOffset: cached.txEndOffset,
+      };
+    }
+
+    try {
+      const anchored = await anchorChunkMetadata({
+        headerMetadata: metadata,
+        offset,
+        fetchTxOffset: (txId) =>
+          this.getTransactionOffset(this.arweaveBaseUrl, txId),
+        fetchTransaction: async (txId) => {
+          const tx = await this.getTransaction(this.arweaveBaseUrl, txId);
+          return { data_root: tx.data_root };
+        },
+      });
+      this.anchoredTxMetadataCache.set(metadata.txId, anchored);
+      metrics.chunkMetadataAnchorCounter.inc({ result: 'hit' });
+      return {
+        effectiveDataRoot: anchored.dataRoot,
+        txStartOffset: anchored.txStartOffset,
+        txEndOffset: anchored.txEndOffset,
+      };
+    } catch (error: any) {
+      if (error instanceof ChainAnchorMismatchError) {
+        log.warn('Chain anchor mismatch; falling back to chain search', {
+          offset,
+          txId: metadata.txId.slice(0, 12) + '...',
+          field: error.field,
+          headerValue: error.headerValue,
+          chainValue: error.chainValue,
+        });
+        metrics.chunkMetadataAnchorCounter.inc({ result: 'mismatch' });
+      } else {
+        log.debug('Chain anchor failed', {
+          offset,
+          error: error?.message,
+        });
+        metrics.chunkMetadataAnchorCounter.inc({ result: 'error' });
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Locate tx bounds and data_root by walking the chain: block-height
+   * binary search + (tx_path shortcut OR tx binary search). This is the
+   * original implementation, preserved as a fallback when the reference
+   * gateway can't supply chunk header metadata or disagrees with chain
+   * state.
+   */
+  private async resolveTxBoundsViaChainSearch({
+    targetHost,
+    offset,
+    maxSearchHeight,
+    chunkResponse,
+  }: {
+    targetHost: string;
+    offset: number;
+    maxSearchHeight: number;
+    chunkResponse: { tx_path?: string };
+  }): Promise<{
+    effectiveDataRoot?: Uint8Array;
+    txStartOffset?: number;
+    txEndOffset?: number;
+  }> {
+    try {
+      // Step 1: Find the containing block (with offset mapping optimization)
+      log.debug('Finding containing block for offset', { targetHost, offset });
+
+      const containingBlockHeight = await this.binarySearchBlocks(
+        targetHost,
+        offset,
+        1,
+        maxSearchHeight,
+      );
+
+      // Step 2: Try TX path parsing if tx_path is present
+      if (
+        chunkResponse.tx_path !== undefined &&
+        chunkResponse.tx_path.length > 0
+      ) {
+        const txPathResult = await this.tryParseTxPath({
+          txPath: chunkResponse.tx_path,
+          targetOffset: offset,
+          containingBlockHeight,
+        });
+
+        if (txPathResult) {
+          log.debug(
+            'TX path parsing succeeded, skipping transaction binary search',
+            {
+              targetHost,
+              offset,
+              txStartOffset: txPathResult.txStartOffset,
+              txEndOffset: txPathResult.txEndOffset,
+            },
+          );
+
+          return {
+            effectiveDataRoot: txPathResult.dataRoot,
+            txStartOffset: txPathResult.txStartOffset,
+            txEndOffset: txPathResult.txEndOffset,
+          };
+        }
+
+        log.debug('TX path parsing failed, falling back to binary search', {
+          targetHost,
+          offset,
+        });
+      }
+
+      // Step 3: Fall back to transaction binary search
+      log.debug('Finding transaction for offset using binary search', {
+        targetHost,
+        offset,
+        containingBlockHeight,
+      });
+
+      const transactionInfo = await this.findTransactionForOffset(
+        targetHost,
+        offset,
+        maxSearchHeight,
+        containingBlockHeight,
+      );
+
+      const effectiveDataRoot = Buffer.from(
+        transactionInfo.dataRoot,
+        'base64url',
+      );
+
+      log.debug('Found transaction and data_root via binary search', {
+        targetHost,
+        offset,
+        txId: transactionInfo.txId.slice(0, 12) + '...',
+        dataRootLength: effectiveDataRoot.length,
+        txStartOffset: transactionInfo.txStartOffset,
+        txEndOffset: transactionInfo.txEndOffset,
+      });
+
+      return {
+        effectiveDataRoot,
+        txStartOffset: transactionInfo.txStartOffset,
+        txEndOffset: transactionInfo.txEndOffset,
+      };
+    } catch (searchError: any) {
+      log.debug('Transaction search failed', {
+        targetHost,
+        offset,
+        error: searchError?.message,
+      });
+      return {};
+    }
+  }
+
+  /**
+   * Entry point used by validateChunkAtOffset: try the reference-header
+   * fast path and fall through to chain search if it doesn't pan out.
+   */
+  private async resolveTxBoundsForOffset(params: {
+    targetHost: string;
+    offset: number;
+    maxSearchHeight: number;
+    chunkResponse: { tx_path?: string };
+  }): Promise<{
+    effectiveDataRoot?: Uint8Array;
+    txStartOffset?: number;
+    txEndOffset?: number;
+  }> {
+    const headerResult = await this.resolveTxBoundsViaReferenceHeaders(
+      params.offset,
+    );
+    if (headerResult !== null) {
+      return headerResult;
+    }
+    metrics.chunkMetadataAnchorCounter.inc({ result: 'fallback' });
+    return this.resolveTxBoundsViaChainSearch(params);
+  }
+
   private async validateChunkAtOffset({
     targetHost,
     offset,
@@ -1284,106 +1531,14 @@ export class Observer {
             }
           })(),
 
-          // Get the data_root for validation - try TX path parsing first, then binary search
-          (async (): Promise<{
-            effectiveDataRoot?: Uint8Array;
-            txStartOffset?: number;
-            txEndOffset?: number;
-          }> => {
-            try {
-              // Step 1: Find the containing block (with offset mapping optimization)
-              log.debug('Finding containing block for offset', {
-                targetHost,
-                offset,
-              });
-
-              const containingBlockHeight = await this.binarySearchBlocks(
-                targetHost,
-                offset,
-                1,
-                maxSearchHeight,
-              );
-
-              // Step 2: Try TX path parsing if tx_path is present
-              if (
-                chunkResponse.tx_path !== undefined &&
-                chunkResponse.tx_path.length > 0
-              ) {
-                const txPathResult = await this.tryParseTxPath({
-                  txPath: chunkResponse.tx_path,
-                  targetOffset: offset,
-                  containingBlockHeight,
-                });
-
-                if (txPathResult) {
-                  log.debug(
-                    'TX path parsing succeeded, skipping transaction binary search',
-                    {
-                      targetHost,
-                      offset,
-                      txStartOffset: txPathResult.txStartOffset,
-                      txEndOffset: txPathResult.txEndOffset,
-                    },
-                  );
-
-                  return {
-                    effectiveDataRoot: txPathResult.dataRoot,
-                    txStartOffset: txPathResult.txStartOffset,
-                    txEndOffset: txPathResult.txEndOffset,
-                  };
-                }
-
-                log.debug(
-                  'TX path parsing failed, falling back to binary search',
-                  {
-                    targetHost,
-                    offset,
-                  },
-                );
-              }
-
-              // Step 3: Fall back to transaction binary search (reuse block we already found)
-              log.debug('Finding transaction for offset using binary search', {
-                targetHost,
-                offset,
-                containingBlockHeight,
-              });
-
-              const transactionInfo = await this.findTransactionForOffset(
-                targetHost,
-                offset,
-                maxSearchHeight,
-                containingBlockHeight,
-              );
-
-              const effectiveDataRoot = Buffer.from(
-                transactionInfo.dataRoot,
-                'base64url',
-              );
-
-              log.debug('Found transaction and data_root via binary search', {
-                targetHost,
-                offset,
-                txId: transactionInfo.txId.slice(0, 12) + '...',
-                dataRootLength: effectiveDataRoot.length,
-                txStartOffset: transactionInfo.txStartOffset,
-                txEndOffset: transactionInfo.txEndOffset,
-              });
-
-              return {
-                effectiveDataRoot,
-                txStartOffset: transactionInfo.txStartOffset,
-                txEndOffset: transactionInfo.txEndOffset,
-              };
-            } catch (searchError: any) {
-              log.debug('Transaction search failed', {
-                targetHost,
-                offset,
-                error: searchError?.message,
-              });
-              return {};
-            }
-          })(),
+          // Resolve tx boundaries + data_root: try reference-gateway headers
+          // anchored against the chain first, then fall back to chain search.
+          this.resolveTxBoundsForOffset({
+            targetHost,
+            offset,
+            maxSearchHeight,
+            chunkResponse,
+          }),
         ]);
 
       // Extract results from parallel operations

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -44,6 +44,7 @@ import {
   ArnsNameAssessments,
   ArnsNamesSource,
   ArnsResolution,
+  ChunkHeaderMetadata,
   EntropySource,
   EpochTimestampSource,
   GatewayAssessments,
@@ -1209,7 +1210,7 @@ export class Observer {
     txStartOffset: number;
     txEndOffset: number;
   } | null> {
-    let metadata;
+    let metadata: ChunkHeaderMetadata | null;
     try {
       const result = await this.referenceGateway.getChunkMetadata({ offset });
       metadata = result.metadata;

--- a/src/reference/composite-reference-gateway.test.ts
+++ b/src/reference/composite-reference-gateway.test.ts
@@ -682,5 +682,109 @@ describe('CompositeReferenceGateway', function () {
       expect(result.host).to.equal('network1.example.com');
       expect(result.metadata).to.not.equal(null);
     });
+
+    it('does not mark network gateway unresponsive for HTTP errors on the probe', async function () {
+      (
+        mockNetworkGatewaySource.getEligibleGateways as sinon.SinonStub
+      ).resolves([
+        createGateway('network1.example.com'),
+        createGateway('network2.example.com'),
+      ]);
+
+      // 405/501/5xx from a reachable gateway means the probe isn't
+      // supported — the gateway is still alive.
+      nock('https://network1.example.com').head('/chunk/12345/data').reply(501);
+      nock('https://network2.example.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', completeHeaders);
+
+      const gateway = new CompositeReferenceGateway({
+        explicitGateway: null,
+        networkGatewaySource: mockNetworkGatewaySource,
+        consensusResolver: mockConsensusResolver,
+        networkOnly: true,
+        networkFallback: false,
+        nodeReleaseVersion: 'test',
+        log: logStub,
+      });
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('network2.example.com');
+      expect(result.metadata).to.not.equal(null);
+      expect(
+        (mockNetworkGatewaySource.markUnresponsive as sinon.SinonStub).called,
+      ).to.be.false;
+    });
+
+    it('marks network gateway unresponsive only on transport errors', async function () {
+      (
+        mockNetworkGatewaySource.getEligibleGateways as sinon.SinonStub
+      ).resolves([
+        createGateway('network1.example.com'),
+        createGateway('network2.example.com'),
+      ]);
+
+      // Transport-level failure: no HTTP response produced.
+      nock('https://network1.example.com')
+        .head('/chunk/12345/data')
+        .replyWithError('ECONNREFUSED');
+      nock('https://network2.example.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', completeHeaders);
+
+      const gateway = new CompositeReferenceGateway({
+        explicitGateway: null,
+        networkGatewaySource: mockNetworkGatewaySource,
+        consensusResolver: mockConsensusResolver,
+        networkOnly: true,
+        networkFallback: false,
+        nodeReleaseVersion: 'test',
+        log: logStub,
+      });
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('network2.example.com');
+      expect(
+        (
+          mockNetworkGatewaySource.markUnresponsive as sinon.SinonStub
+        ).calledOnceWithExactly('network1.example.com'),
+      ).to.be.true;
+    });
+
+    it('falls through to next network gateway when first returns 200 without headers', async function () {
+      (
+        mockNetworkGatewaySource.getEligibleGateways as sinon.SinonStub
+      ).resolves([
+        createGateway('network1.example.com'),
+        createGateway('network2.example.com'),
+      ]);
+
+      nock('https://network1.example.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', {});
+      nock('https://network2.example.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', completeHeaders);
+
+      const gateway = new CompositeReferenceGateway({
+        explicitGateway: null,
+        networkGatewaySource: mockNetworkGatewaySource,
+        consensusResolver: mockConsensusResolver,
+        networkOnly: true,
+        networkFallback: false,
+        nodeReleaseVersion: 'test',
+        log: logStub,
+      });
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('network2.example.com');
+      expect(result.metadata).to.not.equal(null);
+      expect(
+        (mockNetworkGatewaySource.markUnresponsive as sinon.SinonStub).called,
+      ).to.be.false;
+    });
   });
 });

--- a/src/reference/composite-reference-gateway.test.ts
+++ b/src/reference/composite-reference-gateway.test.ts
@@ -20,6 +20,10 @@ import nock from 'nock';
 import * as sinon from 'sinon';
 import * as winston from 'winston';
 
+import {
+  completeHeaders,
+  completeMetadata,
+} from '../lib/chunk-header.fixtures.js';
 import * as metrics from '../metrics.js';
 import {
   ArnsConsensusResolver,
@@ -565,22 +569,10 @@ describe('CompositeReferenceGateway', function () {
   });
 
   describe('getChunkMetadata', function () {
-    const completeHeaders = {
-      'x-arweave-chunk-tx-id': 'T3DcnZlZg_FqOQUf9MSZXQ5j7_ETc04OEqbkX-MZRnc',
-      'x-arweave-chunk-tx-start-offset': '108631448658167',
-      'x-arweave-chunk-tx-data-size': '42724169',
-      'x-arweave-chunk-data-root':
-        'qoQEdVyTqjLpkybZAgkIgtNawXUHUd5TJZwkWx0Vo-A',
-      'x-arweave-chunk-data-path': 'E2OKmVV7k4k',
-      'x-arweave-chunk-tx-path': 'H9gNFx8dbHj',
-      'x-arweave-chunk-start-offset': '108631449706743',
-      'x-arweave-chunk-relative-start-offset': '1048576',
-    };
-
     it('delegates to explicit gateway in mode 1', async function () {
       (mockExplicitGateway.getChunkMetadata as sinon.SinonStub).resolves({
         host: 'explicit.example.com',
-        metadata: { txId: 'tx', dataRoot: 'root' },
+        metadata: completeMetadata,
       });
 
       const gateway = new CompositeReferenceGateway({

--- a/src/reference/composite-reference-gateway.test.ts
+++ b/src/reference/composite-reference-gateway.test.ts
@@ -71,6 +71,7 @@ describe('CompositeReferenceGateway', function () {
     mockExplicitGateway = {
       getArnsResolution: sinon.stub(),
       checkChunkAvailability: sinon.stub(),
+      getChunkMetadata: sinon.stub(),
     };
 
     mockNetworkGatewaySource = {
@@ -560,6 +561,126 @@ describe('CompositeReferenceGateway', function () {
           mockNetworkGatewaySource.markUnresponsive as sinon.SinonStub
         ).calledWith('network1.example.com'),
       ).to.be.true;
+    });
+  });
+
+  describe('getChunkMetadata', function () {
+    const completeHeaders = {
+      'x-arweave-chunk-tx-id': 'T3DcnZlZg_FqOQUf9MSZXQ5j7_ETc04OEqbkX-MZRnc',
+      'x-arweave-chunk-tx-start-offset': '108631448658167',
+      'x-arweave-chunk-tx-data-size': '42724169',
+      'x-arweave-chunk-data-root':
+        'qoQEdVyTqjLpkybZAgkIgtNawXUHUd5TJZwkWx0Vo-A',
+      'x-arweave-chunk-data-path': 'E2OKmVV7k4k',
+      'x-arweave-chunk-tx-path': 'H9gNFx8dbHj',
+      'x-arweave-chunk-start-offset': '108631449706743',
+      'x-arweave-chunk-relative-start-offset': '1048576',
+    };
+
+    it('delegates to explicit gateway in mode 1', async function () {
+      (mockExplicitGateway.getChunkMetadata as sinon.SinonStub).resolves({
+        host: 'explicit.example.com',
+        metadata: { txId: 'tx', dataRoot: 'root' },
+      });
+
+      const gateway = new CompositeReferenceGateway({
+        explicitGateway: mockExplicitGateway,
+        networkGatewaySource: null,
+        consensusResolver: null,
+        networkOnly: false,
+        networkFallback: false,
+        nodeReleaseVersion: 'test',
+        log: logStub,
+      });
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('explicit.example.com');
+      expect(result.metadata).to.not.equal(null);
+    });
+
+    it('returns host/metadata unchanged when explicit returns metadata:null', async function () {
+      (mockExplicitGateway.getChunkMetadata as sinon.SinonStub).resolves({
+        host: 'explicit.example.com',
+        metadata: null,
+      });
+
+      const gateway = new CompositeReferenceGateway({
+        explicitGateway: mockExplicitGateway,
+        networkGatewaySource: mockNetworkGatewaySource,
+        consensusResolver: mockConsensusResolver,
+        networkOnly: false,
+        networkFallback: true,
+        nodeReleaseVersion: 'test',
+        log: logStub,
+      });
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('explicit.example.com');
+      expect(result.metadata).to.equal(null);
+      // metadata:null from explicit is authoritative — no network fallback
+      expect(networkFallbackCounterStub.called).to.be.false;
+    });
+
+    it('falls back to network when explicit throws in mode 2', async function () {
+      (mockExplicitGateway.getChunkMetadata as sinon.SinonStub).rejects(
+        new Error('getChunkMetadata failed on all hosts'),
+      );
+
+      (
+        mockNetworkGatewaySource.getEligibleGateways as sinon.SinonStub
+      ).resolves([createGateway('network1.example.com')]);
+
+      nock('https://network1.example.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', completeHeaders);
+
+      const gateway = new CompositeReferenceGateway({
+        explicitGateway: mockExplicitGateway,
+        networkGatewaySource: mockNetworkGatewaySource,
+        consensusResolver: mockConsensusResolver,
+        networkOnly: false,
+        networkFallback: true,
+        nodeReleaseVersion: 'test',
+        log: logStub,
+      });
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('network1.example.com');
+      expect(result.metadata).to.not.equal(null);
+      expect(
+        networkFallbackCounterStub.calledWith({
+          operation: 'getChunkMetadata',
+          status: 'triggered',
+        }),
+      ).to.be.true;
+    });
+
+    it('uses network directly in mode 3', async function () {
+      (
+        mockNetworkGatewaySource.getEligibleGateways as sinon.SinonStub
+      ).resolves([createGateway('network1.example.com')]);
+
+      nock('https://network1.example.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', completeHeaders);
+
+      const gateway = new CompositeReferenceGateway({
+        explicitGateway: null,
+        networkGatewaySource: mockNetworkGatewaySource,
+        consensusResolver: mockConsensusResolver,
+        networkOnly: true,
+        networkFallback: false,
+        nodeReleaseVersion: 'test',
+        log: logStub,
+      });
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('network1.example.com');
+      expect(result.metadata).to.not.equal(null);
     });
   });
 });

--- a/src/reference/composite-reference-gateway.test.ts
+++ b/src/reference/composite-reference-gateway.test.ts
@@ -599,11 +599,23 @@ describe('CompositeReferenceGateway', function () {
       expect(result.metadata).to.not.equal(null);
     });
 
-    it('returns host/metadata unchanged when explicit returns metadata:null', async function () {
+    it('falls back to network when explicit returns metadata:null in mode 2', async function () {
+      // Older explicit gateways surface as metadata:null (no probe headers
+      // or 404/410 on /chunk/{offset}/data). That's NOT authoritative — we
+      // should keep trying via the network pool so one old host can't
+      // disable the optimization for everyone else.
       (mockExplicitGateway.getChunkMetadata as sinon.SinonStub).resolves({
         host: 'explicit.example.com',
         metadata: null,
       });
+
+      (
+        mockNetworkGatewaySource.getEligibleGateways as sinon.SinonStub
+      ).resolves([createGateway('network1.example.com')]);
+
+      nock('https://network1.example.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', completeHeaders);
 
       const gateway = new CompositeReferenceGateway({
         explicitGateway: mockExplicitGateway,
@@ -617,10 +629,70 @@ describe('CompositeReferenceGateway', function () {
 
       const result = await gateway.getChunkMetadata({ offset: 12345 });
 
+      expect(result.host).to.equal('network1.example.com');
+      expect(result.metadata).to.not.equal(null);
+      expect(
+        networkFallbackCounterStub.calledWith({
+          operation: 'getChunkMetadata',
+          status: 'triggered',
+        }),
+      ).to.be.true;
+    });
+
+    it('returns explicit host with metadata:null when mode 1 and explicit has no metadata', async function () {
+      (mockExplicitGateway.getChunkMetadata as sinon.SinonStub).resolves({
+        host: 'explicit.example.com',
+        metadata: null,
+      });
+
+      const gateway = new CompositeReferenceGateway({
+        explicitGateway: mockExplicitGateway,
+        networkGatewaySource: null,
+        consensusResolver: null,
+        networkOnly: false,
+        networkFallback: false,
+        nodeReleaseVersion: 'test',
+        log: logStub,
+      });
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
       expect(result.host).to.equal('explicit.example.com');
       expect(result.metadata).to.equal(null);
-      // metadata:null from explicit is authoritative — no network fallback
+      // Mode 1: no network configured, no fallback expected
       expect(networkFallbackCounterStub.called).to.be.false;
+    });
+
+    it('keeps explicit host in result when mode-2 network fallback also yields metadata:null', async function () {
+      (mockExplicitGateway.getChunkMetadata as sinon.SinonStub).resolves({
+        host: 'explicit.example.com',
+        metadata: null,
+      });
+
+      (
+        mockNetworkGatewaySource.getEligibleGateways as sinon.SinonStub
+      ).resolves([createGateway('network1.example.com')]);
+
+      nock('https://network1.example.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', {});
+
+      const gateway = new CompositeReferenceGateway({
+        explicitGateway: mockExplicitGateway,
+        networkGatewaySource: mockNetworkGatewaySource,
+        consensusResolver: mockConsensusResolver,
+        networkOnly: false,
+        networkFallback: true,
+        nodeReleaseVersion: 'test',
+        log: logStub,
+      });
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      // Prefer reporting the explicit host we heard back from over a
+      // placeholder network-side host when neither found metadata.
+      expect(result.host).to.equal('explicit.example.com');
+      expect(result.metadata).to.equal(null);
     });
 
     it('falls back to network when explicit throws in mode 2', async function () {

--- a/src/reference/composite-reference-gateway.ts
+++ b/src/reference/composite-reference-gateway.ts
@@ -439,6 +439,8 @@ export class CompositeReferenceGateway
       throw new Error('No eligible network gateways available');
     }
 
+    let lastHostWithoutHeaders: string | undefined;
+
     for (const gateway of gateways) {
       try {
         const portPart = gateway.port !== 443 ? `:${gateway.port}` : '';
@@ -454,11 +456,23 @@ export class CompositeReferenceGateway
         });
 
         if (response.statusCode !== 200) {
+          // Reachable but returned non-200 — try next host, don't blacklist.
           continue;
         }
 
         const metadata = parseChunkHeaderMetadata(response.headers);
-        return { host: gateway.fqdn, metadata };
+        if (metadata !== null) {
+          return { host: gateway.fqdn, metadata };
+        }
+
+        // Reachable, 200, no usable headers: treat like other gateways that
+        // don't support this probe yet — fall through.
+        this.log.debug('Network gateway lacks chunk metadata headers', {
+          gateway: gateway.fqdn,
+          offset,
+        });
+        lastHostWithoutHeaders = gateway.fqdn;
+        continue;
       } catch (error: any) {
         const statusCode = error?.response?.statusCode;
 
@@ -471,15 +485,35 @@ export class CompositeReferenceGateway
           continue;
         }
 
-        this.log.debug('Network gateway metadata fetch failed, trying next', {
+        if (statusCode !== undefined) {
+          // Gateway is reachable (it produced an HTTP response) but does
+          // not support this probe. Do not blacklist the gateway from the
+          // shared pool used by unrelated workloads; just try the next.
+          this.log.debug(
+            'Network gateway returned HTTP error for metadata probe, trying next',
+            {
+              gateway: gateway.fqdn,
+              offset,
+              statusCode,
+              error: error?.message?.slice(0, 256),
+            },
+          );
+          continue;
+        }
+
+        // No HTTP response at all → transport failure (DNS/TLS/timeout/
+        // connection). Safe to mark unresponsive.
+        this.log.debug('Network gateway transport failure on metadata probe', {
           gateway: gateway.fqdn,
           offset,
-          statusCode,
           error: error?.message?.slice(0, 256),
         });
-
         this.networkGatewaySource.markUnresponsive(gateway.fqdn);
       }
+    }
+
+    if (lastHostWithoutHeaders !== undefined) {
+      return { host: lastHostWithoutHeaders, metadata: null };
     }
 
     return { host: 'network', metadata: null };

--- a/src/reference/composite-reference-gateway.ts
+++ b/src/reference/composite-reference-gateway.ts
@@ -19,11 +19,13 @@
 import { Got } from 'got';
 import { Logger } from 'winston';
 
+import { parseChunkHeaderMetadata } from '../lib/chunk-header-parser.js';
 import { createGatewayHttpClient } from '../lib/http-client.js';
 import * as metrics from '../metrics.js';
 import {
   ArnsConsensusResolver,
   ArnsResolution,
+  ChunkHeaderMetadata,
   CompositeReferenceGatewaySource,
   NetworkGatewaySource,
   ReferenceGatewaySource,
@@ -357,5 +359,129 @@ export class CompositeReferenceGateway
 
     // All gateways failed or chunk not found
     return { host: 'network', available: false };
+  }
+
+  /**
+   * Fetch chunk metadata headers with fallback support.
+   */
+  async getChunkMetadata(params: {
+    offset: number;
+  }): Promise<{ host: string; metadata: ChunkHeaderMetadata | null }> {
+    const { offset } = params;
+
+    // Mode 3: Network only
+    if (this.networkOnly) {
+      return this.getChunkMetadataFromNetwork({ offset });
+    }
+
+    // Mode 1 & 2: Try explicit gateway first
+    try {
+      return await this.explicitGateway!.getChunkMetadata(params);
+    } catch (explicitError: any) {
+      // Mode 1: Explicit only
+      if (!this.networkFallback) {
+        return { host: 'explicit', metadata: null };
+      }
+
+      this.log.debug(
+        'Explicit gateway chunk metadata failed, falling back to network',
+        {
+          offset,
+          explicitError: explicitError?.message?.slice(0, 256),
+        },
+      );
+
+      metrics.networkFallbackCounter.inc({
+        operation: 'getChunkMetadata',
+        status: 'triggered',
+      });
+
+      try {
+        const result = await this.getChunkMetadataFromNetwork({ offset });
+
+        metrics.networkFallbackCounter.inc({
+          operation: 'getChunkMetadata',
+          status: result.metadata !== null ? 'success' : 'failure',
+        });
+
+        return result;
+      } catch {
+        metrics.networkFallbackCounter.inc({
+          operation: 'getChunkMetadata',
+          status: 'failure',
+        });
+
+        return { host: 'network', metadata: null };
+      }
+    }
+  }
+
+  /**
+   * Fetch chunk metadata headers from network gateways (sequential).
+   */
+  private async getChunkMetadataFromNetwork(params: {
+    offset: number;
+  }): Promise<{ host: string; metadata: ChunkHeaderMetadata | null }> {
+    if (this.networkGatewaySource === null) {
+      throw new Error('Network gateway source not configured');
+    }
+
+    const { offset } = params;
+
+    const excludeFqdns =
+      this.observedGatewayFqdn !== null ? [this.observedGatewayFqdn] : [];
+
+    const gateways = await this.networkGatewaySource.getEligibleGateways({
+      excludeFqdns,
+    });
+
+    if (gateways.length === 0) {
+      throw new Error('No eligible network gateways available');
+    }
+
+    for (const gateway of gateways) {
+      try {
+        const portPart = gateway.port !== 443 ? `:${gateway.port}` : '';
+        const url = `https://${gateway.fqdn}${portPart}/chunk/${offset}/data`;
+
+        this.log.debug('Fetching chunk metadata from network gateway', {
+          gateway: gateway.fqdn,
+          offset,
+        });
+
+        const response = await this.gotClient.head(url, {
+          timeout: { request: 3000 },
+        });
+
+        if (response.statusCode !== 200) {
+          continue;
+        }
+
+        const metadata = parseChunkHeaderMetadata(response.headers);
+        return { host: gateway.fqdn, metadata };
+      } catch (error: any) {
+        const statusCode = error?.response?.statusCode;
+
+        if (statusCode === 404 || statusCode === 410) {
+          this.log.debug('Chunk metadata not found on network gateway', {
+            gateway: gateway.fqdn,
+            offset,
+            statusCode,
+          });
+          continue;
+        }
+
+        this.log.debug('Network gateway metadata fetch failed, trying next', {
+          gateway: gateway.fqdn,
+          offset,
+          statusCode,
+          error: error?.message?.slice(0, 256),
+        });
+
+        this.networkGatewaySource.markUnresponsive(gateway.fqdn);
+      }
+    }
+
+    return { host: 'network', metadata: null };
   }
 }

--- a/src/reference/composite-reference-gateway.ts
+++ b/src/reference/composite-reference-gateway.ts
@@ -363,6 +363,13 @@ export class CompositeReferenceGateway
 
   /**
    * Fetch chunk metadata headers with fallback support.
+   *
+   * Unlike checkChunkAvailability, a null metadata result from the
+   * explicit gateway is NOT authoritative — older gateways and those
+   * that lack the probe endpoint all surface as null. So when network
+   * fallback is on, we proceed to network gateways whenever the
+   * explicit side couldn't produce metadata, regardless of whether it
+   * returned null or threw.
    */
   async getChunkMetadata(params: {
     offset: number;
@@ -375,44 +382,71 @@ export class CompositeReferenceGateway
     }
 
     // Mode 1 & 2: Try explicit gateway first
+    let explicitResult: {
+      host: string;
+      metadata: ChunkHeaderMetadata | null;
+    } | null = null;
+    let explicitError: any;
     try {
-      return await this.explicitGateway!.getChunkMetadata(params);
-    } catch (explicitError: any) {
-      // Mode 1: Explicit only
-      if (!this.networkFallback) {
-        return { host: 'explicit', metadata: null };
+      explicitResult = await this.explicitGateway!.getChunkMetadata(params);
+      if (explicitResult.metadata !== null) {
+        return explicitResult;
       }
+    } catch (err: any) {
+      explicitError = err;
+    }
 
-      this.log.debug(
-        'Explicit gateway chunk metadata failed, falling back to network',
-        {
-          offset,
-          explicitError: explicitError?.message?.slice(0, 256),
-        },
-      );
+    // Mode 1: pass through whatever explicit produced.
+    if (!this.networkFallback) {
+      if (explicitResult !== null) {
+        return explicitResult;
+      }
+      return { host: 'explicit', metadata: null };
+    }
+
+    // Mode 2: explicit didn't yield metadata — try network.
+    this.log.debug(
+      'Explicit gateway produced no chunk metadata, falling back to network',
+      {
+        offset,
+        explicitHost: explicitResult?.host,
+        explicitError: explicitError?.message?.slice(0, 256),
+      },
+    );
+
+    metrics.networkFallbackCounter.inc({
+      operation: 'getChunkMetadata',
+      status: 'triggered',
+    });
+
+    try {
+      const result = await this.getChunkMetadataFromNetwork({ offset });
 
       metrics.networkFallbackCounter.inc({
         operation: 'getChunkMetadata',
-        status: 'triggered',
+        status: result.metadata !== null ? 'success' : 'failure',
       });
 
-      try {
-        const result = await this.getChunkMetadataFromNetwork({ offset });
-
-        metrics.networkFallbackCounter.inc({
-          operation: 'getChunkMetadata',
-          status: result.metadata !== null ? 'success' : 'failure',
-        });
-
+      if (result.metadata !== null) {
         return result;
-      } catch {
-        metrics.networkFallbackCounter.inc({
-          operation: 'getChunkMetadata',
-          status: 'failure',
-        });
-
-        return { host: 'network', metadata: null };
       }
+      // Network also couldn't produce metadata. Prefer reporting the
+      // explicit-side reachable host so the caller sees a coherent
+      // "feature unavailable" outcome rather than a placeholder.
+      if (explicitResult !== null) {
+        return explicitResult;
+      }
+      return result;
+    } catch {
+      metrics.networkFallbackCounter.inc({
+        operation: 'getChunkMetadata',
+        status: 'failure',
+      });
+
+      if (explicitResult !== null) {
+        return explicitResult;
+      }
+      return { host: 'network', metadata: null };
     }
   }
 
@@ -439,7 +473,7 @@ export class CompositeReferenceGateway
       throw new Error('No eligible network gateways available');
     }
 
-    let lastHostWithoutHeaders: string | undefined;
+    let lastReachableHost: string | undefined;
 
     for (const gateway of gateways) {
       try {
@@ -457,6 +491,7 @@ export class CompositeReferenceGateway
 
         if (response.statusCode !== 200) {
           // Reachable but returned non-200 — try next host, don't blacklist.
+          lastReachableHost = gateway.fqdn;
           continue;
         }
 
@@ -471,17 +506,20 @@ export class CompositeReferenceGateway
           gateway: gateway.fqdn,
           offset,
         });
-        lastHostWithoutHeaders = gateway.fqdn;
+        lastReachableHost = gateway.fqdn;
         continue;
       } catch (error: any) {
         const statusCode = error?.response?.statusCode;
 
+        // 404/410 on /chunk/{offset}/data can just mean "endpoint not
+        // implemented on this host", so it's not authoritative — keep
+        // trying later gateways.
         if (statusCode === 404 || statusCode === 410) {
-          this.log.debug('Chunk metadata not found on network gateway', {
-            gateway: gateway.fqdn,
-            offset,
-            statusCode,
-          });
+          this.log.debug(
+            'Network gateway returned 404/410 for metadata probe, trying next',
+            { gateway: gateway.fqdn, offset, statusCode },
+          );
+          lastReachableHost = gateway.fqdn;
           continue;
         }
 
@@ -498,6 +536,7 @@ export class CompositeReferenceGateway
               error: error?.message?.slice(0, 256),
             },
           );
+          lastReachableHost = gateway.fqdn;
           continue;
         }
 
@@ -512,8 +551,8 @@ export class CompositeReferenceGateway
       }
     }
 
-    if (lastHostWithoutHeaders !== undefined) {
-      return { host: lastHostWithoutHeaders, metadata: null };
+    if (lastReachableHost !== undefined) {
+      return { host: lastReachableHost, metadata: null };
     }
 
     return { host: 'network', metadata: null };

--- a/src/reference/fallback-reference-gateway.test.ts
+++ b/src/reference/fallback-reference-gateway.test.ts
@@ -558,4 +558,155 @@ describe('FallbackReferenceGateway', function () {
       ).to.be.true;
     });
   });
+
+  describe('getChunkMetadata', function () {
+    const completeHeaders = {
+      'x-arweave-chunk-tx-id': 'T3DcnZlZg_FqOQUf9MSZXQ5j7_ETc04OEqbkX-MZRnc',
+      'x-arweave-chunk-tx-start-offset': '108631448658167',
+      'x-arweave-chunk-tx-data-size': '42724169',
+      'x-arweave-chunk-data-root':
+        'qoQEdVyTqjLpkybZAgkIgtNawXUHUd5TJZwkWx0Vo-A',
+      'x-arweave-chunk-data-path': 'E2OKmVV7k4k',
+      'x-arweave-chunk-tx-path': 'H9gNFx8dbHj',
+      'x-arweave-chunk-start-offset': '108631449706743',
+      'x-arweave-chunk-relative-start-offset': '1048576',
+    };
+
+    it('returns parsed metadata when all required headers are present', async function () {
+      const gateway = new FallbackReferenceGateway({
+        hosts: ['gateway1.com'],
+        nodeReleaseVersion: 'test-version',
+        log: logStub,
+      });
+
+      nock('https://gateway1.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', completeHeaders);
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('gateway1.com');
+      expect(result.metadata).to.not.equal(null);
+      expect(result.metadata!.txId).to.equal(
+        completeHeaders['x-arweave-chunk-tx-id'],
+      );
+      expect(result.metadata!.txStartOffset).to.equal(108631448658167n);
+      expect(fallbackCounterStub.called).to.be.false;
+    });
+
+    it('returns metadata:null when first host returns 200 but omits headers', async function () {
+      const gateway = new FallbackReferenceGateway({
+        hosts: ['gateway1.com', 'gateway2.com'],
+        nodeReleaseVersion: 'test-version',
+        log: logStub,
+      });
+
+      // Older gateway: 200 OK but no x-arweave-chunk-* headers
+      nock('https://gateway1.com').head('/chunk/12345/data').reply(200, '', {});
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('gateway1.com');
+      expect(result.metadata).to.equal(null);
+      // Successful response — don't fall through to the second host
+      expect(fallbackCounterStub.called).to.be.false;
+    });
+
+    it('returns metadata:null on authoritative 404', async function () {
+      const gateway = new FallbackReferenceGateway({
+        hosts: ['gateway1.com', 'gateway2.com'],
+        nodeReleaseVersion: 'test-version',
+        log: logStub,
+      });
+
+      nock('https://gateway1.com').head('/chunk/12345/data').reply(404);
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('gateway1.com');
+      expect(result.metadata).to.equal(null);
+      expect(fallbackCounterStub.called).to.be.false;
+    });
+
+    it('returns metadata:null on authoritative 410', async function () {
+      const gateway = new FallbackReferenceGateway({
+        hosts: ['gateway1.com'],
+        nodeReleaseVersion: 'test-version',
+        log: logStub,
+      });
+
+      nock('https://gateway1.com').head('/chunk/12345/data').reply(410);
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.metadata).to.equal(null);
+    });
+
+    it('falls back to second host on network error and increments counter', async function () {
+      const gateway = new FallbackReferenceGateway({
+        hosts: ['gateway1.com', 'gateway2.com'],
+        nodeReleaseVersion: 'test-version',
+        log: logStub,
+      });
+
+      nock('https://gateway1.com')
+        .head('/chunk/12345/data')
+        .replyWithError('ENOTFOUND');
+
+      nock('https://gateway2.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', completeHeaders);
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('gateway2.com');
+      expect(result.metadata).to.not.equal(null);
+      expect(
+        fallbackCounterStub.calledWith({
+          operation: 'getChunkMetadata',
+          host: 'gateway2.com',
+        }),
+      ).to.be.true;
+    });
+
+    it('throws when all hosts fail with non-404/410 errors', async function () {
+      const gateway = new FallbackReferenceGateway({
+        hosts: ['gateway1.com', 'gateway2.com'],
+        nodeReleaseVersion: 'test-version',
+        log: logStub,
+      });
+
+      nock('https://gateway1.com')
+        .head('/chunk/12345/data')
+        .replyWithError('ENOTFOUND');
+      nock('https://gateway2.com').head('/chunk/12345/data').reply(500);
+
+      try {
+        await gateway.getChunkMetadata({ offset: 12345 });
+        expect.fail('Should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.include(
+          'getChunkMetadata failed on all hosts',
+        );
+      }
+    });
+
+    it('returns metadata:null when headers are malformed', async function () {
+      const gateway = new FallbackReferenceGateway({
+        hosts: ['gateway1.com'],
+        nodeReleaseVersion: 'test-version',
+        log: logStub,
+      });
+
+      nock('https://gateway1.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', {
+          ...completeHeaders,
+          'x-arweave-chunk-tx-start-offset': 'not-a-number',
+        });
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+      expect(result.metadata).to.equal(null);
+    });
+  });
 });

--- a/src/reference/fallback-reference-gateway.test.ts
+++ b/src/reference/fallback-reference-gateway.test.ts
@@ -594,7 +594,7 @@ describe('FallbackReferenceGateway', function () {
       expect(fallbackCounterStub.called).to.be.false;
     });
 
-    it('returns metadata:null when first host returns 200 but omits headers', async function () {
+    it('falls through to next host when first returns 200 but omits headers', async function () {
       const gateway = new FallbackReferenceGateway({
         hosts: ['gateway1.com', 'gateway2.com'],
         nodeReleaseVersion: 'test-version',
@@ -603,13 +603,39 @@ describe('FallbackReferenceGateway', function () {
 
       // Older gateway: 200 OK but no x-arweave-chunk-* headers
       nock('https://gateway1.com').head('/chunk/12345/data').reply(200, '', {});
+      // Newer gateway further down the list supports the headers
+      nock('https://gateway2.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', completeHeaders);
 
       const result = await gateway.getChunkMetadata({ offset: 12345 });
 
-      expect(result.host).to.equal('gateway1.com');
+      expect(result.host).to.equal('gateway2.com');
+      expect(result.metadata).to.not.equal(null);
+      expect(
+        fallbackCounterStub.calledWith({
+          operation: 'getChunkMetadata',
+          host: 'gateway2.com',
+        }),
+      ).to.be.true;
+    });
+
+    it('returns metadata:null against last reachable host when no host exposes headers', async function () {
+      const gateway = new FallbackReferenceGateway({
+        hosts: ['gateway1.com', 'gateway2.com'],
+        nodeReleaseVersion: 'test-version',
+        log: logStub,
+      });
+
+      nock('https://gateway1.com').head('/chunk/12345/data').reply(200, '', {});
+      nock('https://gateway2.com').head('/chunk/12345/data').reply(200, '', {});
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      // Last reachable host reported — caller distinguishes "feature
+      // unavailable" (metadata null) from "all hosts down" (throws).
+      expect(result.host).to.equal('gateway2.com');
       expect(result.metadata).to.equal(null);
-      // Successful response — don't fall through to the second host
-      expect(fallbackCounterStub.called).to.be.false;
     });
 
     it('returns metadata:null on authoritative 404', async function () {

--- a/src/reference/fallback-reference-gateway.test.ts
+++ b/src/reference/fallback-reference-gateway.test.ts
@@ -638,9 +638,33 @@ describe('FallbackReferenceGateway', function () {
       expect(result.metadata).to.equal(null);
     });
 
-    it('returns metadata:null on authoritative 404', async function () {
+    it('falls through to next host on 404 (endpoint may not be supported)', async function () {
       const gateway = new FallbackReferenceGateway({
         hosts: ['gateway1.com', 'gateway2.com'],
+        nodeReleaseVersion: 'test-version',
+        log: logStub,
+      });
+
+      nock('https://gateway1.com').head('/chunk/12345/data').reply(404);
+      nock('https://gateway2.com')
+        .head('/chunk/12345/data')
+        .reply(200, '', completeHeaders);
+
+      const result = await gateway.getChunkMetadata({ offset: 12345 });
+
+      expect(result.host).to.equal('gateway2.com');
+      expect(result.metadata).to.not.equal(null);
+      expect(
+        fallbackCounterStub.calledWith({
+          operation: 'getChunkMetadata',
+          host: 'gateway2.com',
+        }),
+      ).to.be.true;
+    });
+
+    it('returns metadata:null against last reachable host when only host returns 404', async function () {
+      const gateway = new FallbackReferenceGateway({
+        hosts: ['gateway1.com'],
         nodeReleaseVersion: 'test-version',
         log: logStub,
       });
@@ -651,10 +675,9 @@ describe('FallbackReferenceGateway', function () {
 
       expect(result.host).to.equal('gateway1.com');
       expect(result.metadata).to.equal(null);
-      expect(fallbackCounterStub.called).to.be.false;
     });
 
-    it('returns metadata:null on authoritative 410', async function () {
+    it('returns metadata:null against last reachable host when only host returns 410', async function () {
       const gateway = new FallbackReferenceGateway({
         hosts: ['gateway1.com'],
         nodeReleaseVersion: 'test-version',
@@ -665,6 +688,7 @@ describe('FallbackReferenceGateway', function () {
 
       const result = await gateway.getChunkMetadata({ offset: 12345 });
 
+      expect(result.host).to.equal('gateway1.com');
       expect(result.metadata).to.equal(null);
     });
 

--- a/src/reference/fallback-reference-gateway.test.ts
+++ b/src/reference/fallback-reference-gateway.test.ts
@@ -20,6 +20,7 @@ import nock from 'nock';
 import * as sinon from 'sinon';
 import * as winston from 'winston';
 
+import { completeHeaders } from '../lib/chunk-header.fixtures.js';
 import * as metrics from '../metrics.js';
 import { FallbackReferenceGateway } from './fallback-reference-gateway.js';
 
@@ -560,18 +561,6 @@ describe('FallbackReferenceGateway', function () {
   });
 
   describe('getChunkMetadata', function () {
-    const completeHeaders = {
-      'x-arweave-chunk-tx-id': 'T3DcnZlZg_FqOQUf9MSZXQ5j7_ETc04OEqbkX-MZRnc',
-      'x-arweave-chunk-tx-start-offset': '108631448658167',
-      'x-arweave-chunk-tx-data-size': '42724169',
-      'x-arweave-chunk-data-root':
-        'qoQEdVyTqjLpkybZAgkIgtNawXUHUd5TJZwkWx0Vo-A',
-      'x-arweave-chunk-data-path': 'E2OKmVV7k4k',
-      'x-arweave-chunk-tx-path': 'H9gNFx8dbHj',
-      'x-arweave-chunk-start-offset': '108631449706743',
-      'x-arweave-chunk-relative-start-offset': '1048576',
-    };
-
     it('returns parsed metadata when all required headers are present', async function () {
       const gateway = new FallbackReferenceGateway({
         hosts: ['gateway1.com'],

--- a/src/reference/fallback-reference-gateway.ts
+++ b/src/reference/fallback-reference-gateway.ts
@@ -242,6 +242,12 @@ export class FallbackReferenceGateway implements ReferenceGatewaySource {
   }): Promise<{ host: string; metadata: ChunkHeaderMetadata | null }> {
     const { offset } = params;
     let lastError: Error | undefined;
+    // Track the most recent reachable host that returned a successful
+    // response without the required headers. If every host lacks header
+    // support we return null against that host rather than throwing, so
+    // the caller knows this is a "feature unavailable" outcome rather
+    // than "all hosts down".
+    let lastHostWithoutHeaders: string | undefined;
 
     for (let i = 0; i < this.hosts.length; i++) {
       const host = this.hosts[i];
@@ -261,13 +267,26 @@ export class FallbackReferenceGateway implements ReferenceGatewaySource {
         }
 
         const metadata = parseChunkHeaderMetadata(response.headers);
-        if (metadata === null) {
-          this.log.debug('Chunk metadata headers missing or malformed', {
-            host,
-            offset,
+        if (metadata !== null) {
+          return { host, metadata };
+        }
+
+        // 200 without usable headers: the host is reachable but doesn't
+        // expose the chunk metadata headers (older deployment). Try the
+        // next host in case it does.
+        this.log.debug(
+          'Chunk metadata headers missing or malformed, trying fallback',
+          { host, offset, hostIndex: i, totalHosts: this.hosts.length },
+        );
+        lastHostWithoutHeaders = host;
+
+        if (i + 1 < this.hosts.length) {
+          metrics.referenceGatewayFallbackCounter.inc({
+            operation: 'getChunkMetadata',
+            host: this.hosts[i + 1],
           });
         }
-        return { host, metadata };
+        continue;
       } catch (error: any) {
         const statusCode = error?.response?.statusCode;
 
@@ -296,6 +315,13 @@ export class FallbackReferenceGateway implements ReferenceGatewaySource {
           });
         }
       }
+    }
+
+    // Prefer reporting the reachable-but-unsupported outcome over the
+    // network error so callers can distinguish "feature unavailable"
+    // from "reference side down".
+    if (lastHostWithoutHeaders !== undefined) {
+      return { host: lastHostWithoutHeaders, metadata: null };
     }
 
     throw new Error(

--- a/src/reference/fallback-reference-gateway.ts
+++ b/src/reference/fallback-reference-gateway.ts
@@ -242,12 +242,20 @@ export class FallbackReferenceGateway implements ReferenceGatewaySource {
   }): Promise<{ host: string; metadata: ChunkHeaderMetadata | null }> {
     const { offset } = params;
     let lastError: Error | undefined;
-    // Track the most recent reachable host that returned a successful
-    // response without the required headers. If every host lacks header
-    // support we return null against that host rather than throwing, so
-    // the caller knows this is a "feature unavailable" outcome rather
-    // than "all hosts down".
-    let lastHostWithoutHeaders: string | undefined;
+    // Track the most recent host that produced any HTTP response (200
+    // without headers, 404, 410, etc.) so we can return metadata:null
+    // against a reachable host rather than throwing when no host ends
+    // up advertising the headers.
+    let lastReachableHost: string | undefined;
+
+    const incrementFallbackCounter = (nextHostIndex: number) => {
+      if (nextHostIndex < this.hosts.length) {
+        metrics.referenceGatewayFallbackCounter.inc({
+          operation: 'getChunkMetadata',
+          host: this.hosts[nextHostIndex],
+        });
+      }
+    };
 
     for (let i = 0; i < this.hosts.length; i++) {
       const host = this.hosts[i];
@@ -271,32 +279,29 @@ export class FallbackReferenceGateway implements ReferenceGatewaySource {
           return { host, metadata };
         }
 
-        // 200 without usable headers: the host is reachable but doesn't
-        // expose the chunk metadata headers (older deployment). Try the
-        // next host in case it does.
+        // 200 without usable headers: reachable but doesn't expose the
+        // chunk metadata headers (older deployment). Try the next host.
         this.log.debug(
           'Chunk metadata headers missing or malformed, trying fallback',
           { host, offset, hostIndex: i, totalHosts: this.hosts.length },
         );
-        lastHostWithoutHeaders = host;
-
-        if (i + 1 < this.hosts.length) {
-          metrics.referenceGatewayFallbackCounter.inc({
-            operation: 'getChunkMetadata',
-            host: this.hosts[i + 1],
-          });
-        }
+        lastReachableHost = host;
+        incrementFallbackCounter(i + 1);
         continue;
       } catch (error: any) {
         const statusCode = error?.response?.statusCode;
 
+        // Unlike `/chunk/{offset}`, a 404/410 on `/chunk/{offset}/data`
+        // can just mean "this host doesn't expose that endpoint" — it's
+        // not authoritative. Keep trying later hosts that might.
         if (statusCode === 404 || statusCode === 410) {
-          this.log.debug('Chunk metadata not available (authoritative)', {
-            host,
-            offset,
-            statusCode,
-          });
-          return { host, metadata: null };
+          this.log.debug(
+            'Chunk metadata endpoint returned 404/410, trying fallback',
+            { host, offset, statusCode },
+          );
+          lastReachableHost = host;
+          incrementFallbackCounter(i + 1);
+          continue;
         }
 
         lastError = error;
@@ -307,21 +312,19 @@ export class FallbackReferenceGateway implements ReferenceGatewaySource {
           statusCode,
           error: error?.message?.slice(0, 256),
         });
-
-        if (i + 1 < this.hosts.length) {
-          metrics.referenceGatewayFallbackCounter.inc({
-            operation: 'getChunkMetadata',
-            host: this.hosts[i + 1],
-          });
+        if (statusCode !== undefined) {
+          // Any other HTTP response still counts as reachable.
+          lastReachableHost = host;
         }
+        incrementFallbackCounter(i + 1);
       }
     }
 
     // Prefer reporting the reachable-but-unsupported outcome over the
-    // network error so callers can distinguish "feature unavailable"
+    // transport error so callers can distinguish "feature unavailable"
     // from "reference side down".
-    if (lastHostWithoutHeaders !== undefined) {
-      return { host: lastHostWithoutHeaders, metadata: null };
+    if (lastReachableHost !== undefined) {
+      return { host: lastReachableHost, metadata: null };
     }
 
     throw new Error(

--- a/src/reference/fallback-reference-gateway.ts
+++ b/src/reference/fallback-reference-gateway.ts
@@ -20,10 +20,15 @@ import { Got } from 'got';
 import { Logger } from 'winston';
 
 import { validateArnsResolutionHeaders } from '../lib/arns-validation.js';
+import { parseChunkHeaderMetadata } from '../lib/chunk-header-parser.js';
 import { createGatewayHttpClient } from '../lib/http-client.js';
 import * as metrics from '../metrics.js';
 import { getArnsResolution } from '../observer.js';
-import { ArnsResolution, ReferenceGatewaySource } from '../types.js';
+import {
+  ArnsResolution,
+  ChunkHeaderMetadata,
+  ReferenceGatewaySource,
+} from '../types.js';
 
 /**
  * FallbackReferenceGateway provides reference gateway operations with
@@ -217,6 +222,84 @@ export class FallbackReferenceGateway implements ReferenceGatewaySource {
     // All hosts failed with non-404/410 errors - throw to trigger network fallback
     throw new Error(
       `checkChunkAvailability failed on all hosts: ${lastError?.message}`,
+    );
+  }
+
+  /**
+   * Fetch chunk metadata headers from reference gateways with fallback.
+   *
+   * Performs a HEAD request to `/chunk/{offset}/data` and extracts the
+   * `x-arweave-chunk-*` headers that advertise tx boundaries, data_root,
+   * and merkle proofs.
+   *
+   * Returns `metadata: null` when the first successful host omits the
+   * required headers (older gateway) — caller should fall back. 404/410
+   * responses are authoritative "chunk not found" and also return null.
+   * Throws only when every host fails with network/HTTP errors.
+   */
+  async getChunkMetadata(params: {
+    offset: number;
+  }): Promise<{ host: string; metadata: ChunkHeaderMetadata | null }> {
+    const { offset } = params;
+    let lastError: Error | undefined;
+
+    for (let i = 0; i < this.hosts.length; i++) {
+      const host = this.hosts[i];
+      const url = `https://${host}/chunk/${offset}/data`;
+
+      this.log.debug('Fetching chunk metadata headers', { host, offset, url });
+
+      try {
+        const response = await this.gotClient.head(url, {
+          timeout: { request: 3000 },
+        });
+
+        if (response.statusCode !== 200) {
+          throw new Error(
+            `Unexpected status code ${response.statusCode} from ${host}`,
+          );
+        }
+
+        const metadata = parseChunkHeaderMetadata(response.headers);
+        if (metadata === null) {
+          this.log.debug('Chunk metadata headers missing or malformed', {
+            host,
+            offset,
+          });
+        }
+        return { host, metadata };
+      } catch (error: any) {
+        const statusCode = error?.response?.statusCode;
+
+        if (statusCode === 404 || statusCode === 410) {
+          this.log.debug('Chunk metadata not available (authoritative)', {
+            host,
+            offset,
+            statusCode,
+          });
+          return { host, metadata: null };
+        }
+
+        lastError = error;
+        this.log.debug('Chunk metadata fetch failed, trying fallback', {
+          host,
+          hostIndex: i,
+          totalHosts: this.hosts.length,
+          statusCode,
+          error: error?.message?.slice(0, 256),
+        });
+
+        if (i + 1 < this.hosts.length) {
+          metrics.referenceGatewayFallbackCounter.inc({
+            operation: 'getChunkMetadata',
+            host: this.hosts[i + 1],
+          });
+        }
+      }
+    }
+
+    throw new Error(
+      `getChunkMetadata failed on all hosts: ${lastError?.message}`,
     );
   }
 }

--- a/src/summarize-report.ts
+++ b/src/summarize-report.ts
@@ -1,0 +1,203 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ObserverReport } from './types.js';
+
+const REPORTS_DIR = './data/reports';
+const UNKNOWN_RELEASE = '(unknown)';
+
+function resolveReportPath(arg: string | undefined): string {
+  if (arg !== undefined && arg !== '') {
+    return arg;
+  }
+  if (!fs.existsSync(REPORTS_DIR)) {
+    throw new Error(
+      `No report path given and default directory ${REPORTS_DIR} does not exist`,
+    );
+  }
+  const entries = fs
+    .readdirSync(REPORTS_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => ({
+      name: f,
+      // Filenames are epoch start heights — sort numerically, fall back to name.
+      key: Number.parseInt(path.basename(f, '.json'), 10),
+    }))
+    .sort((a, b) => {
+      if (Number.isNaN(a.key) || Number.isNaN(b.key)) {
+        return a.name.localeCompare(b.name);
+      }
+      return b.key - a.key;
+    });
+  if (entries.length === 0) {
+    throw new Error(`No report files found in ${REPORTS_DIR}`);
+  }
+  return path.join(REPORTS_DIR, entries[0].name);
+}
+
+function loadReport(filePath: string): ObserverReport {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw) as ObserverReport;
+}
+
+interface ReleaseBucket {
+  total: number;
+  passed: number;
+  ownershipFailures: number;
+  arnsFailures: number;
+  offsetFailures: number;
+  gateways: {
+    host: string;
+    pass: boolean;
+    ownershipPass: boolean;
+    arnsPass: boolean;
+    offsetPass: boolean | null;
+  }[];
+}
+
+function summarize(report: ObserverReport) {
+  const buckets = new Map<string, ReleaseBucket>();
+  const overall = {
+    total: 0,
+    passed: 0,
+    ownershipFailures: 0,
+    arnsFailures: 0,
+    offsetFailures: 0,
+  };
+
+  for (const [host, a] of Object.entries(report.gatewayAssessments)) {
+    const release = a.ownershipAssessment.observedRelease ?? UNKNOWN_RELEASE;
+    let bucket = buckets.get(release);
+    if (bucket === undefined) {
+      bucket = {
+        total: 0,
+        passed: 0,
+        ownershipFailures: 0,
+        arnsFailures: 0,
+        offsetFailures: 0,
+        gateways: [],
+      };
+      buckets.set(release, bucket);
+    }
+
+    const ownershipPass = a.ownershipAssessment.pass;
+    const arnsPass = a.arnsAssessments.pass;
+    const offsetPass =
+      a.offsetAssessments === undefined ? null : a.offsetAssessments.pass;
+
+    bucket.total += 1;
+    overall.total += 1;
+    if (a.pass) {
+      bucket.passed += 1;
+      overall.passed += 1;
+    }
+    if (!ownershipPass) {
+      bucket.ownershipFailures += 1;
+      overall.ownershipFailures += 1;
+    }
+    if (!arnsPass) {
+      bucket.arnsFailures += 1;
+      overall.arnsFailures += 1;
+    }
+    if (offsetPass === false) {
+      bucket.offsetFailures += 1;
+      overall.offsetFailures += 1;
+    }
+
+    bucket.gateways.push({
+      host,
+      pass: a.pass,
+      ownershipPass,
+      arnsPass,
+      offsetPass,
+    });
+  }
+
+  return { buckets, overall };
+}
+
+function pct(n: number, d: number): string {
+  if (d === 0) return '—';
+  return `${((n / d) * 100).toFixed(1)}%`;
+}
+
+function sortReleases(keys: string[]): string[] {
+  return keys.sort((a, b) => {
+    if (a === UNKNOWN_RELEASE) return 1;
+    if (b === UNKNOWN_RELEASE) return -1;
+    const na = Number.parseFloat(a);
+    const nb = Number.parseFloat(b);
+    if (!Number.isNaN(na) && !Number.isNaN(nb)) return nb - na;
+    return a.localeCompare(b);
+  });
+}
+
+function formatGatewayFlags(g: {
+  ownershipPass: boolean;
+  arnsPass: boolean;
+  offsetPass: boolean | null;
+}): string {
+  const parts: string[] = [];
+  if (!g.ownershipPass) parts.push('ownership');
+  if (!g.arnsPass) parts.push('arns');
+  if (g.offsetPass === false) parts.push('offset');
+  return parts.length === 0 ? 'ok' : `fail: ${parts.join(', ')}`;
+}
+
+function main(): void {
+  const reportPath = resolveReportPath(process.argv[2]);
+  const report = loadReport(reportPath);
+  const { buckets, overall } = summarize(report);
+
+  console.log(`Report: ${reportPath}`);
+  console.log(
+    `Epoch ${report.epochIndex} (startHeight=${report.epochStartHeight})`,
+  );
+  console.log(
+    `Overall: ${overall.passed}/${overall.total} passed (${pct(
+      overall.passed,
+      overall.total,
+    )})`,
+  );
+  console.log(
+    `  failures: ownership=${overall.ownershipFailures} arns=${overall.arnsFailures} offset=${overall.offsetFailures}`,
+  );
+  console.log('');
+  console.log('By release:');
+
+  const releases = sortReleases([...buckets.keys()]);
+  for (const release of releases) {
+    const b = buckets.get(release)!;
+    console.log(
+      `  release=${release}  ${b.passed}/${b.total} passed (${pct(
+        b.passed,
+        b.total,
+      )})  ownership=${b.ownershipFailures} arns=${b.arnsFailures} offset=${b.offsetFailures}`,
+    );
+    const failed = b.gateways.filter((g) => !g.pass);
+    if (failed.length > 0) {
+      for (const g of failed) {
+        console.log(`    - ${g.host}  ${formatGatewayFlags(g)}`);
+      }
+    }
+  }
+}
+
+main();

--- a/src/summarize-report.ts
+++ b/src/summarize-report.ts
@@ -35,11 +35,15 @@ function resolveReportPath(arg: string | undefined): string {
   const entries = fs
     .readdirSync(REPORTS_DIR)
     .filter((f) => f.endsWith('.json'))
-    .map((f) => ({
-      name: f,
-      // Filenames are epoch start heights — sort numerically, fall back to name.
-      key: Number.parseInt(path.basename(f, '.json'), 10),
-    }))
+    .map((f) => {
+      const base = path.basename(f, '.json');
+      // Only filenames that are strictly numeric are treated as epoch
+      // start heights. Anything else (e.g. 123-backup.json) sorts
+      // alphabetically so an auxiliary file can't masquerade as the
+      // latest epoch.
+      const key = /^\d+$/.test(base) ? Number.parseInt(base, 10) : NaN;
+      return { name: f, key };
+    })
     .sort((a, b) => {
       if (Number.isNaN(a.key) || Number.isNaN(b.key)) {
         return a.name.localeCompare(b.name);
@@ -142,10 +146,11 @@ function sortReleases(keys: string[]): string[] {
   return keys.sort((a, b) => {
     if (a === UNKNOWN_RELEASE) return 1;
     if (b === UNKNOWN_RELEASE) return -1;
-    const na = Number.parseFloat(a);
-    const nb = Number.parseFloat(b);
-    if (!Number.isNaN(na) && !Number.isNaN(nb)) return nb - na;
-    return a.localeCompare(b);
+    // Numeric-aware comparison so "1.10.0" sorts above "1.9.0".
+    return b.localeCompare(a, undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    });
   });
 }
 

--- a/src/summarize-report.ts
+++ b/src/summarize-report.ts
@@ -70,6 +70,7 @@ interface ReleaseBucket {
   passed: number;
   ownershipFailures: number;
   arnsFailures: number;
+  offsetObserved: number;
   offsetFailures: number;
   gateways: {
     host: string;
@@ -87,6 +88,7 @@ function summarize(report: ObserverReport) {
     passed: 0,
     ownershipFailures: 0,
     arnsFailures: 0,
+    offsetObserved: 0,
     offsetFailures: 0,
   };
 
@@ -99,6 +101,7 @@ function summarize(report: ObserverReport) {
         passed: 0,
         ownershipFailures: 0,
         arnsFailures: 0,
+        offsetObserved: 0,
         offsetFailures: 0,
         gateways: [],
       };
@@ -124,9 +127,13 @@ function summarize(report: ObserverReport) {
       bucket.arnsFailures += 1;
       overall.arnsFailures += 1;
     }
-    if (offsetPass === false) {
-      bucket.offsetFailures += 1;
-      overall.offsetFailures += 1;
+    if (offsetPass !== null) {
+      bucket.offsetObserved += 1;
+      overall.offsetObserved += 1;
+      if (offsetPass === false) {
+        bucket.offsetFailures += 1;
+        overall.offsetFailures += 1;
+      }
     }
 
     bucket.gateways.push({
@@ -186,7 +193,7 @@ function main(): void {
     )})`,
   );
   console.log(
-    `  failures: ownership=${overall.ownershipFailures} arns=${overall.arnsFailures} offset=${overall.offsetFailures}`,
+    `  failures: ownership=${overall.ownershipFailures} arns=${overall.arnsFailures} offset=${overall.offsetFailures}/${overall.offsetObserved} (${pct(overall.offsetFailures, overall.offsetObserved)})`,
   );
   console.log('');
   console.log('By release:');
@@ -198,7 +205,7 @@ function main(): void {
       `  release=${release}  ${b.passed}/${b.total} passed (${pct(
         b.passed,
         b.total,
-      )})  ownership=${b.ownershipFailures} arns=${b.arnsFailures} offset=${b.offsetFailures}`,
+      )})  ownership=${b.ownershipFailures} arns=${b.arnsFailures} offset=${b.offsetFailures}/${b.offsetObserved} (${pct(b.offsetFailures, b.offsetObserved)})`,
     );
     const failed = b.gateways.filter((g) => !g.pass);
     if (failed.length > 0) {

--- a/src/summarize-report.ts
+++ b/src/summarize-report.ts
@@ -45,10 +45,14 @@ function resolveReportPath(arg: string | undefined): string {
       return { name: f, key };
     })
     .sort((a, b) => {
-      if (Number.isNaN(a.key) || Number.isNaN(b.key)) {
-        return a.name.localeCompare(b.name);
-      }
-      return b.key - a.key;
+      const aNumeric = !Number.isNaN(a.key);
+      const bNumeric = !Number.isNaN(b.key);
+      // Numeric epoch filenames always outrank non-numeric auxiliary files
+      // so a stray `050-backup.json` can't be picked as the default report.
+      if (aNumeric && bNumeric) return b.key - a.key;
+      if (aNumeric) return -1;
+      if (bNumeric) return 1;
+      return a.name.localeCompare(b.name);
     });
   if (entries.length === 0) {
     throw new Error(`No report files found in ${REPORTS_DIR}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,17 @@ export interface ArnsResolution {
   timings: any | null;
 }
 
+export interface ChunkHeaderMetadata {
+  txId: string;
+  txStartOffset: bigint;
+  txDataSize: bigint;
+  dataRoot: string;
+  dataPath: string;
+  txPath: string;
+  chunkStartOffset: bigint;
+  chunkRelativeStartOffset: bigint;
+}
+
 export interface ReferenceGatewaySource {
   getArnsResolution(params: {
     arnsName: string;
@@ -116,6 +127,10 @@ export interface ReferenceGatewaySource {
   checkChunkAvailability(params: {
     offset: number;
   }): Promise<{ host: string; available: boolean }>;
+
+  getChunkMetadata(params: {
+    offset: number;
+  }): Promise<{ host: string; metadata: ChunkHeaderMetadata | null }>;
 }
 
 //

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,6 +125,7 @@ export interface ReferenceGatewaySource {
 export interface OwnershipAssessment {
   expectedWallets: string[];
   observedWallet: string | null;
+  observedRelease?: string;
   failureReason?: string;
   pass: boolean;
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -4,5 +4,5 @@
     "sourceMap": false
   },
   "include": ["src"],
-  "exclude": ["tests", "**/*.test.ts"]
+  "exclude": ["tests", "**/*.test.ts", "**/*.fixtures.ts"]
 }


### PR DESCRIPTION
## Summary

- Replace the block-and-tx binary search as the default offset-validation path with a HEAD probe on the reference gateway's `/chunk/{offset}/data`, reading the `x-arweave-chunk-*` headers and anchoring them to the chain via `/tx/{id}/offset` and `/tx/{id}`. Per-tx LRU cache means repeated offsets in the same tx pay zero additional node calls. The existing chain search is preserved as a fallback for gateways that don't send the headers or disagree with the chain.
- Also adds the infrastructure: `ChunkHeaderMetadata` on `ReferenceGatewaySource`, HEAD-based parsing in the fallback and composite reference gateway implementations, a pure `chunk-header-parser`, and a pure `chunk-metadata-anchor` module (never trusts the reference over the chain — any mismatch throws `ChainAnchorMismatchError` and falls back).
- Fallback-semantics fixes: don't blacklist a network gateway from the shared pool just because it returned an HTTP error on this new probe (only transport failures trigger `markUnresponsive` now), and fall through to the next reference host on a 200 response that lacks the headers instead of stopping.
- New metric `observer_chunk_metadata_anchor_total{result}` tracks hit / cache_hit / metadata_missing / mismatch / error / fallback so the rollout can be observed in production.

## Commits

1. `feat(reference): add getChunkMetadata for HEAD-based header parsing` — type + fallback/composite impls + header parser + tests.
2. `feat(lib): add chunk metadata chain-anchor module` — pure verification helper.
3. `feat(observer): use reference-gateway chunk headers for offset validation` — observer wiring, per-tx cache, metric.
4. `fix(reference): don't blacklist gateways that just lack the chunk metadata probe` — follow-up to address review feedback on fallback/liveness semantics.

## Test plan

- [x] `yarn build` passes
- [x] `yarn lint:check` and `yarn format:check` clean
- [x] Full suite: 214 passing (+15 new across parser, anchor, observer wiring, and fallback-semantics)
- [ ] Verify `observer_chunk_metadata_anchor_total` in Grafana once deployed; expect `hit` + `cache_hit` to dominate and `mismatch` to be ~0

## Follow-ups

- Once metrics confirm the header path dominates and mismatch rate is ~0, consider deleting `binarySearchBlocks` / `binarySearchTransactions` / `findTransactionForOffset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blockchain-anchored chunk metadata retrieval from reference gateways with integrity checks and clear mismatch errors.
  * Per-transaction caching of anchored metadata and improved gateway probing/fallback behavior.
  * Added metrics for anchoring outcomes and gateway fallback.

* **Tests**
  * Extensive tests covering header parsing, anchoring logic, gateway probing/fallback paths, and observer integration.

* **Chores**
  * Added a CLI script to summarize assessment reports by release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->