### PR TITLE
fix: harden continuous observer reliability and scheduling

### DIFF
--- a/src/continuous/continuous-observation-scheduler.test.ts
+++ b/src/continuous/continuous-observation-scheduler.test.ts
@@ -243,4 +243,26 @@ describe('ContinuousObservationScheduler', function () {
       ).to.be.false;
     });
   });
+
+  describe('getSubmissionDeadline', function () {
+    it('should place submission deadline after window end by the configured buffer', async function () {
+      const scheduler = new ContinuousObservationScheduler({
+        entropySource,
+        config: {
+          observationsPerGateway: 3,
+          submissionBufferMs: 1234,
+        },
+        log: testLog,
+      });
+
+      const { windowEnd } = await scheduler.initializeEpoch({
+        gateways,
+        epochStartTimestamp,
+        epochEndTimestamp,
+        epochStartHeight,
+      });
+
+      expect(scheduler.getSubmissionDeadline()).to.equal(windowEnd + 1234);
+    });
+  });
 });

--- a/src/continuous/continuous-observation-scheduler.test.ts
+++ b/src/continuous/continuous-observation-scheduler.test.ts
@@ -116,11 +116,7 @@ describe('ContinuousObservationScheduler', function () {
       expect(result1.windowEnd).to.equal(result2.windowEnd);
 
       // Same schedule for each gateway
-      for (const gateway of gateways) {
-        const times1 = result1.schedule.get(gateway.fqdn);
-        const times2 = result2.schedule.get(gateway.fqdn);
-        expect(times1).to.deep.equal(times2);
-      }
+      expect(result1.schedule).to.deep.equal(result2.schedule);
     });
 
     it('should schedule correct number of observations per gateway', async function () {
@@ -139,13 +135,34 @@ describe('ContinuousObservationScheduler', function () {
       });
 
       for (const gateway of gateways) {
-        const times = schedule.get(gateway.fqdn);
-        expect(times).to.have.length(observationsPerGateway);
+        const events = schedule.filter(({ fqdn }) => fqdn === gateway.fqdn);
+        expect(events).to.have.length(observationsPerGateway);
       }
+    });
+
+    it('should spread observations across the full window instead of per-gateway waves', async function () {
+      const scheduler = new ContinuousObservationScheduler({
+        entropySource,
+        config: { observationsPerGateway: 3 },
+        log: testLog,
+      });
+
+      const { schedule } = await scheduler.initializeEpoch({
+        gateways,
+        epochStartTimestamp,
+        epochEndTimestamp,
+        epochStartHeight,
+      });
+
+      const scheduledHosts = schedule.map(({ fqdn }) => fqdn);
+      expect(new Set(scheduledHosts).size).to.equal(gateways.length);
+      expect(scheduledHosts.slice(0, gateways.length)).to.not.deep.equal(
+        gateways.map((gateway) => gateway.fqdn),
+      );
     });
   });
 
-  describe('getGatewaysDue', function () {
+  describe('getObservationsDue', function () {
     it('should return empty array before window starts', async function () {
       const scheduler = new ContinuousObservationScheduler({
         entropySource,
@@ -159,11 +176,11 @@ describe('ContinuousObservationScheduler', function () {
         epochStartHeight,
       });
 
-      const due = scheduler.getGatewaysDue(epochStartTimestamp);
+      const due = scheduler.getObservationsDue(epochStartTimestamp);
       expect(due).to.be.an('array').that.is.empty;
     });
 
-    it('should return empty array after window ends', async function () {
+    it('should continue returning overdue observations after window ends', async function () {
       const scheduler = new ContinuousObservationScheduler({
         entropySource,
         log: testLog,
@@ -176,11 +193,11 @@ describe('ContinuousObservationScheduler', function () {
         epochStartHeight,
       });
 
-      const due = scheduler.getGatewaysDue(epochEndTimestamp);
-      expect(due).to.be.an('array').that.is.empty;
+      const due = scheduler.getObservationsDue(epochEndTimestamp);
+      expect(due.length).to.equal(gateways.length * 3);
     });
 
-    it('should return gateways with passed scheduled times', async function () {
+    it('should return all passed scheduled observations', async function () {
       const scheduler = new ContinuousObservationScheduler({
         entropySource,
         log: testLog,
@@ -194,8 +211,8 @@ describe('ContinuousObservationScheduler', function () {
       });
 
       // Check at end of window - all observations should be due
-      const due = scheduler.getGatewaysDue(windowEnd - 1);
-      expect(due.length).to.be.greaterThan(0);
+      const due = scheduler.getObservationsDue(windowEnd - 1);
+      expect(due.length).to.equal(gateways.length * 3);
     });
   });
 
@@ -214,14 +231,16 @@ describe('ContinuousObservationScheduler', function () {
         epochStartHeight,
       });
 
-      const fqdn = gateways[0].fqdn;
-      const initialCount = scheduler.getSchedule().get(fqdn)?.length ?? 0;
+      const firstObservation = scheduler.getSchedule()[0];
+      const initialCount = scheduler.getPendingObservationCount();
 
       // Mark one observation complete
-      scheduler.markObservationComplete(fqdn, Date.now() + 10 * 60 * 60 * 1000);
+      scheduler.markObservationComplete(firstObservation.id);
 
-      const newCount = scheduler.getSchedule().get(fqdn)?.length ?? 0;
-      expect(newCount).to.equal(initialCount - 1);
+      expect(scheduler.getPendingObservationCount()).to.equal(initialCount - 1);
+      expect(
+        scheduler.getSchedule().some(({ id }) => id === firstObservation.id),
+      ).to.be.false;
     });
   });
 });

--- a/src/continuous/continuous-observation-scheduler.ts
+++ b/src/continuous/continuous-observation-scheduler.ts
@@ -241,6 +241,13 @@ export class ContinuousObservationScheduler {
   }
 
   /**
+   * Clear all pending scheduled observations.
+   */
+  clearSchedule(): void {
+    this.schedule = [];
+  }
+
+  /**
    * Check if the observation window has completed.
    */
   isWindowComplete(currentTime: number): boolean {

--- a/src/continuous/continuous-observation-scheduler.ts
+++ b/src/continuous/continuous-observation-scheduler.ts
@@ -20,7 +20,11 @@ import { Logger } from 'winston';
 
 import { customHashPRNG, shuffleWithPRNG } from '../lib/prng.js';
 import { EntropySource, GatewayHost } from '../types.js';
-import { ObservationState, SchedulerConfig } from './types.js';
+import {
+  ObservationState,
+  ScheduledObservation,
+  SchedulerConfig,
+} from './types.js';
 
 // Default configuration values
 const DEFAULT_OBSERVATIONS_PER_GATEWAY = 3;
@@ -42,7 +46,7 @@ export class ContinuousObservationScheduler {
 
   private windowStart: number = 0;
   private windowEnd: number = 0;
-  private schedule: Map<string, number[]> = new Map();
+  private schedule: ScheduledObservation[] = [];
 
   constructor({
     entropySource,
@@ -85,7 +89,7 @@ export class ContinuousObservationScheduler {
   }): Promise<{
     windowStart: number;
     windowEnd: number;
-    schedule: Map<string, number[]>;
+    schedule: ScheduledObservation[];
   }> {
     const epochDuration = epochEndTimestamp - epochStartTimestamp;
     const windowLength = epochDuration * this.config.windowFraction;
@@ -114,29 +118,33 @@ export class ContinuousObservationScheduler {
     this.windowStart = earliestStart + startOffset;
     this.windowEnd = this.windowStart + windowLength;
 
-    // Shuffle gateways deterministically
-    const shuffledGateways = shuffleWithPRNG(gateways, rng);
+    // Schedule unique gateways only; wallet multiplicity is handled separately.
+    const uniqueFqdns = [...new Set(gateways.map((gateway) => gateway.fqdn))];
+    const observationAssignments = shuffleWithPRNG(
+      uniqueFqdns.flatMap((fqdn) =>
+        Array.from({ length: this.config.observationsPerGateway }, () => fqdn),
+      ),
+      rng,
+    );
 
-    // Schedule observations for each gateway
-    this.schedule = new Map();
-    const slotLength = windowLength / this.config.observationsPerGateway;
+    // Spread every observation event across the full window.
+    const slotLength =
+      observationAssignments.length > 0
+        ? windowLength / observationAssignments.length
+        : windowLength;
 
-    for (const gateway of shuffledGateways) {
-      const times: number[] = [];
-
-      for (let i = 0; i < this.config.observationsPerGateway; i++) {
-        const slotStart = this.windowStart + i * slotLength;
-        // Use 80% of slot for jitter to avoid observations bunching at slot boundaries
+    this.schedule = observationAssignments
+      .map((fqdn, index) => {
+        const slotStart = this.windowStart + index * slotLength;
         const jitter = rng() * slotLength * 0.8;
-        times.push(slotStart + jitter);
-      }
 
-      // Sort times to ensure they're in chronological order
-      this.schedule.set(
-        gateway.fqdn,
-        times.sort((a, b) => a - b),
-      );
-    }
+        return {
+          id: `${fqdn}:${index}`,
+          fqdn,
+          scheduledAt: slotStart + jitter,
+        };
+      })
+      .sort((left, right) => left.scheduledAt - right.scheduledAt);
 
     this.log.info('Epoch observation schedule initialized', {
       epochStartTimestamp,
@@ -145,9 +153,9 @@ export class ContinuousObservationScheduler {
       windowStart: this.windowStart,
       windowEnd: this.windowEnd,
       windowLength,
-      gatewayCount: gateways.length,
+      gatewayCount: uniqueFqdns.length,
       observationsPerGateway: this.config.observationsPerGateway,
-      totalObservations: gateways.length * this.config.observationsPerGateway,
+      totalObservations: this.schedule.length,
     });
 
     return {
@@ -163,17 +171,16 @@ export class ContinuousObservationScheduler {
   restoreFromState(state: ObservationState): void {
     this.windowStart = state.windowStart;
     this.windowEnd = state.windowEnd;
-    this.schedule = new Map(state.pendingObservations);
+    this.schedule = [...state.pendingObservations].sort(
+      (left, right) => left.scheduledAt - right.scheduledAt,
+    );
 
     this.log.info('Scheduler state restored', {
       epochIndex: state.epochIndex,
       windowStart: this.windowStart,
       windowEnd: this.windowEnd,
-      pendingGateways: this.schedule.size,
-      pendingObservations: Array.from(this.schedule.values()).reduce(
-        (sum, times) => sum + times.length,
-        0,
-      ),
+      pendingGateways: new Set(this.schedule.map(({ fqdn }) => fqdn)).size,
+      pendingObservations: this.schedule.length,
     });
   }
 
@@ -194,50 +201,35 @@ export class ContinuousObservationScheduler {
   /**
    * Get the full schedule map.
    */
-  getSchedule(): Map<string, number[]> {
-    return this.schedule;
+  getSchedule(): ScheduledObservation[] {
+    return [...this.schedule];
   }
 
   /**
-   * Get gateways that have observations due at or before the current time.
+   * Get observation events that are due at or before the current time.
    *
-   * Returns gateways with at least one scheduled observation time that has passed.
-   * This handles catch-up after observer downtime.
+   * After the observation window closes, overdue events remain due so the
+   * observer can catch up before finalizing the epoch.
    */
-  getGatewaysDue(currentTime: number): string[] {
-    if (currentTime < this.windowStart || currentTime > this.windowEnd) {
+  getObservationsDue(currentTime: number): ScheduledObservation[] {
+    if (currentTime < this.windowStart) {
       return [];
     }
 
-    const due: string[] = [];
-    for (const [fqdn, times] of this.schedule) {
-      // Find any scheduled time that has passed
-      const overdueTime = times.find((t) => t <= currentTime);
-      if (overdueTime !== undefined) {
-        due.push(fqdn);
-      }
-    }
-    return due;
+    return this.schedule.filter(
+      (observation) => observation.scheduledAt <= currentTime,
+    );
   }
 
   /**
-   * Mark an observation as complete for a gateway.
-   *
-   * Removes the earliest due observation time from the schedule.
+   * Mark an observation event as complete.
    */
-  markObservationComplete(fqdn: string, completedAt: number): void {
-    const times = this.schedule.get(fqdn);
-    if (times) {
-      // Remove the first time that's at or before completedAt
-      const idx = times.findIndex((t) => t <= completedAt);
-      if (idx !== -1) {
-        times.splice(idx, 1);
-      }
-
-      // If no more observations for this gateway, remove from schedule
-      if (times.length === 0) {
-        this.schedule.delete(fqdn);
-      }
+  markObservationComplete(observationId: string): void {
+    const index = this.schedule.findIndex(
+      (observation) => observation.id === observationId,
+    );
+    if (index !== -1) {
+      this.schedule.splice(index, 1);
     }
   }
 
@@ -259,16 +251,13 @@ export class ContinuousObservationScheduler {
    * Get the number of pending observations across all gateways.
    */
   getPendingObservationCount(): number {
-    return Array.from(this.schedule.values()).reduce(
-      (sum, times) => sum + times.length,
-      0,
-    );
+    return this.schedule.length;
   }
 
   /**
    * Get the number of gateways with pending observations.
    */
   getPendingGatewayCount(): number {
-    return this.schedule.size;
+    return new Set(this.schedule.map(({ fqdn }) => fqdn)).size;
   }
 }

--- a/src/continuous/continuous-observation-scheduler.ts
+++ b/src/continuous/continuous-observation-scheduler.ts
@@ -199,6 +199,13 @@ export class ContinuousObservationScheduler {
   }
 
   /**
+   * Get the hard deadline for submission after catch-up retries.
+   */
+  getSubmissionDeadline(): number {
+    return this.windowEnd + this.config.submissionBufferMs;
+  }
+
+  /**
    * Get the full schedule map.
    */
   getSchedule(): ScheduledObservation[] {

--- a/src/continuous/continuous-observer.test.ts
+++ b/src/continuous/continuous-observer.test.ts
@@ -208,7 +208,9 @@ describe('ContinuousObserver Integration', function () {
       // Should have 2 remaining observations for first gateway
       const remainingCount = newScheduler
         .getSchedule()
-        .filter((scheduledObservation) => scheduledObservation.fqdn === firstGateway).length;
+        .filter(
+          (scheduledObservation) => scheduledObservation.fqdn === firstGateway,
+        ).length;
       expect(remainingCount).to.equal(2);
     });
   });
@@ -366,7 +368,7 @@ describe('ContinuousObserver Integration', function () {
         saveReport: sinon
           .stub()
           .onFirstCall()
-          .rejects(new Error('sink unavailable'))
+          .rejects(new Error('sink unavailable')),
       };
       const stateStore = {
         load: sinon.stub().resolves(null),
@@ -616,7 +618,10 @@ describe('ContinuousObserver Integration', function () {
         assessOwnership: sinon
           .stub()
           .callsFake(async ({ host }: { host: string }) => {
-            if (host === 'gateway2.example.com' && gateway2FailuresRemaining > 0) {
+            if (
+              host === 'gateway2.example.com' &&
+              gateway2FailuresRemaining > 0
+            ) {
               gateway2FailuresRemaining -= 1;
               throw new Error('temporary failure');
             }

--- a/src/continuous/continuous-observer.test.ts
+++ b/src/continuous/continuous-observer.test.ts
@@ -128,7 +128,7 @@ describe('ContinuousObserver Integration', function () {
       expect(loadedState!.epochIndex).to.equal(1);
       expect(loadedState!.windowStart).to.equal(windowStart);
       expect(loadedState!.windowEnd).to.equal(windowEnd);
-      expect(loadedState!.pendingObservations.size).to.equal(schedule.size);
+      expect(loadedState!.pendingObservations).to.deep.equal(schedule);
       expect(loadedState!.gatewayObservations.size).to.equal(3);
       expect(loadedState!.offsetAssessmentGateways.has('gateway1.example.com'))
         .to.be.true;
@@ -145,7 +145,7 @@ describe('ContinuousObserver Integration', function () {
       // Verify scheduler state matches
       expect(restoredScheduler.getWindowStart()).to.equal(windowStart);
       expect(restoredScheduler.getWindowEnd()).to.equal(windowEnd);
-      expect(restoredScheduler.getSchedule().size).to.equal(schedule.size);
+      expect(restoredScheduler.getSchedule()).to.deep.equal(schedule);
     });
 
     it('should track observation completion through save/restore cycle', async function () {
@@ -163,14 +163,18 @@ describe('ContinuousObserver Integration', function () {
           epochStartHeight,
         });
 
-      // Get initial count for first gateway
       const firstGateway = gateways[0].fqdn;
-      const initialCount = schedule.get(firstGateway)?.length ?? 0;
+      const initialCount = schedule.filter(
+        (observation) => observation.fqdn === firstGateway,
+      ).length;
       expect(initialCount).to.equal(3);
 
       // Mark one observation complete
-      const midWindowTime = windowStart + (windowEnd - windowStart) / 2;
-      scheduler.markObservationComplete(firstGateway, midWindowTime);
+      const observation = schedule.find(
+        (scheduledObservation) => scheduledObservation.fqdn === firstGateway,
+      );
+      expect(observation).to.not.be.undefined;
+      scheduler.markObservationComplete(observation!.id);
 
       // Save state
       const state: ObservationState = {
@@ -200,8 +204,9 @@ describe('ContinuousObserver Integration', function () {
       newScheduler.restoreFromState(loadedState!);
 
       // Should have 2 remaining observations for first gateway
-      const remainingCount =
-        newScheduler.getSchedule().get(firstGateway)?.length ?? 0;
+      const remainingCount = newScheduler
+        .getSchedule()
+        .filter((scheduledObservation) => scheduledObservation.fqdn === firstGateway).length;
       expect(remainingCount).to.equal(2);
     });
   });
@@ -293,7 +298,7 @@ describe('ContinuousObserver Integration', function () {
         epochStartHeight,
         windowStart: Date.now() + windowStartOffsetMs,
         windowEnd: Date.now() + windowEndOffsetMs,
-        pendingObservations: new Map(),
+        pendingObservations: [],
         gatewayObservations: new Map(
           gateways.map((g) => [
             g.fqdn,
@@ -393,6 +398,259 @@ describe('ContinuousObserver Integration', function () {
       expect(stateStore.save.calledWithExactly(state)).to.be.true;
       expect(stateStore.clear.calledOnce).to.be.true;
       expect((observer as any).state.epochIndex).to.equal(2);
+    });
+  });
+
+  describe('Overdue Observation Catch-up', function () {
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({
+        now: new Date('2026-01-01T00:00:00.000Z'),
+        shouldAdvanceTime: false,
+      });
+    });
+
+    afterEach(function () {
+      clock.restore();
+      sinon.restore();
+    });
+
+    function createObserverForCatchUp({
+      stateStore,
+      reportSink,
+      epochIndex = 1,
+    }: {
+      stateStore: {
+        load: sinon.SinonStub;
+        save: sinon.SinonStub;
+        clear: sinon.SinonStub;
+      };
+      reportSink: { saveReport: sinon.SinonStub };
+      epochIndex?: number;
+    }): ContinuousObserver {
+      return new ContinuousObserver({
+        observerAddress: 'observer-wallet',
+        referenceGateway: {
+          getArnsResolution: sinon.stub().rejects(new Error('unused')),
+          checkChunkAvailability: sinon.stub().rejects(new Error('unused')),
+          getChunkMetadata: sinon.stub().rejects(new Error('unused')),
+        },
+        epochSource: {
+          getEpochIndex: sinon.stub().resolves(epochIndex),
+          getEpochStartTimestamp: sinon.stub().resolves(epochStartTimestamp),
+          getEpochEndTimestamp: sinon.stub().resolves(epochEndTimestamp),
+          getEpochStartHeight: sinon.stub().resolves(epochStartHeight),
+          getEpochSettings: sinon.stub().resolves({
+            epochZeroStartTimestamp: 0,
+            durationMs: epochEndTimestamp - epochStartTimestamp,
+          }),
+        },
+        hostsSource: {
+          getHosts: sinon.stub().resolves(gateways),
+        },
+        prescribedNamesSource: {
+          getNames: sinon.stub().resolves([]),
+        },
+        chosenNamesSource: {
+          getNames: sinon.stub().resolves([]),
+        },
+        entropySource,
+        stateStore,
+        reportSink,
+        nodeReleaseVersion: 'test-release',
+        nameAssessmentConcurrency: 1,
+        config: {
+          cycleIntervalMs: 1000,
+          observationsPerGateway: 3,
+          majorityThreshold: 2,
+          gatewayAssessmentConcurrency: 2,
+        },
+        log: testLog,
+      });
+    }
+
+    function restoreState(
+      observer: ContinuousObserver,
+      state: ObservationState,
+    ): void {
+      (observer as any).state = state;
+      (observer as any).scheduler.restoreFromState(state);
+    }
+
+    it('drains multiple overdue observations for the same gateway in one cycle', async function () {
+      const stateStore = {
+        load: sinon.stub().resolves(null),
+        save: sinon.stub().resolves(),
+        clear: sinon.stub().resolves(),
+      };
+      const reportSink = {
+        saveReport: sinon.stub().resolves({ report: {} as any }),
+      };
+      const observer = createObserverForCatchUp({
+        stateStore,
+        reportSink,
+      });
+      const state: ObservationState = {
+        epochIndex: 1,
+        epochStartTimestamp,
+        epochEndTimestamp,
+        epochStartHeight,
+        windowStart: Date.now() - 120_000,
+        windowEnd: Date.now() - 1_000,
+        pendingObservations: [
+          {
+            id: 'gateway1.example.com:0',
+            fqdn: 'gateway1.example.com',
+            scheduledAt: Date.now() - 10_000,
+          },
+          {
+            id: 'gateway1.example.com:1',
+            fqdn: 'gateway1.example.com',
+            scheduledAt: Date.now() - 5_000,
+          },
+        ],
+        gatewayObservations: new Map([
+          [
+            'gateway1.example.com',
+            {
+              fqdn: 'gateway1.example.com',
+              wallet: 'wallet1',
+              observations: [],
+            },
+          ],
+        ]),
+        gatewayWallets: new Map([['gateway1.example.com', ['wallet1']]]),
+        offsetAssessmentGateways: new Set(),
+        lastCycleTimestamp: Date.now(),
+        reportSubmitted: false,
+      };
+      const assessor = {
+        assessOwnership: sinon.stub().resolves({
+          expectedWallets: ['wallet1'],
+          observedWallet: 'wallet1',
+          pass: true,
+        }),
+        assessGatewayArns: sinon.stub().resolves({
+          prescribedNames: {},
+          chosenNames: {},
+          pass: true,
+        }),
+        clearEpochState: sinon.stub(),
+      };
+
+      restoreState(observer, state);
+      (observer as any).assessor = assessor;
+
+      await (observer as any).runObservationCycle();
+
+      expect(assessor.assessOwnership.callCount).to.equal(2);
+      expect(
+        state.gatewayObservations.get('gateway1.example.com')!.observations,
+      ).to.have.length(2);
+      expect(state.pendingObservations).to.be.empty;
+      expect(state.reportSubmitted).to.be.true;
+      expect(reportSink.saveReport.calledOnce).to.be.true;
+    });
+
+    it('retries overdue observations after window close before submitting', async function () {
+      const stateStore = {
+        load: sinon.stub().resolves(null),
+        save: sinon.stub().resolves(),
+        clear: sinon.stub().resolves(),
+      };
+      const reportSink = {
+        saveReport: sinon.stub().resolves({ report: {} as any }),
+      };
+      const observer = createObserverForCatchUp({
+        stateStore,
+        reportSink,
+      });
+      const state: ObservationState = {
+        epochIndex: 1,
+        epochStartTimestamp,
+        epochEndTimestamp,
+        epochStartHeight,
+        windowStart: Date.now() - 120_000,
+        windowEnd: Date.now() - 1_000,
+        pendingObservations: [
+          {
+            id: 'gateway1.example.com:0',
+            fqdn: 'gateway1.example.com',
+            scheduledAt: Date.now() - 10_000,
+          },
+          {
+            id: 'gateway2.example.com:0',
+            fqdn: 'gateway2.example.com',
+            scheduledAt: Date.now() - 5_000,
+          },
+        ],
+        gatewayObservations: new Map([
+          [
+            'gateway1.example.com',
+            {
+              fqdn: 'gateway1.example.com',
+              wallet: 'wallet1',
+              observations: [],
+            },
+          ],
+          [
+            'gateway2.example.com',
+            {
+              fqdn: 'gateway2.example.com',
+              wallet: 'wallet2',
+              observations: [],
+            },
+          ],
+        ]),
+        gatewayWallets: new Map([
+          ['gateway1.example.com', ['wallet1']],
+          ['gateway2.example.com', ['wallet2']],
+        ]),
+        offsetAssessmentGateways: new Set(),
+        lastCycleTimestamp: Date.now(),
+        reportSubmitted: false,
+      };
+      let gateway2FailuresRemaining = 1;
+      const assessor = {
+        assessOwnership: sinon
+          .stub()
+          .callsFake(async ({ host }: { host: string }) => {
+            if (host === 'gateway2.example.com' && gateway2FailuresRemaining > 0) {
+              gateway2FailuresRemaining -= 1;
+              throw new Error('temporary failure');
+            }
+
+            return {
+              expectedWallets:
+                host === 'gateway1.example.com' ? ['wallet1'] : ['wallet2'],
+              observedWallet:
+                host === 'gateway1.example.com' ? 'wallet1' : 'wallet2',
+              pass: true,
+            };
+          }),
+        assessGatewayArns: sinon.stub().resolves({
+          prescribedNames: {},
+          chosenNames: {},
+          pass: true,
+        }),
+        clearEpochState: sinon.stub(),
+      };
+
+      restoreState(observer, state);
+      (observer as any).assessor = assessor;
+
+      await (observer as any).runObservationCycle();
+
+      expect(state.reportSubmitted).to.be.false;
+      expect(state.pendingObservations).to.have.length(1);
+      expect(reportSink.saveReport.called).to.be.false;
+
+      await (observer as any).runObservationCycle();
+
+      expect(state.pendingObservations).to.be.empty;
+      expect(state.reportSubmitted).to.be.true;
+      expect(reportSink.saveReport.calledOnce).to.be.true;
     });
   });
 

--- a/src/continuous/continuous-observer.test.ts
+++ b/src/continuous/continuous-observer.test.ts
@@ -17,8 +17,10 @@
  */
 
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 import { createLogger, transports } from 'winston';
 
+import { ContinuousObserver } from './continuous-observer.js';
 import { EntropySource, GatewayHost } from '../types.js';
 import { ContinuousObservationScheduler } from './continuous-observation-scheduler.js';
 import { FsObservationStateStore } from './observation-state-store.js';
@@ -201,6 +203,196 @@ describe('ContinuousObserver Integration', function () {
       const remainingCount =
         newScheduler.getSchedule().get(firstGateway)?.length ?? 0;
       expect(remainingCount).to.equal(2);
+    });
+  });
+
+  describe('Report Submission State', function () {
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({
+        now: new Date('2026-01-01T00:00:00.000Z'),
+        shouldAdvanceTime: false,
+      });
+    });
+
+    afterEach(function () {
+      clock.restore();
+      sinon.restore();
+    });
+
+    function createObserver({
+      epochIndex,
+      reportSink,
+      stateStore,
+    }: {
+      epochIndex: number;
+      reportSink: { saveReport: sinon.SinonStub };
+      stateStore: {
+        load: sinon.SinonStub;
+        save: sinon.SinonStub;
+        clear: sinon.SinonStub;
+      };
+    }): ContinuousObserver {
+      return new ContinuousObserver({
+        observerAddress: 'observer-wallet',
+        referenceGateway: {
+          getArnsResolution: sinon.stub().rejects(new Error('unused')),
+          checkChunkAvailability: sinon.stub().rejects(new Error('unused')),
+          getChunkMetadata: sinon.stub().rejects(new Error('unused')),
+        },
+        epochSource: {
+          getEpochIndex: sinon.stub().resolves(epochIndex),
+          getEpochStartTimestamp: sinon.stub().resolves(epochStartTimestamp),
+          getEpochEndTimestamp: sinon.stub().resolves(epochEndTimestamp),
+          getEpochStartHeight: sinon.stub().resolves(epochStartHeight),
+          getEpochSettings: sinon.stub().resolves({
+            epochZeroStartTimestamp: 0,
+            durationMs: epochEndTimestamp - epochStartTimestamp,
+          }),
+        },
+        hostsSource: {
+          getHosts: sinon.stub().resolves(gateways),
+        },
+        prescribedNamesSource: {
+          getNames: sinon.stub().resolves([]),
+        },
+        chosenNamesSource: {
+          getNames: sinon.stub().resolves([]),
+        },
+        entropySource,
+        stateStore,
+        reportSink,
+        nodeReleaseVersion: 'test-release',
+        nameAssessmentConcurrency: 1,
+        config: {
+          cycleIntervalMs: 1000,
+          observationsPerGateway: 3,
+          majorityThreshold: 2,
+          gatewayAssessmentConcurrency: 1,
+        },
+        log: testLog,
+      });
+    }
+
+    function createState({
+      reportSubmitted = false,
+      epoch = 1,
+      windowStartOffsetMs = -60_000,
+      windowEndOffsetMs = -1_000,
+    }: {
+      reportSubmitted?: boolean;
+      epoch?: number;
+      windowStartOffsetMs?: number;
+      windowEndOffsetMs?: number;
+    }): ObservationState {
+      return {
+        epochIndex: epoch,
+        epochStartTimestamp,
+        epochEndTimestamp,
+        epochStartHeight,
+        windowStart: Date.now() + windowStartOffsetMs,
+        windowEnd: Date.now() + windowEndOffsetMs,
+        pendingObservations: new Map(),
+        gatewayObservations: new Map(
+          gateways.map((g) => [
+            g.fqdn,
+            {
+              fqdn: g.fqdn,
+              wallet: g.wallet,
+              observations: [],
+            },
+          ]),
+        ),
+        gatewayWallets: new Map(gateways.map((g) => [g.fqdn, [g.wallet]])),
+        offsetAssessmentGateways: new Set(),
+        lastCycleTimestamp: Date.now(),
+        reportSubmitted,
+      };
+    }
+
+    function restoreObserverState(
+      observer: ContinuousObserver,
+      state: ObservationState,
+    ): void {
+      (observer as any).state = state;
+      (observer as any).scheduler.restoreFromState(state);
+    }
+
+    it('keeps reportSubmitted false when submission fails at window close', async function () {
+      const reportSink = {
+        saveReport: sinon
+          .stub()
+          .onFirstCall()
+          .rejects(new Error('sink unavailable'))
+          .onSecondCall()
+          .resolves({ report: {} as any }),
+      };
+      const stateStore = {
+        load: sinon.stub().resolves(null),
+        save: sinon.stub().resolves(),
+        clear: sinon.stub().resolves(),
+      };
+      const observer = createObserver({
+        epochIndex: 1,
+        reportSink,
+        stateStore,
+      });
+      const state = createState({});
+
+      restoreObserverState(observer, state);
+
+      await (observer as any).runObservationCycle();
+
+      expect(state.reportSubmitted).to.be.false;
+      expect(stateStore.save.called).to.be.false;
+
+      await (observer as any).runObservationCycle();
+
+      expect(state.reportSubmitted).to.be.true;
+      expect(stateStore.save.calledOnceWithExactly(state)).to.be.true;
+    });
+
+    it('preserves state on epoch rollover until submission succeeds', async function () {
+      const reportSink = {
+        saveReport: sinon
+          .stub()
+          .onFirstCall()
+          .rejects(new Error('sink unavailable'))
+          .onSecondCall()
+          .resolves({ report: {} as any }),
+      };
+      const stateStore = {
+        load: sinon.stub().resolves(null),
+        save: sinon.stub().resolves(),
+        clear: sinon.stub().resolves(),
+      };
+      const observer = createObserver({
+        epochIndex: 2,
+        reportSink,
+        stateStore,
+      });
+      const state = createState({
+        epoch: 1,
+        windowStartOffsetMs: -120_000,
+        windowEndOffsetMs: 120_000,
+      });
+
+      restoreObserverState(observer, state);
+
+      await (observer as any).runObservationCycle();
+
+      expect((observer as any).state).to.equal(state);
+      expect(state.reportSubmitted).to.be.false;
+      expect(stateStore.clear.called).to.be.false;
+      expect(stateStore.save.called).to.be.false;
+
+      await (observer as any).runObservationCycle();
+
+      expect(state.reportSubmitted).to.be.true;
+      expect(stateStore.save.calledWithExactly(state)).to.be.true;
+      expect(stateStore.clear.calledOnce).to.be.true;
+      expect((observer as any).state.epochIndex).to.equal(2);
     });
   });
 

--- a/src/continuous/continuous-observer.test.ts
+++ b/src/continuous/continuous-observer.test.ts
@@ -778,12 +778,78 @@ describe('ContinuousObserver Integration', function () {
 
       const firstCallCount = assessor.assessOwnership.callCount;
       expect(state.submissionDeadlineExceeded).to.be.true;
-      expect(firstCallCount).to.equal(1);
+      expect(firstCallCount).to.equal(0);
       expect(reportSink.saveReport.called).to.be.false;
 
       await (observer as any).runObservationCycle();
 
       expect(assessor.assessOwnership.callCount).to.equal(firstCallCount);
+      expect(reportSink.saveReport.called).to.be.false;
+    });
+
+    it('does not run restored overdue observations after restart past the submission deadline', async function () {
+      const deadlinePassedWindowEnd = Date.now() - 5_000_000;
+      const state: ObservationState = {
+        epochIndex: 1,
+        epochStartTimestamp,
+        epochEndTimestamp,
+        epochStartHeight,
+        windowStart: deadlinePassedWindowEnd - 60_000,
+        windowEnd: deadlinePassedWindowEnd,
+        pendingObservations: [
+          {
+            id: 'gateway1.example.com:0',
+            fqdn: 'gateway1.example.com',
+            scheduledAt: deadlinePassedWindowEnd - 120_000,
+          },
+        ],
+        gatewayObservations: new Map([
+          [
+            'gateway1.example.com',
+            {
+              fqdn: 'gateway1.example.com',
+              wallet: 'wallet1',
+              observations: [],
+            },
+          ],
+        ]),
+        gatewayWallets: new Map([['gateway1.example.com', ['wallet1']]]),
+        offsetAssessmentGateways: new Set(),
+        lastCycleTimestamp: Date.now(),
+        reportSubmitted: false,
+        submissionDeadlineExceeded: false,
+      };
+      const stateStore = {
+        load: sinon.stub().resolves(state),
+        save: sinon.stub().resolves(),
+        clear: sinon.stub().resolves(),
+      };
+      const reportSink = {
+        saveReport: sinon.stub().resolves({ report: {} as any }),
+      };
+      const observer = createObserverForCatchUp({
+        stateStore,
+        reportSink,
+      });
+      const assessor = {
+        assessOwnership: sinon.stub().rejects(new Error('should not run')),
+        assessGatewayArns: sinon.stub().resolves({
+          prescribedNames: {},
+          chosenNames: {},
+          pass: true,
+        }),
+        initializeForEpoch: sinon.stub(),
+        clearEpochState: sinon.stub(),
+      };
+      (observer as any).assessor = assessor;
+
+      await (observer as any).initializeOrRestore();
+      await (observer as any).runObservationCycle();
+
+      expect(assessor.assessOwnership.called).to.be.false;
+      expect(state.submissionDeadlineExceeded).to.be.true;
+      expect(state.pendingObservations).to.be.empty;
+      expect(stateStore.save.calledOnceWithExactly(state)).to.be.true;
       expect(reportSink.saveReport.called).to.be.false;
     });
   });

--- a/src/continuous/continuous-observer.test.ts
+++ b/src/continuous/continuous-observer.test.ts
@@ -20,6 +20,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { createLogger, transports } from 'winston';
 
+import * as metrics from '../metrics.js';
 import { ContinuousObserver } from './continuous-observer.js';
 import { EntropySource, GatewayHost } from '../types.js';
 import { ContinuousObservationScheduler } from './continuous-observation-scheduler.js';
@@ -491,6 +492,8 @@ describe('ContinuousObserver Integration', function () {
         stateStore,
         reportSink,
       });
+      (observer as any).prescribedNames = ['prescribed1', 'prescribed2'];
+      (observer as any).chosenNames = ['chosen1'];
       const state: ObservationState = {
         epochIndex: 1,
         epochStartTimestamp,
@@ -566,6 +569,8 @@ describe('ContinuousObserver Integration', function () {
         stateStore,
         reportSink,
       });
+      (observer as any).prescribedNames = ['prescribed1', 'prescribed2'];
+      (observer as any).chosenNames = ['chosen1'];
       const state: ObservationState = {
         epochIndex: 1,
         epochStartTimestamp,
@@ -666,6 +671,8 @@ describe('ContinuousObserver Integration', function () {
         stateStore,
         reportSink,
       });
+      (observer as any).prescribedNames = ['prescribed1', 'prescribed2'];
+      (observer as any).chosenNames = ['chosen1'];
       const state: ObservationState = {
         epochIndex: 1,
         epochStartTimestamp,
@@ -717,6 +724,94 @@ describe('ContinuousObserver Integration', function () {
         state.gatewayObservations.get('gateway1.example.com')!.observations[0]
           .ownershipAssessment.failureReason,
       ).to.equal('Observation deadline exceeded after repeated errors');
+      expect(
+        Object.keys(
+          state.gatewayObservations.get('gateway1.example.com')!.observations[0]
+            .arnsAssessments.prescribedNames,
+        ),
+      ).to.deep.equal(['prescribed1', 'prescribed2']);
+      expect(
+        Object.keys(
+          state.gatewayObservations.get('gateway1.example.com')!.observations[0]
+            .arnsAssessments.chosenNames,
+        ),
+      ).to.deep.equal(['chosen1']);
+    });
+
+    it('records forced deadline misses separately from execution errors', async function () {
+      const stateStore = {
+        load: sinon.stub().resolves(null),
+        save: sinon.stub().resolves(),
+        clear: sinon.stub().resolves(),
+      };
+      const reportSink = {
+        saveReport: sinon.stub().resolves({ report: {} as any }),
+      };
+      const observer = createObserverForCatchUp({
+        stateStore,
+        reportSink,
+      });
+      const state: ObservationState = {
+        epochIndex: 1,
+        epochStartTimestamp,
+        epochEndTimestamp,
+        epochStartHeight,
+        windowStart: Date.now() - 5_000_000,
+        windowEnd: Date.now() - 5_000_000,
+        pendingObservations: [
+          {
+            id: 'gateway1.example.com:0',
+            fqdn: 'gateway1.example.com',
+            scheduledAt: Date.now() - 5_100_000,
+          },
+        ],
+        gatewayObservations: new Map([
+          [
+            'gateway1.example.com',
+            {
+              fqdn: 'gateway1.example.com',
+              wallet: 'wallet1',
+              observations: [],
+            },
+          ],
+        ]),
+        gatewayWallets: new Map([['gateway1.example.com', ['wallet1']]]),
+        offsetAssessmentGateways: new Set(),
+        lastCycleTimestamp: Date.now(),
+        reportSubmitted: false,
+      };
+      const assessor = {
+        assessOwnership: sinon.stub().rejects(new Error('persistent failure')),
+        assessGatewayArns: sinon.stub().resolves({
+          prescribedNames: {},
+          chosenNames: {},
+          pass: true,
+        }),
+        clearEpochState: sinon.stub(),
+      };
+      const counterStub = sinon.stub(metrics.gatewayObservationsCounter, 'inc');
+
+      restoreState(observer, state);
+      (observer as any).assessor = assessor;
+
+      try {
+        await (observer as any).runObservationCycle();
+      } finally {
+        counterStub.restore();
+      }
+
+      expect(
+        counterStub.calledWithMatch(sinon.match({
+          fqdn: 'gateway1.example.com',
+          status: 'error',
+        })),
+      ).to.be.true;
+      expect(
+        counterStub.calledWithMatch(sinon.match({
+          fqdn: 'gateway1.example.com',
+          status: 'deadline',
+        })),
+      ).to.be.true;
     });
   });
 

--- a/src/continuous/continuous-observer.test.ts
+++ b/src/continuous/continuous-observer.test.ts
@@ -395,7 +395,7 @@ describe('ContinuousObserver Integration', function () {
       await (observer as any).runObservationCycle();
 
       expect(state.reportSubmitted).to.be.true;
-      expect(stateStore.save.calledWithExactly(state)).to.be.true;
+      expect(stateStore.save.calledOnce).to.be.true;
       expect(stateStore.clear.calledOnce).to.be.true;
       expect((observer as any).state.epochIndex).to.equal(2);
     });
@@ -651,6 +651,72 @@ describe('ContinuousObserver Integration', function () {
       expect(state.pendingObservations).to.be.empty;
       expect(state.reportSubmitted).to.be.true;
       expect(reportSink.saveReport.calledOnce).to.be.true;
+    });
+
+    it('forces missed observations and submits when the submission deadline is reached', async function () {
+      const stateStore = {
+        load: sinon.stub().resolves(null),
+        save: sinon.stub().resolves(),
+        clear: sinon.stub().resolves(),
+      };
+      const reportSink = {
+        saveReport: sinon.stub().resolves({ report: {} as any }),
+      };
+      const observer = createObserverForCatchUp({
+        stateStore,
+        reportSink,
+      });
+      const state: ObservationState = {
+        epochIndex: 1,
+        epochStartTimestamp,
+        epochEndTimestamp,
+        epochStartHeight,
+        windowStart: Date.now() - 5_000_000,
+        windowEnd: Date.now() - 5_000_000,
+        pendingObservations: [
+          {
+            id: 'gateway1.example.com:0',
+            fqdn: 'gateway1.example.com',
+            scheduledAt: Date.now() - 5_100_000,
+          },
+        ],
+        gatewayObservations: new Map([
+          [
+            'gateway1.example.com',
+            {
+              fqdn: 'gateway1.example.com',
+              wallet: 'wallet1',
+              observations: [],
+            },
+          ],
+        ]),
+        gatewayWallets: new Map([['gateway1.example.com', ['wallet1']]]),
+        offsetAssessmentGateways: new Set(),
+        lastCycleTimestamp: Date.now(),
+        reportSubmitted: false,
+      };
+      const assessor = {
+        assessOwnership: sinon.stub().rejects(new Error('persistent failure')),
+        assessGatewayArns: sinon.stub().resolves({
+          prescribedNames: {},
+          chosenNames: {},
+          pass: true,
+        }),
+        clearEpochState: sinon.stub(),
+      };
+
+      restoreState(observer, state);
+      (observer as any).assessor = assessor;
+
+      await (observer as any).runObservationCycle();
+
+      expect(state.pendingObservations).to.be.empty;
+      expect(state.reportSubmitted).to.be.true;
+      expect(reportSink.saveReport.calledOnce).to.be.true;
+      expect(
+        state.gatewayObservations.get('gateway1.example.com')!.observations[0]
+          .ownershipAssessment.failureReason,
+      ).to.equal('Observation deadline exceeded after repeated errors');
     });
   });
 

--- a/src/continuous/continuous-observer.test.ts
+++ b/src/continuous/continuous-observer.test.ts
@@ -20,7 +20,6 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { createLogger, transports } from 'winston';
 
-import * as metrics from '../metrics.js';
 import { ContinuousObserver } from './continuous-observer.js';
 import { EntropySource, GatewayHost } from '../types.js';
 import { ContinuousObservationScheduler } from './continuous-observation-scheduler.js';
@@ -113,6 +112,7 @@ describe('ContinuousObserver Integration', function () {
         offsetAssessmentGateways: new Set(['gateway1.example.com']),
         lastCycleTimestamp: Date.now(),
         reportSubmitted: false,
+        submissionDeadlineExceeded: false,
       };
 
       // Persist state
@@ -191,6 +191,7 @@ describe('ContinuousObserver Integration', function () {
         offsetAssessmentGateways: new Set(),
         lastCycleTimestamp: Date.now(),
         reportSubmitted: false,
+        submissionDeadlineExceeded: false,
       };
 
       await stateStore.save(state);
@@ -314,6 +315,7 @@ describe('ContinuousObserver Integration', function () {
         offsetAssessmentGateways: new Set(),
         lastCycleTimestamp: Date.now(),
         reportSubmitted,
+        submissionDeadlineExceeded: false,
       };
     }
 
@@ -359,14 +361,12 @@ describe('ContinuousObserver Integration', function () {
       expect(stateStore.save.calledOnceWithExactly(state)).to.be.true;
     });
 
-    it('preserves state on epoch rollover until submission succeeds', async function () {
+    it('discards stale unsubmitted epoch state on rollover', async function () {
       const reportSink = {
         saveReport: sinon
           .stub()
           .onFirstCall()
           .rejects(new Error('sink unavailable'))
-          .onSecondCall()
-          .resolves({ report: {} as any }),
       };
       const stateStore = {
         load: sinon.stub().resolves(null),
@@ -388,16 +388,9 @@ describe('ContinuousObserver Integration', function () {
 
       await (observer as any).runObservationCycle();
 
-      expect((observer as any).state).to.equal(state);
-      expect(state.reportSubmitted).to.be.false;
-      expect(stateStore.clear.called).to.be.false;
-      expect(stateStore.save.called).to.be.false;
-
-      await (observer as any).runObservationCycle();
-
-      expect(state.reportSubmitted).to.be.true;
-      expect(stateStore.save.calledOnce).to.be.true;
+      expect(reportSink.saveReport.called).to.be.false;
       expect(stateStore.clear.calledOnce).to.be.true;
+      expect(stateStore.save.calledOnce).to.be.true;
       expect((observer as any).state.epochIndex).to.equal(2);
     });
   });
@@ -527,6 +520,7 @@ describe('ContinuousObserver Integration', function () {
         offsetAssessmentGateways: new Set(),
         lastCycleTimestamp: Date.now(),
         reportSubmitted: false,
+        submissionDeadlineExceeded: false,
       };
       const assessor = {
         assessOwnership: sinon.stub().resolves({
@@ -615,6 +609,7 @@ describe('ContinuousObserver Integration', function () {
         offsetAssessmentGateways: new Set(),
         lastCycleTimestamp: Date.now(),
         reportSubmitted: false,
+        submissionDeadlineExceeded: false,
       };
       let gateway2FailuresRemaining = 1;
       const assessor = {
@@ -658,7 +653,71 @@ describe('ContinuousObserver Integration', function () {
       expect(reportSink.saveReport.calledOnce).to.be.true;
     });
 
-    it('forces missed observations and submits when the submission deadline is reached', async function () {
+    it('closes the epoch without submitting once the submission deadline is reached', async function () {
+      const stateStore = {
+        load: sinon.stub().resolves(null),
+        save: sinon.stub().resolves(),
+        clear: sinon.stub().resolves(),
+      };
+      const reportSink = {
+        saveReport: sinon.stub().resolves({ report: {} as any }),
+      };
+      const observer = createObserverForCatchUp({
+        stateStore,
+        reportSink,
+      });
+      const state: ObservationState = {
+        epochIndex: 1,
+        epochStartTimestamp,
+        epochEndTimestamp,
+        epochStartHeight,
+        windowStart: Date.now() - 5_000_000,
+        windowEnd: Date.now() - 5_000_000,
+        pendingObservations: [
+          {
+            id: 'gateway1.example.com:0',
+            fqdn: 'gateway1.example.com',
+            scheduledAt: Date.now() - 5_100_000,
+          },
+        ],
+        gatewayObservations: new Map([
+          [
+            'gateway1.example.com',
+            {
+              fqdn: 'gateway1.example.com',
+              wallet: 'wallet1',
+              observations: [],
+            },
+          ],
+        ]),
+        gatewayWallets: new Map([['gateway1.example.com', ['wallet1']]]),
+        offsetAssessmentGateways: new Set(),
+        lastCycleTimestamp: Date.now(),
+        reportSubmitted: false,
+        submissionDeadlineExceeded: false,
+      };
+      const assessor = {
+        assessOwnership: sinon.stub().rejects(new Error('persistent failure')),
+        assessGatewayArns: sinon.stub().resolves({
+          prescribedNames: {},
+          chosenNames: {},
+          pass: true,
+        }),
+        clearEpochState: sinon.stub(),
+      };
+
+      restoreState(observer, state);
+      (observer as any).assessor = assessor;
+
+      await (observer as any).runObservationCycle();
+
+      expect(state.pendingObservations).to.be.empty;
+      expect(state.reportSubmitted).to.be.false;
+      expect(state.submissionDeadlineExceeded).to.be.true;
+      expect(reportSink.saveReport.called).to.be.false;
+    });
+
+    it('does not keep retrying after the submission deadline is reached', async function () {
       const stateStore = {
         load: sinon.stub().resolves(null),
         save: sinon.stub().resolves(),
@@ -701,6 +760,7 @@ describe('ContinuousObserver Integration', function () {
         offsetAssessmentGateways: new Set(),
         lastCycleTimestamp: Date.now(),
         reportSubmitted: false,
+        submissionDeadlineExceeded: false,
       };
       const assessor = {
         assessOwnership: sinon.stub().rejects(new Error('persistent failure')),
@@ -711,107 +771,20 @@ describe('ContinuousObserver Integration', function () {
         }),
         clearEpochState: sinon.stub(),
       };
-
       restoreState(observer, state);
       (observer as any).assessor = assessor;
 
       await (observer as any).runObservationCycle();
 
-      expect(state.pendingObservations).to.be.empty;
-      expect(state.reportSubmitted).to.be.true;
-      expect(reportSink.saveReport.calledOnce).to.be.true;
-      expect(
-        state.gatewayObservations.get('gateway1.example.com')!.observations[0]
-          .ownershipAssessment.failureReason,
-      ).to.equal('Observation deadline exceeded after repeated errors');
-      expect(
-        Object.keys(
-          state.gatewayObservations.get('gateway1.example.com')!.observations[0]
-            .arnsAssessments.prescribedNames,
-        ),
-      ).to.deep.equal(['prescribed1', 'prescribed2']);
-      expect(
-        Object.keys(
-          state.gatewayObservations.get('gateway1.example.com')!.observations[0]
-            .arnsAssessments.chosenNames,
-        ),
-      ).to.deep.equal(['chosen1']);
-    });
+      const firstCallCount = assessor.assessOwnership.callCount;
+      expect(state.submissionDeadlineExceeded).to.be.true;
+      expect(firstCallCount).to.equal(1);
+      expect(reportSink.saveReport.called).to.be.false;
 
-    it('records forced deadline misses separately from execution errors', async function () {
-      const stateStore = {
-        load: sinon.stub().resolves(null),
-        save: sinon.stub().resolves(),
-        clear: sinon.stub().resolves(),
-      };
-      const reportSink = {
-        saveReport: sinon.stub().resolves({ report: {} as any }),
-      };
-      const observer = createObserverForCatchUp({
-        stateStore,
-        reportSink,
-      });
-      const state: ObservationState = {
-        epochIndex: 1,
-        epochStartTimestamp,
-        epochEndTimestamp,
-        epochStartHeight,
-        windowStart: Date.now() - 5_000_000,
-        windowEnd: Date.now() - 5_000_000,
-        pendingObservations: [
-          {
-            id: 'gateway1.example.com:0',
-            fqdn: 'gateway1.example.com',
-            scheduledAt: Date.now() - 5_100_000,
-          },
-        ],
-        gatewayObservations: new Map([
-          [
-            'gateway1.example.com',
-            {
-              fqdn: 'gateway1.example.com',
-              wallet: 'wallet1',
-              observations: [],
-            },
-          ],
-        ]),
-        gatewayWallets: new Map([['gateway1.example.com', ['wallet1']]]),
-        offsetAssessmentGateways: new Set(),
-        lastCycleTimestamp: Date.now(),
-        reportSubmitted: false,
-      };
-      const assessor = {
-        assessOwnership: sinon.stub().rejects(new Error('persistent failure')),
-        assessGatewayArns: sinon.stub().resolves({
-          prescribedNames: {},
-          chosenNames: {},
-          pass: true,
-        }),
-        clearEpochState: sinon.stub(),
-      };
-      const counterStub = sinon.stub(metrics.gatewayObservationsCounter, 'inc');
+      await (observer as any).runObservationCycle();
 
-      restoreState(observer, state);
-      (observer as any).assessor = assessor;
-
-      try {
-        await (observer as any).runObservationCycle();
-      } finally {
-        counterStub.restore();
-      }
-
-      expect(
-        counterStub.calledWithMatch(sinon.match({
-          fqdn: 'gateway1.example.com',
-          status: 'error',
-        })),
-      ).to.be.true;
-      expect(
-        counterStub.calledWithMatch(sinon.match({
-          fqdn: 'gateway1.example.com',
-          status: 'deadline',
-        })),
-      ).to.be.true;
+      expect(assessor.assessOwnership.callCount).to.equal(firstCallCount);
+      expect(reportSink.saveReport.called).to.be.false;
     });
   });
 

--- a/src/continuous/continuous-observer.ts
+++ b/src/continuous/continuous-observer.ts
@@ -38,6 +38,7 @@ import {
   ContinuousObserverConfig,
   GatewayObservationResult,
   ObservationState,
+  ScheduledObservation,
 } from './types.js';
 
 // Default configuration values
@@ -255,6 +256,8 @@ export class ContinuousObserver {
     }
 
     // Initialize state
+    const uniqueFqdns = [...new Set(gateways.map((gateway) => gateway.fqdn))];
+
     this.state = {
       epochIndex,
       epochStartTimestamp,
@@ -262,11 +265,15 @@ export class ContinuousObserver {
       epochStartHeight,
       windowStart,
       windowEnd,
-      pendingObservations: new Map(schedule),
+      pendingObservations: [...schedule],
       gatewayObservations: new Map(
-        gateways.map((g) => [
-          g.fqdn,
-          { fqdn: g.fqdn, wallet: g.wallet, observations: [] },
+        uniqueFqdns.map((fqdn) => [
+          fqdn,
+          {
+            fqdn,
+            wallet: gateways.find((gateway) => gateway.fqdn === fqdn)?.wallet ?? '',
+            observations: [],
+          },
         ]),
       ),
       gatewayWallets,
@@ -283,10 +290,10 @@ export class ContinuousObserver {
 
     this.log.info('Epoch initialized', {
       epochIndex,
-      gatewayCount: gateways.length,
+      gatewayCount: uniqueFqdns.length,
       windowStart: new Date(windowStart).toISOString(),
       windowEnd: new Date(windowEnd).toISOString(),
-      totalObservations: gateways.length * this.config.observationsPerGateway,
+      totalObservations: schedule.length,
     });
   }
 
@@ -370,18 +377,6 @@ export class ContinuousObserver {
       return;
     }
 
-    // Window complete? Finalize and wait
-    if (this.scheduler.isWindowComplete(now)) {
-      if (!this.state.reportSubmitted) {
-        const submitted = await this.finalizeAndSubmitReport();
-        if (submitted) {
-          this.state.reportSubmitted = true;
-          await this.stateStore.save(this.state);
-        }
-      }
-      return;
-    }
-
     // Not yet in window? Wait
     if (this.scheduler.isBeforeWindow(now)) {
       this.log.debug('Before observation window, waiting', {
@@ -392,63 +387,82 @@ export class ContinuousObserver {
     }
 
     // Get due gateways and observe with limited concurrency
-    const dueGateways = this.scheduler.getGatewaysDue(now);
-    if (dueGateways.length === 0) {
-      return;
+    const dueObservations = this.scheduler.getObservationsDue(now);
+    if (dueObservations.length > 0) {
+      const observationsByGateway = new Map<string, ScheduledObservation[]>();
+      for (const observation of dueObservations) {
+        const existing = observationsByGateway.get(observation.fqdn) ?? [];
+        existing.push(observation);
+        observationsByGateway.set(observation.fqdn, existing);
+      }
+
+      this.log.debug('Observing due gateway batches', {
+        observationCount: dueObservations.length,
+        gatewayCount: observationsByGateway.size,
+        gateways: [...observationsByGateway.keys()].slice(0, 5),
+      });
+
+      await pMap(
+        observationsByGateway.entries(),
+        async ([fqdn, observations]) => {
+          for (const observation of observations) {
+            try {
+              const result = await this.observeGateway({
+                fqdn,
+                scheduledAt: observation.scheduledAt,
+              });
+              const aggregate = this.state!.gatewayObservations.get(fqdn);
+              if (aggregate) {
+                aggregate.observations.push(result);
+              }
+              this.scheduler.markObservationComplete(observation.id);
+
+              metrics.gatewayObservationsCounter?.inc({
+                fqdn,
+                status: result.pass ? 'pass' : 'fail',
+              });
+            } catch (error: any) {
+              this.log.error('Error observing gateway', {
+                fqdn,
+                scheduledAt: observation.scheduledAt,
+                error: error.message,
+              });
+            }
+          }
+        },
+        { concurrency: this.config.gatewayAssessmentConcurrency },
+      );
+
+      this.state.lastCycleTimestamp = now;
+      this.state.pendingObservations = this.scheduler.getSchedule();
+
+      await this.stateStore.save(this.state);
     }
 
-    this.log.debug('Observing due gateways', {
-      count: dueGateways.length,
-      gateways: dueGateways.slice(0, 5),
-    });
-
-    await pMap(
-      dueGateways,
-      async (fqdn) => {
-        try {
-          const result = await this.observeGateway(fqdn);
-          const aggregate = this.state!.gatewayObservations.get(fqdn);
-          if (aggregate) {
-            aggregate.observations.push(result);
-          }
-          this.scheduler.markObservationComplete(fqdn, now);
-
-          // Update metrics
-          metrics.gatewayObservationsCounter?.inc({
-            fqdn,
-            status: result.pass ? 'pass' : 'fail',
-          });
-        } catch (error: any) {
-          this.log.error('Error observing gateway', {
-            fqdn,
-            error: error.message,
-          });
+    if (
+      this.scheduler.isWindowComplete(now) &&
+      this.scheduler.getPendingObservationCount() === 0
+    ) {
+      if (!this.state.reportSubmitted) {
+        const submitted = await this.finalizeAndSubmitReport();
+        if (submitted) {
+          this.state.reportSubmitted = true;
+          await this.stateStore.save(this.state);
         }
-      },
-      { concurrency: this.config.gatewayAssessmentConcurrency },
-    );
-
-    // Update state
-    this.state.lastCycleTimestamp = now;
-    this.state.pendingObservations = this.scheduler.getSchedule();
-
-    // Persist state after each cycle
-    await this.stateStore.save(this.state);
+      }
+    }
   }
 
   /**
    * Observe a single gateway.
    */
-  private async observeGateway(
-    fqdn: string,
-  ): Promise<GatewayObservationResult> {
-    const scheduledTime = this.scheduler.getSchedule().get(fqdn)?.[0];
-    if (scheduledTime === undefined) {
-      this.log.warn('No scheduled time found for gateway, using current time', {
-        fqdn,
-      });
-    }
-    const scheduledAt = scheduledTime ?? Date.now();
+  private async observeGateway({
+    fqdn,
+    scheduledAt,
+  }: {
+    fqdn: string;
+    scheduledAt: number;
+  }): Promise<GatewayObservationResult> {
     const observedAt = Date.now();
 
     const expectedWallets = this.state!.gatewayWallets.get(fqdn) ?? [];
@@ -616,7 +630,10 @@ export class ContinuousObserver {
     // Observer state: 0=waiting, 1=observing, 2=finalizing
     if (this.scheduler.isBeforeWindow(now)) {
       metrics.continuousObserverStateGauge.set(0);
-    } else if (this.scheduler.isWindowComplete(now)) {
+    } else if (
+      this.scheduler.isWindowComplete(now) &&
+      this.scheduler.getPendingObservationCount() === 0
+    ) {
       metrics.continuousObserverStateGauge.set(2);
     } else {
       metrics.continuousObserverStateGauge.set(1);

--- a/src/continuous/continuous-observer.ts
+++ b/src/continuous/continuous-observer.ts
@@ -351,9 +351,6 @@ export class ContinuousObserver {
 
     const now = Date.now();
 
-    // Update progress and state metrics
-    this.updateCycleMetrics(now);
-
     // Check for epoch transition
     const currentEpochIndex = await this.epochSource.getEpochIndex();
     if (currentEpochIndex !== this.state.epochIndex) {
@@ -382,12 +379,29 @@ export class ContinuousObserver {
 
     // Not yet in window? Wait
     if (this.scheduler.isBeforeWindow(now)) {
+      this.updateCycleMetrics(now);
       this.log.debug('Before observation window, waiting', {
         windowStart: new Date(this.scheduler.getWindowStart()).toISOString(),
         now: new Date(now).toISOString(),
       });
       return;
     }
+
+    if (
+      !this.state.submissionDeadlineExceeded &&
+      now >= this.scheduler.getSubmissionDeadline()
+    ) {
+      this.state.submissionDeadlineExceeded = true;
+      this.state.pendingObservations = [];
+      this.scheduler.clearSchedule();
+      await this.stateStore.save(this.state);
+      this.log.warn('Submission window closed for epoch', {
+        epochIndex: this.state.epochIndex,
+      });
+    }
+
+    // Update progress and state metrics after deadline transitions.
+    this.updateCycleMetrics(now);
 
     if (this.state.submissionDeadlineExceeded) {
       return;
@@ -448,17 +462,6 @@ export class ContinuousObserver {
       this.state.pendingObservations = this.scheduler.getSchedule();
 
       await this.stateStore.save(this.state);
-    }
-
-    if (now >= this.scheduler.getSubmissionDeadline()) {
-      this.state.submissionDeadlineExceeded = true;
-      this.state.pendingObservations = [];
-      this.scheduler.clearSchedule();
-      await this.stateStore.save(this.state);
-      this.log.warn('Submission window closed for epoch', {
-        epochIndex: this.state.epochIndex,
-      });
-      return;
     }
 
     if (
@@ -649,8 +652,10 @@ export class ContinuousObserver {
         : 0;
     metrics.windowProgressGauge.set(progress);
 
-    // Observer state: 0=waiting, 1=observing, 2=finalizing
-    if (this.scheduler.isBeforeWindow(now)) {
+    // Observer state: 0=waiting, 1=observing, 2=finalizing, 3=expired
+    if (this.state.submissionDeadlineExceeded) {
+      metrics.continuousObserverStateGauge.set(3);
+    } else if (this.scheduler.isBeforeWindow(now)) {
       metrics.continuousObserverStateGauge.set(0);
     } else if (
       this.scheduler.isWindowComplete(now) &&

--- a/src/continuous/continuous-observer.ts
+++ b/src/continuous/continuous-observer.ts
@@ -464,8 +464,25 @@ export class ContinuousObserver {
       await this.stateStore.save(this.state);
     }
 
+    // Draining observations above can take long enough to cross the
+    // submission deadline; re-check before finalizing so we don't submit late.
+    const finalizeTime = Date.now();
+    if (finalizeTime >= this.scheduler.getSubmissionDeadline()) {
+      if (!this.state.submissionDeadlineExceeded) {
+        this.state.submissionDeadlineExceeded = true;
+        this.state.pendingObservations = [];
+        this.scheduler.clearSchedule();
+        await this.stateStore.save(this.state);
+        this.log.warn('Submission window closed for epoch', {
+          epochIndex: this.state.epochIndex,
+        });
+        this.updateCycleMetrics(finalizeTime);
+      }
+      return;
+    }
+
     if (
-      this.scheduler.isWindowComplete(now) &&
+      this.scheduler.isWindowComplete(finalizeTime) &&
       this.scheduler.getPendingObservationCount() === 0
     ) {
       if (!this.state.reportSubmitted) {

--- a/src/continuous/continuous-observer.ts
+++ b/src/continuous/continuous-observer.ts
@@ -23,7 +23,6 @@ import { GatewayAssessor } from '../assessment/gateway-assessor.js';
 import * as metrics from '../metrics.js';
 import { REPORT_FORMAT_VERSION } from '../observer.js';
 import {
-  ArnsNameAssessments,
   ArnsNamesSource,
   EntropySource,
   EpochTimestampSource,
@@ -290,6 +289,7 @@ export class ContinuousObserver {
       offsetAssessmentGateways: new Set(), // TODO: implement offset selection
       lastCycleTimestamp: Date.now(),
       reportSubmitted: false,
+      submissionDeadlineExceeded: false,
     };
 
     // Load names and initialize assessor
@@ -362,24 +362,15 @@ export class ContinuousObserver {
         currentEpoch: currentEpochIndex,
       });
 
-      // Finalize current epoch if we haven't submitted yet
       if (!this.state.reportSubmitted) {
-        this.forceMissedObservations(
-          'Observation deadline exceeded before epoch transition',
+        this.log.warn(
+          'Discarding unsubmitted epoch state after submission window closed',
+          {
+            epochIndex: this.state.epochIndex,
+            nextEpochIndex: currentEpochIndex,
+            submissionDeadlineExceeded: this.state.submissionDeadlineExceeded,
+          },
         );
-        const submitted = await this.finalizeAndSubmitReport();
-        if (!submitted) {
-          this.log.warn(
-            'Deferring epoch transition until report submission succeeds',
-            {
-              epochIndex: this.state.epochIndex,
-              nextEpochIndex: currentEpochIndex,
-            },
-          );
-          return;
-        }
-
-        this.state.reportSubmitted = true;
       }
 
       // Clear state and reinitialize
@@ -395,6 +386,10 @@ export class ContinuousObserver {
         windowStart: new Date(this.scheduler.getWindowStart()).toISOString(),
         now: new Date(now).toISOString(),
       });
+      return;
+    }
+
+    if (this.state.submissionDeadlineExceeded) {
       return;
     }
 
@@ -455,15 +450,15 @@ export class ContinuousObserver {
       await this.stateStore.save(this.state);
     }
 
-    if (
-      this.scheduler.isWindowComplete(now) &&
-      now >= this.scheduler.getSubmissionDeadline() &&
-      this.scheduler.getPendingObservationCount() > 0
-    ) {
-      this.forceMissedObservations(
-        'Observation deadline exceeded after repeated errors',
-      );
+    if (now >= this.scheduler.getSubmissionDeadline()) {
+      this.state.submissionDeadlineExceeded = true;
+      this.state.pendingObservations = [];
+      this.scheduler.clearSchedule();
       await this.stateStore.save(this.state);
+      this.log.warn('Submission window closed for epoch', {
+        epochIndex: this.state.epochIndex,
+      });
+      return;
     }
 
     if (
@@ -478,28 +473,6 @@ export class ContinuousObserver {
         }
       }
     }
-  }
-
-  private forceMissedObservations(failureReason: string): void {
-    if (!this.state) {
-      throw new Error('State not initialized');
-    }
-
-    for (const observation of this.scheduler.getSchedule()) {
-      const aggregate = this.state.gatewayObservations.get(observation.fqdn);
-      if (aggregate) {
-        aggregate.observations.push(
-          this.createMissedObservation(observation, failureReason),
-        );
-      }
-      this.scheduler.markObservationComplete(observation.id);
-      metrics.gatewayObservationsCounter?.inc({
-        fqdn: observation.fqdn,
-        status: 'deadline',
-      });
-    }
-
-    this.state.pendingObservations = this.scheduler.getSchedule();
   }
 
   /**
@@ -550,49 +523,6 @@ export class ContinuousObserver {
       ownershipAssessment,
       arnsAssessments,
       pass,
-    };
-  }
-
-  private createMissedObservation(
-    observation: ScheduledObservation,
-    failureReason: string,
-  ): GatewayObservationResult {
-    const createMissedNameAssessments = (
-      names: string[],
-    ): ArnsNameAssessments => {
-      const assessedAt = Math.floor(Date.now() / 1000);
-      return Object.fromEntries(
-        names.map((name) => [
-          name,
-          {
-            assessedAt,
-            expectedId: null,
-            resolvedId: null,
-            expectedDataHash: null,
-            resolvedDataHash: null,
-            failureReason,
-            pass: false,
-          },
-        ]),
-      );
-    };
-
-    return {
-      fqdn: observation.fqdn,
-      observedAt: Date.now(),
-      scheduledAt: observation.scheduledAt,
-      ownershipAssessment: {
-        expectedWallets: this.state!.gatewayWallets.get(observation.fqdn) ?? [],
-        observedWallet: null,
-        failureReason,
-        pass: false,
-      },
-      arnsAssessments: {
-        prescribedNames: createMissedNameAssessments(this.prescribedNames),
-        chosenNames: createMissedNameAssessments(this.chosenNames),
-        pass: false,
-      },
-      pass: false,
     };
   }
 

--- a/src/continuous/continuous-observer.ts
+++ b/src/continuous/continuous-observer.ts
@@ -347,7 +347,20 @@ export class ContinuousObserver {
 
       // Finalize current epoch if we haven't submitted yet
       if (!this.state.reportSubmitted) {
-        await this.finalizeAndSubmitReport();
+        const submitted = await this.finalizeAndSubmitReport();
+        if (!submitted) {
+          this.log.warn(
+            'Deferring epoch transition until report submission succeeds',
+            {
+              epochIndex: this.state.epochIndex,
+              nextEpochIndex: currentEpochIndex,
+            },
+          );
+          return;
+        }
+
+        this.state.reportSubmitted = true;
+        await this.stateStore.save(this.state);
       }
 
       // Clear state and reinitialize
@@ -360,9 +373,11 @@ export class ContinuousObserver {
     // Window complete? Finalize and wait
     if (this.scheduler.isWindowComplete(now)) {
       if (!this.state.reportSubmitted) {
-        await this.finalizeAndSubmitReport();
-        this.state.reportSubmitted = true;
-        await this.stateStore.save(this.state);
+        const submitted = await this.finalizeAndSubmitReport();
+        if (submitted) {
+          this.state.reportSubmitted = true;
+          await this.stateStore.save(this.state);
+        }
       }
       return;
     }
@@ -478,7 +493,7 @@ export class ContinuousObserver {
   /**
    * Finalize observations and submit the report.
    */
-  private async finalizeAndSubmitReport(): Promise<void> {
+  private async finalizeAndSubmitReport(): Promise<boolean> {
     if (!this.state) {
       throw new Error('State not initialized');
     }
@@ -495,11 +510,13 @@ export class ContinuousObserver {
       this.log.info('Report submitted successfully', {
         epochIndex: report.epochIndex,
       });
+      return true;
     } catch (error: any) {
       this.log.error('Failed to submit report', {
         epochIndex: report.epochIndex,
         error: error.message,
       });
+      return false;
     }
   }
 

--- a/src/continuous/continuous-observer.ts
+++ b/src/continuous/continuous-observer.ts
@@ -23,6 +23,7 @@ import { GatewayAssessor } from '../assessment/gateway-assessor.js';
 import * as metrics from '../metrics.js';
 import { REPORT_FORMAT_VERSION } from '../observer.js';
 import {
+  ArnsNameAssessments,
   ArnsNamesSource,
   EntropySource,
   EpochTimestampSource,
@@ -494,7 +495,7 @@ export class ContinuousObserver {
       this.scheduler.markObservationComplete(observation.id);
       metrics.gatewayObservationsCounter?.inc({
         fqdn: observation.fqdn,
-        status: 'error',
+        status: 'deadline',
       });
     }
 
@@ -556,6 +557,26 @@ export class ContinuousObserver {
     observation: ScheduledObservation,
     failureReason: string,
   ): GatewayObservationResult {
+    const createMissedNameAssessments = (
+      names: string[],
+    ): ArnsNameAssessments => {
+      const assessedAt = Math.floor(Date.now() / 1000);
+      return Object.fromEntries(
+        names.map((name) => [
+          name,
+          {
+            assessedAt,
+            expectedId: null,
+            resolvedId: null,
+            expectedDataHash: null,
+            resolvedDataHash: null,
+            failureReason,
+            pass: false,
+          },
+        ]),
+      );
+    };
+
     return {
       fqdn: observation.fqdn,
       observedAt: Date.now(),
@@ -567,8 +588,8 @@ export class ContinuousObserver {
         pass: false,
       },
       arnsAssessments: {
-        prescribedNames: {},
-        chosenNames: {},
+        prescribedNames: createMissedNameAssessments(this.prescribedNames),
+        chosenNames: createMissedNameAssessments(this.chosenNames),
         pass: false,
       },
       pass: false,

--- a/src/continuous/continuous-observer.ts
+++ b/src/continuous/continuous-observer.ts
@@ -247,12 +247,14 @@ export class ContinuousObserver {
 
     // Build gateway wallet mapping (handle duplicates)
     const gatewayWallets = new Map<string, string[]>();
+    const walletByFqdn = new Map<string, string>();
     for (const gateway of gateways) {
       const existing = gatewayWallets.get(gateway.fqdn) ?? [];
       if (!existing.includes(gateway.wallet)) {
         existing.push(gateway.wallet);
       }
       gatewayWallets.set(gateway.fqdn, existing);
+      walletByFqdn.set(gateway.fqdn, gateway.wallet);
     }
 
     // Initialize state
@@ -267,14 +269,21 @@ export class ContinuousObserver {
       windowEnd,
       pendingObservations: [...schedule],
       gatewayObservations: new Map(
-        uniqueFqdns.map((fqdn) => [
-          fqdn,
-          {
+        uniqueFqdns.map((fqdn) => {
+          const wallet = walletByFqdn.get(fqdn);
+          if (wallet === undefined) {
+            throw new Error(`Missing wallet for gateway ${fqdn}`);
+          }
+
+          return [
             fqdn,
-            wallet: gateways.find((gateway) => gateway.fqdn === fqdn)?.wallet ?? '',
-            observations: [],
-          },
-        ]),
+            {
+              fqdn,
+              wallet,
+              observations: [],
+            },
+          ];
+        }),
       ),
       gatewayWallets,
       offsetAssessmentGateways: new Set(), // TODO: implement offset selection
@@ -354,6 +363,9 @@ export class ContinuousObserver {
 
       // Finalize current epoch if we haven't submitted yet
       if (!this.state.reportSubmitted) {
+        this.forceMissedObservations(
+          'Observation deadline exceeded before epoch transition',
+        );
         const submitted = await this.finalizeAndSubmitReport();
         if (!submitted) {
           this.log.warn(
@@ -367,7 +379,6 @@ export class ContinuousObserver {
         }
 
         this.state.reportSubmitted = true;
-        await this.stateStore.save(this.state);
       }
 
       // Clear state and reinitialize
@@ -422,6 +433,10 @@ export class ContinuousObserver {
                 status: result.pass ? 'pass' : 'fail',
               });
             } catch (error: any) {
+              metrics.gatewayObservationsCounter?.inc({
+                fqdn,
+                status: 'error',
+              });
               this.log.error('Error observing gateway', {
                 fqdn,
                 scheduledAt: observation.scheduledAt,
@@ -441,6 +456,17 @@ export class ContinuousObserver {
 
     if (
       this.scheduler.isWindowComplete(now) &&
+      now >= this.scheduler.getSubmissionDeadline() &&
+      this.scheduler.getPendingObservationCount() > 0
+    ) {
+      this.forceMissedObservations(
+        'Observation deadline exceeded after repeated errors',
+      );
+      await this.stateStore.save(this.state);
+    }
+
+    if (
+      this.scheduler.isWindowComplete(now) &&
       this.scheduler.getPendingObservationCount() === 0
     ) {
       if (!this.state.reportSubmitted) {
@@ -451,6 +477,28 @@ export class ContinuousObserver {
         }
       }
     }
+  }
+
+  private forceMissedObservations(failureReason: string): void {
+    if (!this.state) {
+      throw new Error('State not initialized');
+    }
+
+    for (const observation of this.scheduler.getSchedule()) {
+      const aggregate = this.state.gatewayObservations.get(observation.fqdn);
+      if (aggregate) {
+        aggregate.observations.push(
+          this.createMissedObservation(observation, failureReason),
+        );
+      }
+      this.scheduler.markObservationComplete(observation.id);
+      metrics.gatewayObservationsCounter?.inc({
+        fqdn: observation.fqdn,
+        status: 'error',
+      });
+    }
+
+    this.state.pendingObservations = this.scheduler.getSchedule();
   }
 
   /**
@@ -501,6 +549,29 @@ export class ContinuousObserver {
       ownershipAssessment,
       arnsAssessments,
       pass,
+    };
+  }
+
+  private createMissedObservation(
+    observation: ScheduledObservation,
+    failureReason: string,
+  ): GatewayObservationResult {
+    return {
+      fqdn: observation.fqdn,
+      observedAt: Date.now(),
+      scheduledAt: observation.scheduledAt,
+      ownershipAssessment: {
+        expectedWallets: this.state!.gatewayWallets.get(observation.fqdn) ?? [],
+        observedWallet: null,
+        failureReason,
+        pass: false,
+      },
+      arnsAssessments: {
+        prescribedNames: {},
+        chosenNames: {},
+        pass: false,
+      },
+      pass: false,
     };
   }
 

--- a/src/continuous/observation-state-store.test.ts
+++ b/src/continuous/observation-state-store.test.ts
@@ -18,6 +18,7 @@
 
 import { expect } from 'chai';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { createLogger, transports } from 'winston';
 
@@ -30,28 +31,18 @@ const testLog = createLogger({
 });
 
 describe('FsObservationStateStore', function () {
-  const testDir = './data/test';
-  const testStatePath = path.join(testDir, 'test-observation-state.json');
+  let testDir: string;
+  let testStatePath: string;
 
   beforeEach(async function () {
-    // Ensure test directory exists
-    await fs.promises.mkdir(testDir, { recursive: true });
-
-    // Clean up any existing test file
-    try {
-      await fs.promises.unlink(testStatePath);
-    } catch {
-      // Ignore if file doesn't exist
-    }
+    testDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'observation-state-store-'),
+    );
+    testStatePath = path.join(testDir, 'test-observation-state.json');
   });
 
   afterEach(async function () {
-    // Clean up test file
-    try {
-      await fs.promises.unlink(testStatePath);
-    } catch {
-      // Ignore if file doesn't exist
-    }
+    await fs.promises.rm(testDir, { recursive: true, force: true });
   });
 
   function createTestState(): ObservationState {
@@ -211,6 +202,61 @@ describe('FsObservationStateStore', function () {
           scheduledAt: 140,
         },
       ]);
+    });
+
+    it('should return null for malformed mixed pending observation formats', async function () {
+      const store = new FsObservationStateStore({
+        statePath: testStatePath,
+        log: testLog,
+      });
+
+      await fs.promises.writeFile(
+        testStatePath,
+        JSON.stringify({
+          epochIndex: 42,
+          epochStartTimestamp: 100,
+          epochEndTimestamp: 200,
+          epochStartHeight: 1000,
+          windowStart: 110,
+          windowEnd: 150,
+          pendingObservations: [
+            ['gateway2.example.com', [140]],
+            {
+              id: 'gateway1.example.com:0',
+              fqdn: 'gateway1.example.com',
+              scheduledAt: 120,
+            },
+          ],
+          gatewayObservations: [],
+          gatewayWallets: [],
+          offsetAssessmentGateways: [],
+          lastCycleTimestamp: 123,
+          reportSubmitted: false,
+          submissionDeadlineExceeded: false,
+        }),
+      );
+
+      const loadedState = await store.load();
+
+      expect(loadedState).to.be.null;
+    });
+
+    it('should preserve submissionDeadlineExceeded through save and load', async function () {
+      const store = new FsObservationStateStore({
+        statePath: testStatePath,
+        log: testLog,
+      });
+
+      const originalState = {
+        ...createTestState(),
+        submissionDeadlineExceeded: true,
+      };
+      await store.save(originalState);
+
+      const loadedState = await store.load();
+
+      expect(loadedState).to.not.be.null;
+      expect(loadedState!.submissionDeadlineExceeded).to.be.true;
     });
   });
 

--- a/src/continuous/observation-state-store.test.ts
+++ b/src/continuous/observation-state-store.test.ts
@@ -161,6 +161,55 @@ describe('FsObservationStateStore', function () {
         originalState.pendingObservations,
       );
     });
+
+    it('should migrate legacy pending observation tuples', async function () {
+      const store = new FsObservationStateStore({
+        statePath: testStatePath,
+        log: testLog,
+      });
+
+      await fs.promises.writeFile(
+        testStatePath,
+        JSON.stringify({
+          epochIndex: 42,
+          epochStartTimestamp: 100,
+          epochEndTimestamp: 200,
+          epochStartHeight: 1000,
+          windowStart: 110,
+          windowEnd: 150,
+          pendingObservations: [
+            ['gateway2.example.com', [140]],
+            ['gateway1.example.com', [120, 130]],
+          ],
+          gatewayObservations: [],
+          gatewayWallets: [],
+          offsetAssessmentGateways: [],
+          lastCycleTimestamp: 123,
+          reportSubmitted: false,
+        }),
+      );
+
+      const loadedState = await store.load();
+
+      expect(loadedState).to.not.be.null;
+      expect(loadedState!.pendingObservations).to.deep.equal([
+        {
+          id: 'gateway1.example.com:0',
+          fqdn: 'gateway1.example.com',
+          scheduledAt: 120,
+        },
+        {
+          id: 'gateway1.example.com:1',
+          fqdn: 'gateway1.example.com',
+          scheduledAt: 130,
+        },
+        {
+          id: 'gateway2.example.com:0',
+          fqdn: 'gateway2.example.com',
+          scheduledAt: 140,
+        },
+      ]);
+    });
   });
 
   describe('clear', function () {

--- a/src/continuous/observation-state-store.test.ts
+++ b/src/continuous/observation-state-store.test.ts
@@ -96,6 +96,7 @@ describe('FsObservationStateStore', function () {
       offsetAssessmentGateways: new Set(['gateway1.example.com']),
       lastCycleTimestamp: Date.now(),
       reportSubmitted: false,
+      submissionDeadlineExceeded: false,
     };
   }
 
@@ -186,6 +187,7 @@ describe('FsObservationStateStore', function () {
           offsetAssessmentGateways: [],
           lastCycleTimestamp: 123,
           reportSubmitted: false,
+          submissionDeadlineExceeded: false,
         }),
       );
 

--- a/src/continuous/observation-state-store.test.ts
+++ b/src/continuous/observation-state-store.test.ts
@@ -62,10 +62,23 @@ describe('FsObservationStateStore', function () {
       epochStartHeight: 1000,
       windowStart: Date.now(),
       windowEnd: Date.now() + 12 * 60 * 60 * 1000,
-      pendingObservations: new Map([
-        ['gateway1.example.com', [Date.now() + 1000, Date.now() + 2000]],
-        ['gateway2.example.com', [Date.now() + 3000]],
-      ]),
+      pendingObservations: [
+        {
+          id: 'gateway1.example.com:0',
+          fqdn: 'gateway1.example.com',
+          scheduledAt: Date.now() + 1000,
+        },
+        {
+          id: 'gateway1.example.com:1',
+          fqdn: 'gateway1.example.com',
+          scheduledAt: Date.now() + 2000,
+        },
+        {
+          id: 'gateway2.example.com:0',
+          fqdn: 'gateway2.example.com',
+          scheduledAt: Date.now() + 3000,
+        },
+      ],
       gatewayObservations: new Map([
         [
           'gateway1.example.com',
@@ -137,20 +150,15 @@ describe('FsObservationStateStore', function () {
       expect(loadedState!.windowStart).to.equal(originalState.windowStart);
       expect(loadedState!.windowEnd).to.equal(originalState.windowEnd);
 
-      // Verify Map structures are restored
-      expect(loadedState!.pendingObservations).to.be.instanceOf(Map);
+      // Verify collection structures are restored
+      expect(loadedState!.pendingObservations).to.be.an('array');
       expect(loadedState!.gatewayObservations).to.be.instanceOf(Map);
       expect(loadedState!.gatewayWallets).to.be.instanceOf(Map);
       expect(loadedState!.offsetAssessmentGateways).to.be.instanceOf(Set);
 
       // Verify content is preserved
-      expect(loadedState!.pendingObservations.size).to.equal(
-        originalState.pendingObservations.size,
-      );
-      expect(
-        loadedState!.pendingObservations.get('gateway1.example.com'),
-      ).to.deep.equal(
-        originalState.pendingObservations.get('gateway1.example.com'),
+      expect(loadedState!.pendingObservations).to.deep.equal(
+        originalState.pendingObservations,
       );
     });
   });

--- a/src/continuous/observation-state-store.ts
+++ b/src/continuous/observation-state-store.ts
@@ -67,6 +67,7 @@ export class FsObservationStateStore implements ObservationStateStore {
       offsetAssessmentGateways: Array.from(state.offsetAssessmentGateways),
       lastCycleTimestamp: state.lastCycleTimestamp,
       reportSubmitted: state.reportSubmitted,
+      submissionDeadlineExceeded: state.submissionDeadlineExceeded,
     };
 
     // Atomic write: write to temp file then rename
@@ -102,6 +103,7 @@ export class FsObservationStateStore implements ObservationStateStore {
         offsetAssessmentGateways: new Set(parsed.offsetAssessmentGateways),
         lastCycleTimestamp: parsed.lastCycleTimestamp,
         reportSubmitted: parsed.reportSubmitted,
+        submissionDeadlineExceeded: parsed.submissionDeadlineExceeded ?? false,
       };
 
       this.log.debug('Observation state loaded', {

--- a/src/continuous/observation-state-store.ts
+++ b/src/continuous/observation-state-store.ts
@@ -57,7 +57,7 @@ export class FsObservationStateStore implements ObservationStateStore {
       epochStartHeight: state.epochStartHeight,
       windowStart: state.windowStart,
       windowEnd: state.windowEnd,
-      pendingObservations: Array.from(state.pendingObservations.entries()),
+      pendingObservations: state.pendingObservations,
       gatewayObservations: Array.from(state.gatewayObservations.entries()),
       gatewayWallets: Array.from(state.gatewayWallets.entries()),
       offsetAssessmentGateways: Array.from(state.offsetAssessmentGateways),
@@ -74,10 +74,7 @@ export class FsObservationStateStore implements ObservationStateStore {
     this.log.debug('Observation state saved', {
       epochIndex: state.epochIndex,
       gatewayCount: state.gatewayObservations.size,
-      pendingCount: Array.from(state.pendingObservations.values()).reduce(
-        (sum, times) => sum + times.length,
-        0,
-      ),
+      pendingCount: state.pendingObservations.length,
     });
   }
 
@@ -93,7 +90,7 @@ export class FsObservationStateStore implements ObservationStateStore {
         epochStartHeight: parsed.epochStartHeight,
         windowStart: parsed.windowStart,
         windowEnd: parsed.windowEnd,
-        pendingObservations: new Map(parsed.pendingObservations),
+        pendingObservations: parsed.pendingObservations,
         gatewayObservations: new Map(parsed.gatewayObservations),
         gatewayWallets: new Map(parsed.gatewayWallets),
         offsetAssessmentGateways: new Set(parsed.offsetAssessmentGateways),

--- a/src/continuous/observation-state-store.ts
+++ b/src/continuous/observation-state-store.ts
@@ -20,7 +20,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { Logger } from 'winston';
 
-import { ObservationState, SerializedObservationState } from './types.js';
+import {
+  ObservationState,
+  ScheduledObservation,
+  SerializedObservationState,
+} from './types.js';
 
 /**
  * Interface for persisting observation state
@@ -90,7 +94,9 @@ export class FsObservationStateStore implements ObservationStateStore {
         epochStartHeight: parsed.epochStartHeight,
         windowStart: parsed.windowStart,
         windowEnd: parsed.windowEnd,
-        pendingObservations: parsed.pendingObservations,
+        pendingObservations: this.parsePendingObservations(
+          parsed.pendingObservations,
+        ),
         gatewayObservations: new Map(parsed.gatewayObservations),
         gatewayWallets: new Map(parsed.gatewayWallets),
         offsetAssessmentGateways: new Set(parsed.offsetAssessmentGateways),
@@ -114,6 +120,53 @@ export class FsObservationStateStore implements ObservationStateStore {
       });
       return null;
     }
+  }
+
+  private parsePendingObservations(
+    pendingObservations: SerializedObservationState['pendingObservations'],
+  ): ScheduledObservation[] {
+    if (pendingObservations.length === 0) {
+      return [];
+    }
+
+    const first = pendingObservations[0];
+    if (
+      Array.isArray(first) &&
+      first.length === 2 &&
+      typeof first[0] === 'string' &&
+      Array.isArray(first[1])
+    ) {
+      this.log.info('Migrating legacy pending observation state format');
+      const legacyPendingObservations = pendingObservations as [
+        string,
+        number[],
+      ][];
+      return legacyPendingObservations
+        .flatMap(([fqdn, scheduledTimes]) =>
+          scheduledTimes.map((scheduledAt: number, index: number) => ({
+            id: `${fqdn}:${index}`,
+            fqdn,
+            scheduledAt,
+          })),
+        )
+        .sort((left, right) => left.scheduledAt - right.scheduledAt);
+    }
+
+    if (
+      pendingObservations.every(
+        (observation): observation is ScheduledObservation =>
+          !Array.isArray(observation) &&
+          typeof observation.id === 'string' &&
+          typeof observation.fqdn === 'string' &&
+          typeof observation.scheduledAt === 'number',
+      )
+    ) {
+      return [...pendingObservations].sort(
+        (left, right) => left.scheduledAt - right.scheduledAt,
+      );
+    }
+
+    throw new Error('Unsupported pending observation state format');
   }
 
   async clear(): Promise<void> {

--- a/src/continuous/observation-state-store.ts
+++ b/src/continuous/observation-state-store.ts
@@ -131,19 +131,20 @@ export class FsObservationStateStore implements ObservationStateStore {
       return [];
     }
 
-    const first = pendingObservations[0];
-    if (
-      Array.isArray(first) &&
-      first.length === 2 &&
-      typeof first[0] === 'string' &&
-      Array.isArray(first[1])
-    ) {
+    const isLegacyPendingObservation = (
+      observation: ScheduledObservation | [string, number[]],
+    ): observation is [string, number[]] =>
+      Array.isArray(observation) &&
+      observation.length === 2 &&
+      typeof observation[0] === 'string' &&
+      Array.isArray(observation[1]) &&
+      observation[1].every(
+        (scheduledAt): scheduledAt is number => typeof scheduledAt === 'number',
+      );
+
+    if (pendingObservations.every(isLegacyPendingObservation)) {
       this.log.info('Migrating legacy pending observation state format');
-      const legacyPendingObservations = pendingObservations as [
-        string,
-        number[],
-      ][];
-      return legacyPendingObservations
+      return pendingObservations
         .flatMap(([fqdn, scheduledTimes]) =>
           scheduledTimes.map((scheduledAt: number, index: number) => ({
             id: `${fqdn}:${index}`,

--- a/src/continuous/types.ts
+++ b/src/continuous/types.ts
@@ -75,6 +75,8 @@ export interface ObservationState {
   lastCycleTimestamp: number;
   // Whether report has been submitted for this epoch
   reportSubmitted: boolean;
+  // Whether the submission window has expired for this epoch
+  submissionDeadlineExceeded: boolean;
 }
 
 /**
@@ -93,6 +95,7 @@ export interface SerializedObservationState {
   offsetAssessmentGateways: string[];
   lastCycleTimestamp: number;
   reportSubmitted: boolean;
+  submissionDeadlineExceeded: boolean;
 }
 
 /**

--- a/src/continuous/types.ts
+++ b/src/continuous/types.ts
@@ -45,6 +45,15 @@ export interface GatewayObservationAggregate {
 }
 
 /**
+ * Scheduled observation event persisted for catch-up and restart recovery.
+ */
+export interface ScheduledObservation {
+  id: string;
+  fqdn: string;
+  scheduledAt: number;
+}
+
+/**
  * Complete observation state for an epoch (persisted)
  */
 export interface ObservationState {
@@ -54,8 +63,8 @@ export interface ObservationState {
   epochStartHeight: number;
   windowStart: number;
   windowEnd: number;
-  // Scheduled observation times per gateway (key = fqdn)
-  pendingObservations: Map<string, number[]>;
+  // Scheduled observation events pending completion
+  pendingObservations: ScheduledObservation[];
   // Completed observations per gateway (key = fqdn)
   gatewayObservations: Map<string, GatewayObservationAggregate>;
   // Gateway to wallet mapping
@@ -78,7 +87,7 @@ export interface SerializedObservationState {
   epochStartHeight: number;
   windowStart: number;
   windowEnd: number;
-  pendingObservations: [string, number[]][]; // Array of tuples for Map
+  pendingObservations: ScheduledObservation[];
   gatewayObservations: [string, GatewayObservationAggregate][];
   gatewayWallets: [string, string[]][];
   offsetAssessmentGateways: string[];

--- a/src/continuous/types.ts
+++ b/src/continuous/types.ts
@@ -87,7 +87,7 @@ export interface SerializedObservationState {
   epochStartHeight: number;
   windowStart: number;
   windowEnd: number;
-  pendingObservations: ScheduledObservation[];
+  pendingObservations: ScheduledObservation[] | [string, number[]][];
   gatewayObservations: [string, GatewayObservationAggregate][];
   gatewayWallets: [string, string[]][];
   offsetAssessmentGateways: string[];

--- a/src/lib/block-offset-mapping.test.ts
+++ b/src/lib/block-offset-mapping.test.ts
@@ -6,7 +6,6 @@
  */
 
 import { expect } from 'chai';
-import fs from 'node:fs';
 import path from 'node:path';
 import { BlockOffsetMapping } from './block-offset-mapping.js';
 

--- a/src/lib/tx-path-parser.test.ts
+++ b/src/lib/tx-path-parser.test.ts
@@ -393,7 +393,7 @@ describe('tx-path-parser', function () {
       const txPath = Buffer.from(txPathB64, 'base64url');
       const txRoot = Buffer.from(txRootB64, 'base64url');
 
-      const { result, rejectionReason, branchCount } = await parseTxPath({
+      const { result } = await parseTxPath({
         txRoot,
         txPath,
         targetOffset,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -153,7 +153,8 @@ export const epochCoverageGauge = new Gauge({
 
 export const continuousObserverStateGauge = new Gauge({
   name: 'observer_continuous_state',
-  help: 'Current state of continuous observer (0=waiting, 1=observing, 2=finalizing)',
+  help:
+    'Current state of continuous observer (0=waiting, 1=observing, 2=finalizing, 3=expired)',
   registers: [register],
 });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -153,8 +153,7 @@ export const epochCoverageGauge = new Gauge({
 
 export const continuousObserverStateGauge = new Gauge({
   name: 'observer_continuous_state',
-  help:
-    'Current state of continuous observer (0=waiting, 1=observing, 2=finalizing, 3=expired)',
+  help: 'Current state of continuous observer (0=waiting, 1=observing, 2=finalizing, 3=expired)',
   registers: [register],
 });
 

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -43,7 +43,8 @@ const OneMiB = 1048576;
 const entropy = Buffer.from('entropy');
 
 function createReport(
-  overrides: Partial<ObserverReport> & Pick<ObserverReport, 'gatewayAssessments'>,
+  overrides: Partial<ObserverReport> &
+    Pick<ObserverReport, 'gatewayAssessments'>,
 ): ObserverReport {
   return {
     formatVersion: 2,
@@ -1180,9 +1181,8 @@ describe('Observer', function () {
             ).resolveTxBoundsViaReferenceHeaders(probeOffset);
 
             expect(result).to.equal(null);
-            expect(
-              counterStub.calledWith(sinon.match({ result: 'mismatch' })),
-            ).to.be.true;
+            expect(counterStub.calledWith(sinon.match({ result: 'mismatch' })))
+              .to.be.true;
           } finally {
             counterStub.restore();
           }

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -21,7 +21,6 @@ import nock from 'nock';
 import crypto from 'node:crypto';
 import sinon from 'sinon';
 
-import * as config from './config.js';
 import { customHashPRNG } from './lib/prng.js';
 import * as metrics from './metrics.js';
 import {
@@ -31,7 +30,6 @@ import {
 } from './observer.js';
 import { ReferenceGatewaySource } from './types.js';
 import type {
-  GatewayAssessments,
   ObserverReport,
   GatewayHost,
   ArnsNamesSource,
@@ -43,6 +41,21 @@ import type {
 const OneMiB = 1048576;
 
 const entropy = Buffer.from('entropy');
+
+function createReport(
+  overrides: Partial<ObserverReport> & Pick<ObserverReport, 'gatewayAssessments'>,
+): ObserverReport {
+  return {
+    formatVersion: 2,
+    observerAddress: 'test-observer',
+    generatedAt: 100,
+    epochStartTimestamp: 100,
+    epochEndTimestamp: 200,
+    epochStartHeight: 1000,
+    epochIndex: 1,
+    ...overrides,
+  };
+}
 
 describe('Observer', function () {
   describe('getArnsResolution', function () {
@@ -421,6 +434,7 @@ describe('Observer', function () {
 
     beforeEach(function () {
       epochSourceStub = {
+        getEpochSettings: sinon.stub(),
         getEpochStartTimestamp: sinon.stub(),
         getEpochEndTimestamp: sinon.stub(),
         getEpochStartHeight: sinon.stub(),
@@ -449,10 +463,12 @@ describe('Observer', function () {
       referenceGatewayStub = {
         getArnsResolution: sinon.stub(),
         checkChunkAvailability: sinon.stub(),
-        getChunkMetadata: sinon
-          .stub()
-          .resolves({ host: 'reference.example.com', metadata: null }),
+        getChunkMetadata: sinon.stub(),
       };
+      referenceGatewayStub.getChunkMetadata.resolves({
+        host: 'reference.example.com',
+        metadata: null,
+      });
 
       observer = new Observer({
         observerAddress: 'test-observer',
@@ -477,24 +493,16 @@ describe('Observer', function () {
 
     describe('calculateFailureRate', function () {
       it('should return 0 for empty report', function () {
-        const report: ObserverReport = {
-          epochStartTimestamp: 100,
-          epochEndTimestamp: 200,
-          epochStartHeight: 1000,
-          epochIndex: 1,
+        const report: ObserverReport = createReport({
           gatewayAssessments: {},
-        };
+        });
 
         const failureRate = (observer as any).calculateFailureRate(report);
         expect(failureRate).to.equal(0);
       });
 
       it('should calculate correct failure rate for single gateway', function () {
-        const report: ObserverReport = {
-          epochStartTimestamp: 100,
-          epochEndTimestamp: 200,
-          epochStartHeight: 1000,
-          epochIndex: 1,
+        const report: ObserverReport = createReport({
           gatewayAssessments: {
             'gateway1.com': {
               ownershipAssessment: {
@@ -509,6 +517,10 @@ describe('Observer', function () {
                     failureReason: 'timeout',
                     expectedStatusCode: 200,
                     assessedAt: 100,
+                    expectedId: null,
+                    resolvedId: null,
+                    expectedDataHash: null,
+                    resolvedDataHash: null,
                   },
                 },
                 chosenNames: {
@@ -523,10 +535,12 @@ describe('Observer', function () {
                     resolvedDataHash: 'hash1',
                   },
                 },
+                pass: false,
               },
+              pass: false,
             },
           },
-        };
+        });
 
         const failureRate = (observer as any).calculateFailureRate(report);
         // 1 failure out of 3 assessments (1 ownership + 2 names)
@@ -534,11 +548,7 @@ describe('Observer', function () {
       });
 
       it('should calculate correct failure rate for multiple gateways', function () {
-        const report: ObserverReport = {
-          epochStartTimestamp: 100,
-          epochEndTimestamp: 200,
-          epochStartHeight: 1000,
-          epochIndex: 1,
+        const report: ObserverReport = createReport({
           gatewayAssessments: {
             'gateway1.com': {
               ownershipAssessment: {
@@ -549,7 +559,9 @@ describe('Observer', function () {
               arnsAssessments: {
                 prescribedNames: {},
                 chosenNames: {},
+                pass: true,
               },
+              pass: true,
             },
             'gateway2.com': {
               ownershipAssessment: {
@@ -561,10 +573,12 @@ describe('Observer', function () {
               arnsAssessments: {
                 prescribedNames: {},
                 chosenNames: {},
+                pass: true,
               },
+              pass: false,
             },
           },
-        };
+        });
 
         const failureRate = (observer as any).calculateFailureRate(report);
         // 1 failure out of 2 assessments
@@ -604,6 +618,9 @@ describe('Observer', function () {
 
         // Return mock reports for each call
         runSingleObservationStub.resolves({
+          formatVersion: 2,
+          observerAddress: 'test-observer',
+          generatedAt: 100,
           epochStartTimestamp: 100,
           epochEndTimestamp: 200,
           epochStartHeight: 1000,
@@ -618,7 +635,9 @@ describe('Observer', function () {
               arnsAssessments: {
                 prescribedNames: {},
                 chosenNames: {},
+                pass: true,
               },
+              pass: true,
             },
           },
         });
@@ -640,7 +659,6 @@ describe('Observer', function () {
         );
 
         // Mock different failure rates for each observation
-        let observationCount = 0;
         const runSingleObservationStub = sinon.stub(
           observer as any,
           'runSingleObservation',
@@ -648,6 +666,9 @@ describe('Observer', function () {
 
         // First observation with high failure rate
         runSingleObservationStub.onCall(0).resolves({
+          formatVersion: 2,
+          observerAddress: 'test-observer',
+          generatedAt: 100,
           epochStartTimestamp: 100,
           epochEndTimestamp: 200,
           epochStartHeight: 1000,
@@ -663,13 +684,18 @@ describe('Observer', function () {
               arnsAssessments: {
                 prescribedNames: {},
                 chosenNames: {},
+                pass: false,
               },
+              pass: false,
             },
           },
         });
 
         // Second observation with low failure rate
         runSingleObservationStub.onCall(1).resolves({
+          formatVersion: 2,
+          observerAddress: 'test-observer',
+          generatedAt: 100,
           epochStartTimestamp: 100,
           epochEndTimestamp: 200,
           epochStartHeight: 1000,
@@ -684,7 +710,9 @@ describe('Observer', function () {
               arnsAssessments: {
                 prescribedNames: {},
                 chosenNames: {},
+                pass: true,
               },
+              pass: true,
             },
           },
         });
@@ -717,10 +745,6 @@ describe('Observer', function () {
         // const shuffledGatewayHosts = [...gatewayHosts].sort(() => Math.random() - 0.5);
 
         // Spy on the original runSingleObservation before stubbing
-        const originalMethod = (observer as any).runSingleObservation.bind(
-          observer,
-        );
-
         // Track calls to verify shuffling logic is present
         let callCount = 0;
         const runSingleObservationStub = sinon.stub(
@@ -731,6 +755,9 @@ describe('Observer', function () {
           callCount++;
           // The implementation creates a new shuffled array each time
           return {
+            formatVersion: 2,
+            observerAddress: 'test-observer',
+            generatedAt: 100,
             epochStartTimestamp: args[0],
             epochEndTimestamp: args[1],
             epochStartHeight: args[2],
@@ -1153,7 +1180,9 @@ describe('Observer', function () {
             ).resolveTxBoundsViaReferenceHeaders(probeOffset);
 
             expect(result).to.equal(null);
-            expect(counterStub.calledWith({ result: 'mismatch' })).to.be.true;
+            expect(
+              counterStub.calledWith(sinon.match({ result: 'mismatch' })),
+            ).to.be.true;
           } finally {
             counterStub.restore();
           }


### PR DESCRIPTION
## Summary

Hardens the continuous observer's scheduling, deadline handling, and report submission so an epoch is no longer silently lost when the observer restarts mid-window or runs past its submission window.

- Replaced the per-gateway `Map<fqdn, number[]>` schedule with a flat list of `ScheduledObservation { id, fqdn, scheduledAt }` events. Each event is tracked and acked individually so duplicates, restart catch-up, and overdue retries are deterministic. Legacy persisted state is auto-migrated on load.
- Added an explicit submission deadline (`windowEnd + submissionBufferMs`). Once exceeded, the scheduler clears its pending work, sets `submissionDeadlineExceeded`, and the observer stops issuing new observations rather than spinning on stale state.
- Finalization is now gated on both the window being complete and the pending queue being empty, and only flips `reportSubmitted` when the submit actually succeeds — so transient submit failures retry instead of dropping the report.
- On epoch transition, an unsubmitted prior epoch is no longer force-finalized after the deadline; it's logged and discarded so we don't submit a stale report into the wrong epoch.
- Added the `expired` (3) state to `observer_continuous_state` and bumped scheduler/observer/state-store test coverage substantially.

## Test plan

- [ ] `yarn test` passes locally
- [ ] `yarn lint:check` passes
- [ ] Verify legacy state file (pre-migration `pendingObservations` tuple format) loads and migrates cleanly on first cycle
- [ ] Soak: restart the observer mid-window and confirm the persisted schedule resumes without duplicating completed observations
- [ ] Soak: force a submit failure and confirm the next cycle retries instead of marking `reportSubmitted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced submission deadline per epoch that blocks submission and clears pending observations when exceeded.
  * Added explicit submission-deadline visibility (new deadline value accessible).

* **Improvements**
  * Observations now spread evenly across the full observation window, improving timing distribution.
  * Better persistence and restart behavior for deadline-exceeded states.

* **Bug Fixes**
  * Overdue observation catch-up now reliably drains and retries overdue work until deadline.

* **Tests**
  * Expanded integration and migration tests covering deadline, overdue handling, and state migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->