### PR TITLE
chore(lint): fix lint:check across solana track to unblock image builds

### DIFF
--- a/src/continuous/continuous-observer.test.ts
+++ b/src/continuous/continuous-observer.test.ts
@@ -505,7 +505,9 @@ describe('ContinuousObserver Integration', function () {
         clear: sinon.stub().resolves(),
       };
       const reportSink = {
-        saveReport: sinon.stub().resolves({ report: {} as any, reportTxId: 'mock-arweave-tx-id' }),
+        saveReport: sinon
+          .stub()
+          .resolves({ report: {} as any, reportTxId: 'mock-arweave-tx-id' }),
       };
       const observer = createObserverForCatchUp({
         stateStore,
@@ -583,7 +585,9 @@ describe('ContinuousObserver Integration', function () {
         clear: sinon.stub().resolves(),
       };
       const reportSink = {
-        saveReport: sinon.stub().resolves({ report: {} as any, reportTxId: 'mock-arweave-tx-id' }),
+        saveReport: sinon
+          .stub()
+          .resolves({ report: {} as any, reportTxId: 'mock-arweave-tx-id' }),
       };
       const observer = createObserverForCatchUp({
         stateStore,
@@ -689,7 +693,9 @@ describe('ContinuousObserver Integration', function () {
         clear: sinon.stub().resolves(),
       };
       const reportSink = {
-        saveReport: sinon.stub().resolves({ report: {} as any, reportTxId: 'mock-arweave-tx-id' }),
+        saveReport: sinon
+          .stub()
+          .resolves({ report: {} as any, reportTxId: 'mock-arweave-tx-id' }),
       };
       const observer = createObserverForCatchUp({
         stateStore,
@@ -753,7 +759,9 @@ describe('ContinuousObserver Integration', function () {
         clear: sinon.stub().resolves(),
       };
       const reportSink = {
-        saveReport: sinon.stub().resolves({ report: {} as any, reportTxId: 'mock-arweave-tx-id' }),
+        saveReport: sinon
+          .stub()
+          .resolves({ report: {} as any, reportTxId: 'mock-arweave-tx-id' }),
       };
       const observer = createObserverForCatchUp({
         stateStore,
@@ -854,7 +862,9 @@ describe('ContinuousObserver Integration', function () {
         clear: sinon.stub().resolves(),
       };
       const reportSink = {
-        saveReport: sinon.stub().resolves({ report: {} as any, reportTxId: 'mock-arweave-tx-id' }),
+        saveReport: sinon
+          .stub()
+          .resolves({ report: {} as any, reportTxId: 'mock-arweave-tx-id' }),
       };
       const observer = createObserverForCatchUp({
         stateStore,
@@ -1146,9 +1156,10 @@ describe('ContinuousObserver Integration', function () {
 
     function persistenceSinkStub(): { saveReport: sinon.SinonStub } {
       return {
-        saveReport: sinon
-          .stub()
-          .callsFake(async (info: any) => ({ ...info, persistedLocally: true })),
+        saveReport: sinon.stub().callsFake(async (info: any) => ({
+          ...info,
+          persistedLocally: true,
+        })),
       };
     }
 
@@ -1480,9 +1491,9 @@ describe('ContinuousObserver Integration', function () {
       expect((observer as any).chosenNames).to.deep.equal(['c1', 'c2', 'c3']);
       expect(assessor.initializeForEpoch.calledOnce).to.equal(true);
       // namesCount = prescribed + chosen
-      expect(
-        assessor.initializeForEpoch.firstCall.args[0].namesCount,
-      ).to.equal(5);
+      expect(assessor.initializeForEpoch.firstCall.args[0].namesCount).to.equal(
+        5,
+      );
 
       // Third cycle — flag is already set, no re-fetch.
       await (observer as any).runObservationCycle();

--- a/src/entropy/solana-epoch-entropy-source.test.ts
+++ b/src/entropy/solana-epoch-entropy-source.test.ts
@@ -18,7 +18,13 @@ import { SolanaEpochEntropySource } from './solana-epoch-entropy-source.js';
 function makeLog(): winston.Logger {
   const noop = sinon.stub();
   return {
-    child: () => ({ verbose: noop, info: noop, warn: noop, error: noop, debug: noop }),
+    child: () => ({
+      verbose: noop,
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+    }),
     verbose: noop,
     info: noop,
     warn: noop,

--- a/src/entropy/solana-epoch-entropy-source.ts
+++ b/src/entropy/solana-epoch-entropy-source.ts
@@ -51,10 +51,7 @@ import {
 import crypto from 'node:crypto';
 import type winston from 'winston';
 
-import {
-  deserializeEpoch,
-  getEpochPDA,
-} from '@ar.io/sdk';
+import { deserializeEpoch, getEpochPDA } from '@ar.io/sdk';
 import type { EntropySource, EpochTimestampSource } from '../types.js';
 
 export interface SolanaEpochEntropySourceConfig {
@@ -143,13 +140,13 @@ export class SolanaEpochEntropySource implements EntropySource {
     hash.update(`observers=`);
     for (let i = 0; i < epoch.observerCount; i++) {
       const addr = epoch.prescribedObservers[i];
-      if (addr) hash.update(String(addr));
+      if (addr !== undefined) hash.update(String(addr));
       hash.update(',');
     }
     hash.update(`\nnameHashes=`);
     for (let i = 0; i < epoch.nameCount; i++) {
       const h = epoch.prescribedNameHashes[i];
-      if (h) hash.update(h);
+      if (h !== undefined) hash.update(h);
     }
 
     const entropy = hash.digest();

--- a/src/epoch/epoch-cranker.ts
+++ b/src/epoch/epoch-cranker.ts
@@ -13,7 +13,12 @@
  * `cranker/src/state-machine.ts` in the solana-ar-io monorepo. Keep the
  * pipeline ordering, error handling, and edge-case behavior in sync.
  */
-import type { Address, Rpc, SolanaRpcApi, TransactionSigner } from '@solana/kit';
+import type {
+  Address,
+  Rpc,
+  SolanaRpcApi,
+  TransactionSigner,
+} from '@solana/kit';
 import type { SolanaARIOWriteable } from '@ar.io/sdk';
 import { classifyError, type ErrorCategory } from './errors.js';
 
@@ -173,7 +178,8 @@ export class EpochCranker {
     const currentIndex = settings.currentEpochIndex;
     const targetEpochIndex = currentIndex > 0 ? currentIndex - 1 : 0;
     const now = Math.floor(Date.now() / 1000);
-    const nextEpochStart = settings.genesisTimestamp + currentIndex * settings.epochDuration;
+    const nextEpochStart =
+      settings.genesisTimestamp + currentIndex * settings.epochDuration;
 
     // 2. Bootstrap: no epochs exist yet, create epoch 0 if genesis time passed
     if (currentIndex === 0) {
@@ -209,10 +215,14 @@ export class EpochCranker {
         progress: `${epoch.tallyIndex}/${epoch.activeGatewayCount}`,
       });
       try {
-        const gatewayPDAs = epoch.activeGatewayCount > 0
-          ? await ario.getRegistryGatewayPDAs(epoch.tallyIndex, batchSize)
-          : [];
-        await ario.tallyWeights({ epochIndex: targetEpochIndex, gatewayAccounts: gatewayPDAs });
+        const gatewayPDAs =
+          epoch.activeGatewayCount > 0
+            ? await ario.getRegistryGatewayPDAs(epoch.tallyIndex, batchSize)
+            : [];
+        await ario.tallyWeights({
+          epochIndex: targetEpochIndex,
+          gatewayAccounts: gatewayPDAs,
+        });
       } catch (err) {
         this.handleError(err, 'tally_weights');
       }
@@ -250,10 +260,17 @@ export class EpochCranker {
         progress: `${epoch.distributionIndex}/${epoch.activeGatewayCount}`,
       });
       try {
-        const gatewayPDAs = epoch.activeGatewayCount > 0
-          ? await ario.getRegistryGatewayPDAs(epoch.distributionIndex, batchSize)
-          : [];
-        await ario.distributeEpoch({ epochIndex: targetEpochIndex, gatewayAccounts: gatewayPDAs });
+        const gatewayPDAs =
+          epoch.activeGatewayCount > 0
+            ? await ario.getRegistryGatewayPDAs(
+                epoch.distributionIndex,
+                batchSize,
+              )
+            : [];
+        await ario.distributeEpoch({
+          epochIndex: targetEpochIndex,
+          gatewayAccounts: gatewayPDAs,
+        });
       } catch (err) {
         this.handleError(err, 'distribute_epoch');
       }
@@ -341,7 +358,9 @@ export class EpochCranker {
         if (cfg && Number(cfg.nextRecordsPruneTimestamp) <= now) {
           const expired = await ario.getExpiredArnsRecords(now);
           while (expired.length > 0 && budget.remaining > 0) {
-            const batch = expired.splice(0, batchSize).map((r: any) => r.pubkey);
+            const batch = expired
+              .splice(0, batchSize)
+              .map((r: any) => r.pubkey);
             try {
               await ario.pruneExpiredNames({
                 maxNames: batch.length,
@@ -367,7 +386,9 @@ export class EpochCranker {
         if (cfg && Number(cfg.nextReturnedNamesPruneTimestamp) <= now) {
           const expired = await ario.getExpiredReturnedNames(now);
           while (expired.length > 0 && budget.remaining > 0) {
-            const batch = expired.splice(0, batchSize).map((r: any) => r.pubkey);
+            const batch = expired
+              .splice(0, batchSize)
+              .map((r: any) => r.pubkey);
             try {
               await ario.pruneReturnedNames({
                 maxNames: batch.length,

--- a/src/epoch/errors.test.ts
+++ b/src/epoch/errors.test.ts
@@ -25,7 +25,9 @@ describe('cranker error classification', () => {
     it('extracts hex `custom program error: 0xbbf` (= 3007) form from simulation failures', () => {
       // What we actually see in `[crank:close_observation]` logs when
       // the cranker hits a non-existent Observation PDA.
-      const err = new Error('Transaction simulation failed: custom program error: 0xbbf');
+      const err = new Error(
+        'Transaction simulation failed: custom program error: 0xbbf',
+      );
       expect(parseAnchorErrorCode(err)).to.equal(3007);
     });
 
@@ -103,15 +105,27 @@ describe('cranker error classification', () => {
       // Program owns the slot); 3012 is defensive coverage for
       // zero-data accounts.
       expect(
-        classifyError(new Error('AnchorError ... Error Number: 3007 ... AccountOwnedByWrongProgram')),
+        classifyError(
+          new Error(
+            'AnchorError ... Error Number: 3007 ... AccountOwnedByWrongProgram',
+          ),
+        ),
       ).to.equal('already_done');
       expect(
-        classifyError(new Error('AnchorError ... Error Number: 3012 ... AccountNotInitialized')),
+        classifyError(
+          new Error(
+            'AnchorError ... Error Number: 3012 ... AccountNotInitialized',
+          ),
+        ),
       ).to.equal('already_done');
       // And the simulation-failure hex form that we actually see in
       // close_observation logs:
       expect(
-        classifyError(new Error('Transaction simulation failed: custom program error: 0xbbf')),
+        classifyError(
+          new Error(
+            'Transaction simulation failed: custom program error: 0xbbf',
+          ),
+        ),
       ).to.equal('already_done');
       // And the realistic SolanaError cause chain produced by the SDK
       // when close_observation hits a non-existent PDA:
@@ -164,8 +178,12 @@ describe('cranker error classification', () => {
       expect(
         classifyError(new Error('HTTP error (429): Too Many Requests')),
       ).to.equal('not_ready');
-      expect(classifyError(new Error('Too Many Requests'))).to.equal('not_ready');
-      expect(classifyError(new Error('rate limit exceeded'))).to.equal('not_ready');
+      expect(classifyError(new Error('Too Many Requests'))).to.equal(
+        'not_ready',
+      );
+      expect(classifyError(new Error('rate limit exceeded'))).to.equal(
+        'not_ready',
+      );
       // Also walks the cause chain — RPC error nested in SolanaError
       const inner = new Error('HTTP error (429): Too Many Requests');
       const outer = Object.assign(new Error('Transaction send failed'), {
@@ -175,12 +193,18 @@ describe('cranker error classification', () => {
     });
 
     it('treats RPC-level "already processed" as "already_done"', () => {
-      expect(classifyError(new Error('Transaction already been processed'))).to.equal('already_done');
-      expect(classifyError(new Error('AlreadyProcessed'))).to.equal('already_done');
+      expect(
+        classifyError(new Error('Transaction already been processed')),
+      ).to.equal('already_done');
+      expect(classifyError(new Error('AlreadyProcessed'))).to.equal(
+        'already_done',
+      );
     });
 
     it('falls through to "real" for unrecognised errors', () => {
-      expect(classifyError(new Error('completely unexpected program error'))).to.equal('real');
+      expect(
+        classifyError(new Error('completely unexpected program error')),
+      ).to.equal('real');
     });
   });
 });

--- a/src/epoch/errors.ts
+++ b/src/epoch/errors.ts
@@ -35,8 +35,7 @@ const ALREADY_DONE_ERRORS = new Set<number>([
   //          path where the account exists but has zero data could
   //          surface this. Semantically equivalent to "nothing to
   //          close."
-  3007,
-  3012,
+  3007, 3012,
   // RewardsAlreadyDistributed (variant 37)
   6037,
   // EpochAlreadyExists (variant 41)
@@ -79,7 +78,11 @@ const NOT_READY_ERRORS = new Set<number>([
 function collectErrorText(error: unknown): string {
   const parts: string[] = [];
   let current: unknown = error;
-  for (let depth = 0; current != null && depth < 10; depth++) {
+  for (
+    let depth = 0;
+    current !== undefined && current !== null && depth < 10;
+    depth++
+  ) {
     if (typeof current === 'string') {
       parts.push(current);
       break;
@@ -90,7 +93,7 @@ function collectErrorText(error: unknown): string {
         context?: { logs?: string[]; err?: unknown };
         cause?: unknown;
       };
-      if (e.message) parts.push(e.message);
+      if (e.message !== undefined && e.message !== '') parts.push(e.message);
       if (Array.isArray(e.context?.logs)) parts.push(e.context.logs.join('\n'));
       if (e.context?.err && typeof e.context.err === 'object') {
         // kit packs `{ InstructionError: [idx, {Custom: N}] }` here
@@ -134,7 +137,10 @@ export function classifyError(error: unknown): ErrorCategory {
   // Walk the cause chain so we catch it whether it's at the top-level
   // message or nested inside a `SolanaError`.
   const msg = collectErrorText(error);
-  if (msg.includes('already been processed') || msg.includes('AlreadyProcessed')) {
+  if (
+    msg.includes('already been processed') ||
+    msg.includes('AlreadyProcessed')
+  ) {
     return 'already_done';
   }
 

--- a/src/epochs/solana-epoch-source.test.ts
+++ b/src/epochs/solana-epoch-source.test.ts
@@ -13,7 +13,13 @@ import { SolanaEpochSource } from './solana-epoch-source.js';
 function makeLog(): winston.Logger {
   const noop = sinon.stub();
   return {
-    child: () => ({ verbose: noop, info: noop, warn: noop, error: noop, debug: noop }),
+    child: () => ({
+      verbose: noop,
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+    }),
     verbose: noop,
     info: noop,
     warn: noop,
@@ -88,9 +94,7 @@ describe('SolanaEpochSource', () => {
       expect(p.epochStartTimestamp).to.equal(
         (1_700_000_000 + 17 * 3600) * 1000,
       );
-      expect(p.epochEndTimestamp).to.equal(
-        (1_700_000_000 + 18 * 3600) * 1000,
-      );
+      expect(p.epochEndTimestamp).to.equal((1_700_000_000 + 18 * 3600) * 1000);
       expect(p.epochStartHeight).to.equal(0);
     });
 

--- a/src/epochs/solana-epoch-source.ts
+++ b/src/epochs/solana-epoch-source.ts
@@ -30,10 +30,7 @@ import {
 } from '@solana/kit';
 import type winston from 'winston';
 
-import {
-  deserializeEpochSettingsFull,
-  getEpochSettingsPDA,
-} from '@ar.io/sdk';
+import { deserializeEpochSettingsFull, getEpochSettingsPDA } from '@ar.io/sdk';
 import type {
   EpochSettings,
   EpochTimestampParams,

--- a/src/hosts/solana-hosts-source.test.ts
+++ b/src/hosts/solana-hosts-source.test.ts
@@ -14,7 +14,13 @@ import { SolanaHostsSource } from './solana-hosts-source.js';
 function makeLog(): winston.Logger {
   const noop = sinon.stub();
   return {
-    child: () => ({ verbose: noop, info: noop, warn: noop, error: noop, debug: noop }),
+    child: () => ({
+      verbose: noop,
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+    }),
     verbose: noop,
     info: noop,
     warn: noop,
@@ -34,11 +40,19 @@ describe('SolanaHostsSource', () => {
     const readable = makeReadable([
       {
         gatewayAddress: 'OPERATOR_A',
-        settings: { fqdn: 'gateway-a.example.com', port: 443, protocol: 'https' },
+        settings: {
+          fqdn: 'gateway-a.example.com',
+          port: 443,
+          protocol: 'https',
+        },
       },
       {
         gatewayAddress: 'OPERATOR_B',
-        settings: { fqdn: 'gateway-b.example.com', port: 443, protocol: 'https' },
+        settings: {
+          fqdn: 'gateway-b.example.com',
+          port: 443,
+          protocol: 'https',
+        },
       },
     ]);
     const src = new SolanaHostsSource({ readable, log: makeLog() });

--- a/src/names/solana-names-source.test.ts
+++ b/src/names/solana-names-source.test.ts
@@ -14,7 +14,13 @@ import { SolanaNamesSource } from './solana-names-source.js';
 function makeLog(): winston.Logger {
   const noop = sinon.stub();
   return {
-    child: () => ({ verbose: noop, info: noop, warn: noop, error: noop, debug: noop }),
+    child: () => ({
+      verbose: noop,
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+    }),
     verbose: noop,
     info: noop,
     warn: noop,
@@ -45,10 +51,7 @@ describe('SolanaNamesSource', () => {
     it('walks paginated ArnsRecord results and returns sorted unique names', async () => {
       const stub = sinon.stub();
       stub.onCall(0).resolves({
-        items: [
-          { name: 'turbo' },
-          { name: 'ardrive' },
-        ],
+        items: [{ name: 'turbo' }, { name: 'ardrive' }],
         nextCursor: 'CURSOR_1',
       });
       stub.onCall(1).resolves({
@@ -63,8 +66,14 @@ describe('SolanaNamesSource', () => {
       const names = await src.getAllNames(0);
       expect(names).to.deep.equal(['ardrive', 'permaweb', 'turbo']);
       expect(stub.callCount).to.equal(2);
-      expect(stub.firstCall.args[0]).to.deep.equal({ cursor: undefined, limit: 1000 });
-      expect(stub.secondCall.args[0]).to.deep.equal({ cursor: 'CURSOR_1', limit: 1000 });
+      expect(stub.firstCall.args[0]).to.deep.equal({
+        cursor: undefined,
+        limit: 1000,
+      });
+      expect(stub.secondCall.args[0]).to.deep.equal({
+        cursor: 'CURSOR_1',
+        limit: 1000,
+      });
     });
 
     it('honors a custom page size', async () => {
@@ -76,7 +85,10 @@ describe('SolanaNamesSource', () => {
         pageSize: 250,
       });
       await src.getAllNames(0);
-      expect(stub.firstCall.args[0]).to.deep.equal({ cursor: undefined, limit: 250 });
+      expect(stub.firstCall.args[0]).to.deep.equal({
+        cursor: undefined,
+        limit: 250,
+      });
     });
 
     it('caches results within allNamesCacheTtlMs', async () => {

--- a/src/store/pipeline-report-sink.test.ts
+++ b/src/store/pipeline-report-sink.test.ts
@@ -247,9 +247,7 @@ describe('PipelineReportSink', function () {
 
     it('honors a custom maxGatewayFailureThreshold below the default', async function () {
       // Threshold 0.5 → 60% failure should trip; 50% should pass.
-      const sinks: ReportSinkEntry[] = [
-        { name: 'sink1', sink: mockSink1 },
-      ];
+      const sinks: ReportSinkEntry[] = [{ name: 'sink1', sink: mockSink1 }];
       pipelineReportSink = new PipelineReportSink({
         log: logStub,
         sinks,
@@ -287,9 +285,7 @@ describe('PipelineReportSink', function () {
     });
 
     it('handles an empty gateway-assessments map without crashing (no divide-by-zero)', async function () {
-      const sinks: ReportSinkEntry[] = [
-        { name: 'sink1', sink: mockSink1 },
-      ];
+      const sinks: ReportSinkEntry[] = [{ name: 'sink1', sink: mockSink1 }];
       pipelineReportSink = new PipelineReportSink({ log: logStub, sinks });
       const report = createMockReport(0, 0); // no gateways
       await pipelineReportSink.saveReport({ report });

--- a/src/store/solana-contract-report-sink.test.ts
+++ b/src/store/solana-contract-report-sink.test.ts
@@ -69,7 +69,10 @@ function makeReport(opts: {
   } as any;
 }
 
-function makeReportInfo(report: ObserverReport, reportTxId?: string): ReportInfo {
+function makeReportInfo(
+  report: ObserverReport,
+  reportTxId?: string,
+): ReportInfo {
   return {
     report,
     reportTxId,
@@ -103,10 +106,7 @@ function makeReadable(
 }
 
 /** Build a stub writeable that returns a fake tx signature from saveObservations. */
-function makeWriteable(opts: {
-  txId?: string;
-  throws?: Error;
-}): {
+function makeWriteable(opts: { txId?: string; throws?: Error }): {
   contract: SolanaARIOWriteable;
   saveStub: sinon.SinonStub;
 } {
@@ -145,7 +145,9 @@ describe('SolanaContractReportSink', () => {
         epochIndex: 42,
         failedWallets: ['Failed1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'],
       });
-      const result = await sink.saveReport(makeReportInfo(report, REPORT_TX_ID));
+      const result = await sink.saveReport(
+        makeReportInfo(report, REPORT_TX_ID),
+      );
 
       expect(saveStub.calledOnce).to.equal(true);
       const args = saveStub.firstCall.args[0];
@@ -173,7 +175,9 @@ describe('SolanaContractReportSink', () => {
         observerAddress: OBSERVER_PUBKEY,
       });
       const report = makeReport({ epochIndex: 7, failedWallets: [] });
-      const result = await sink.saveReport(makeReportInfo(report, REPORT_TX_ID));
+      const result = await sink.saveReport(
+        makeReportInfo(report, REPORT_TX_ID),
+      );
       expect(saveStub.calledOnce).to.equal(true);
       expect(saveStub.firstCall.args[0].failedGateways).to.deep.equal([]);
       expect(result.interactionTxIds).to.deep.equal(['SIG_EMPTY']);

--- a/src/store/solana-contract-report-sink.ts
+++ b/src/store/solana-contract-report-sink.ts
@@ -94,7 +94,9 @@ export class SolanaContractReportSink implements ReportSink {
     // can't submit a bogus on-chain tx. The cost is one extra RPC read
     // per submission cycle — negligible compared to the Turbo upload
     // that already preceded us.
-    let status: Awaited<ReturnType<SolanaARIOReadable['getEpochObservationStatus']>>;
+    let status: Awaited<
+      ReturnType<SolanaARIOReadable['getEpochObservationStatus']>
+    >;
     try {
       status = await this.readable.getEpochObservationStatus(
         epochIndex,
@@ -119,14 +121,11 @@ export class SolanaContractReportSink implements ReportSink {
       return reportInfo;
     }
     if (status.alreadyObserved) {
-      this.log.warn(
-        'Observation already submitted for this epoch — skipping',
-        {
-          epochIndex,
-          observer: this.observerAddress,
-          observerIdx: status.observerIdx,
-        },
-      );
+      this.log.warn('Observation already submitted for this epoch — skipping', {
+        epochIndex,
+        observer: this.observerAddress,
+        observerIdx: status.observerIdx,
+      });
       return reportInfo;
     }
     if (!status.windowOpen) {

--- a/src/store/turbo-report-sink.test.ts
+++ b/src/store/turbo-report-sink.test.ts
@@ -47,7 +47,10 @@ describe('signerOwnerAddress', () => {
 
   it('returns base64url(sha256(publicKey)) for a 512-byte (Arweave RSA-4096) pubkey', () => {
     // Use a random-looking but deterministic 512-byte modulus.
-    const pubkey = crypto.createHash('sha512').update('arweave-modulus').digest();
+    const pubkey = crypto
+      .createHash('sha512')
+      .update('arweave-modulus')
+      .digest();
     const modulus = Buffer.concat([pubkey, pubkey, pubkey, pubkey]); // 256 bytes
     const fullModulus = Buffer.concat([modulus, modulus]); // 512 bytes
     const expected = crypto
@@ -75,8 +78,12 @@ describe('signerOwnerAddress', () => {
   });
 
   it('different pubkeys produce different owner addresses', () => {
-    const a = signerOwnerAddress(fakeSigner(Buffer.from('00'.repeat(32), 'hex')));
-    const b = signerOwnerAddress(fakeSigner(Buffer.from('01'.repeat(32), 'hex')));
+    const a = signerOwnerAddress(
+      fakeSigner(Buffer.from('00'.repeat(32), 'hex')),
+    );
+    const b = signerOwnerAddress(
+      fakeSigner(Buffer.from('01'.repeat(32), 'hex')),
+    );
     expect(a).to.not.equal(b);
   });
 });

--- a/src/store/turbo-report-sink.ts
+++ b/src/store/turbo-report-sink.ts
@@ -80,7 +80,6 @@ async function createReportDataItem(signer: Signer, report: ObserverReport) {
  * Exported for unit testing.
  */
 export function signerOwnerAddress(signer: Signer): string {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const pubkey = (signer as any).publicKey as Buffer;
   return crypto
     .createHash('sha256')

--- a/src/system.ts
+++ b/src/system.ts
@@ -152,7 +152,10 @@ let observerAddress: string = config.OBSERVER_WALLET;
 if (!config.SOLANA_RPC_URL) {
   throw new Error('SOLANA_RPC_URL is required');
 }
-if (!config.SOLANA_KEYPAIR_PATH) {
+if (
+  config.SOLANA_KEYPAIR_PATH === undefined ||
+  config.SOLANA_KEYPAIR_PATH === ''
+) {
   throw new Error('SOLANA_KEYPAIR_PATH is required');
 }
 const solanaRpc = createSolanaRpc(config.SOLANA_RPC_URL);
@@ -185,16 +188,20 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
     rpc: solanaRpc,
     rpcSubscriptions: solanaRpcSubscriptions,
     signer: solanaSigner,
-    ...(config.ARIO_CORE_PROGRAM_ID
+    ...(config.ARIO_CORE_PROGRAM_ID !== undefined &&
+    config.ARIO_CORE_PROGRAM_ID !== ''
       ? { coreProgramId: config.ARIO_CORE_PROGRAM_ID as any }
       : {}),
-    ...(config.ARIO_GAR_PROGRAM_ID
+    ...(config.ARIO_GAR_PROGRAM_ID !== undefined &&
+    config.ARIO_GAR_PROGRAM_ID !== ''
       ? { garProgramId: config.ARIO_GAR_PROGRAM_ID as any }
       : {}),
-    ...(config.ARIO_ARNS_PROGRAM_ID
+    ...(config.ARIO_ARNS_PROGRAM_ID !== undefined &&
+    config.ARIO_ARNS_PROGRAM_ID !== ''
       ? { arnsProgramId: config.ARIO_ARNS_PROGRAM_ID as any }
       : {}),
-    ...(config.ARIO_ANT_PROGRAM_ID
+    ...(config.ARIO_ANT_PROGRAM_ID !== undefined &&
+    config.ARIO_ANT_PROGRAM_ID !== ''
       ? { antProgramId: config.ARIO_ANT_PROGRAM_ID as any }
       : {}),
   });
@@ -210,16 +217,20 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
     rpc: solanaRpc,
     rpcSubscriptions: solanaRpcSubscriptions,
     signer: observerSigner,
-    ...(config.ARIO_CORE_PROGRAM_ID
+    ...(config.ARIO_CORE_PROGRAM_ID !== undefined &&
+    config.ARIO_CORE_PROGRAM_ID !== ''
       ? { coreProgramId: config.ARIO_CORE_PROGRAM_ID as any }
       : {}),
-    ...(config.ARIO_GAR_PROGRAM_ID
+    ...(config.ARIO_GAR_PROGRAM_ID !== undefined &&
+    config.ARIO_GAR_PROGRAM_ID !== ''
       ? { garProgramId: config.ARIO_GAR_PROGRAM_ID as any }
       : {}),
-    ...(config.ARIO_ARNS_PROGRAM_ID
+    ...(config.ARIO_ARNS_PROGRAM_ID !== undefined &&
+    config.ARIO_ARNS_PROGRAM_ID !== ''
       ? { arnsProgramId: config.ARIO_ARNS_PROGRAM_ID as any }
       : {}),
-    ...(config.ARIO_ANT_PROGRAM_ID
+    ...(config.ARIO_ANT_PROGRAM_ID !== undefined &&
+    config.ARIO_ANT_PROGRAM_ID !== ''
       ? { antProgramId: config.ARIO_ANT_PROGRAM_ID as any }
       : {}),
   });
@@ -264,7 +275,9 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
   switch (uploadIdentity.mode) {
     case 'arweave':
       bundleSigner = new ArweaveSigner(uploadIdentity.jwk);
-      bundleSignerLabel = await arweave.wallets.jwkToAddress(uploadIdentity.jwk);
+      bundleSignerLabel = await arweave.wallets.jwkToAddress(
+        uploadIdentity.jwk,
+      );
       bundleSignerChain = 'arweave';
       break;
     case 'solana':
@@ -283,7 +296,9 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
       );
       bundleSignerLabel =
         '0x' +
-        Buffer.from((bundleSigner as any).publicKey).toString('hex').slice(-40);
+        Buffer.from((bundleSigner as any).publicKey)
+          .toString('hex')
+          .slice(-40);
       bundleSignerChain = 'ethereum';
       break;
     case 'disabled':
@@ -303,12 +318,18 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
   // Epoch cranking — opt-in via ENABLE_EPOCH_CRANKING=true. Zero overhead
   // when disabled (dynamic import).
   if (config.ENABLE_EPOCH_CRANKING) {
-    if (!config.ARIO_ARNS_PROGRAM_ID) {
+    if (
+      config.ARIO_ARNS_PROGRAM_ID === undefined ||
+      config.ARIO_ARNS_PROGRAM_ID === ''
+    ) {
       throw new Error(
         'ARIO_ARNS_PROGRAM_ID is required when ENABLE_EPOCH_CRANKING=true (needed to derive the NameRegistry PDA for prescribe_epoch).',
       );
     }
-    if (!config.ARIO_GAR_PROGRAM_ID) {
+    if (
+      config.ARIO_GAR_PROGRAM_ID === undefined ||
+      config.ARIO_GAR_PROGRAM_ID === ''
+    ) {
       throw new Error(
         'ARIO_GAR_PROGRAM_ID is required when ENABLE_EPOCH_CRANKING=true (needed to read EpochSettings).',
       );
@@ -344,7 +365,7 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
         const [pda] = await getEpochSettingsPDA(
           config.ARIO_GAR_PROGRAM_ID as any,
         );
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         const account = await fetchEncodedAccount(solanaRpc as any, pda, {
           commitment: 'confirmed',
         });
@@ -381,15 +402,17 @@ const observedGatewayHostList =
         log,
       });
 
-if (!config.ARIO_GAR_PROGRAM_ID) {
+if (
+  config.ARIO_GAR_PROGRAM_ID === undefined ||
+  config.ARIO_GAR_PROGRAM_ID === ''
+) {
   throw new Error(
     'ARIO_GAR_PROGRAM_ID is required (used to derive the EpochSettings PDA).',
   );
 }
 export const epochSource = new SolanaEpochSource({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   rpc: solanaRpc as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   garProgramAddress: config.ARIO_GAR_PROGRAM_ID as any,
   log,
 });
@@ -418,9 +441,9 @@ if (!config.ARIO_GAR_PROGRAM_ID) {
 }
 const sharedEpochEntropySource = new SolanaEpochEntropySource({
   epochSource,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   rpc: solanaRpc as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   garProgramAddress: config.ARIO_GAR_PROGRAM_ID as any,
   log,
 });
@@ -663,7 +686,7 @@ export const contractReportSink = new SolanaContractReportSink({
   log,
   contract: solanaObserverContract,
   readable: solanaObserverContract, // Writeable extends Readable
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   observerAddress: solanaObserverAddress as any,
 });
 
@@ -703,7 +726,7 @@ export const submissionGate =
     ? async (report: ObserverReport) => {
         const status = await solanaObserverContract.getEpochObservationStatus(
           report.epochIndex,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
           solanaObserverAddress as any,
         );
         if (!status.prescribed) {

--- a/src/wallet-config.ts
+++ b/src/wallet-config.ts
@@ -256,7 +256,10 @@ function parseSolanaKeypair(raw: string, path: string): Uint8Array {
   }
   if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
     const keys = Object.keys(parsed as object).slice(0, 5);
-    if ((parsed as any).kty === 'RSA' && typeof (parsed as any).n === 'string') {
+    if (
+      (parsed as any).kty === 'RSA' &&
+      typeof (parsed as any).n === 'string'
+    ) {
       throw new Error(
         `Expected a Solana keypair (64-byte JSON array) at ${path}, found an Arweave RSA JWK ` +
           `(keys: [${keys.join(', ')}]). Did you mean to set ARWEAVE_UPLOAD_KEY_FILE instead?`,
@@ -290,7 +293,9 @@ function parseArweaveJwk(raw: string, origin: string): JWKInterface {
   try {
     parsed = JSON.parse(raw);
   } catch (err: any) {
-    throw new Error(`Failed to parse Arweave JWK from ${origin}: ${err.message}`);
+    throw new Error(
+      `Failed to parse Arweave JWK from ${origin}: ${err.message}`,
+    );
   }
   if (Array.isArray(parsed)) {
     throw new Error(
@@ -336,15 +341,16 @@ export function resolveUploadIdentity(
   fallbackSolanaPath?: string, // observer or operator path, when no explicit upload key
 ): UploadIdentity {
   const arweaveEnvs = [
-    env.ARWEAVE_UPLOAD_KEY_FILE && 'ARWEAVE_UPLOAD_KEY_FILE',
-    env.ARWEAVE_UPLOAD_JWK && 'ARWEAVE_UPLOAD_JWK',
+    Boolean(env.ARWEAVE_UPLOAD_KEY_FILE) && 'ARWEAVE_UPLOAD_KEY_FILE',
+    Boolean(env.ARWEAVE_UPLOAD_JWK) && 'ARWEAVE_UPLOAD_JWK',
   ].filter(Boolean) as string[];
   const ethereumEnvs = [
-    env.ETHEREUM_UPLOAD_PRIVATE_KEY_FILE && 'ETHEREUM_UPLOAD_PRIVATE_KEY_FILE',
-    env.ETHEREUM_UPLOAD_PRIVATE_KEY && 'ETHEREUM_UPLOAD_PRIVATE_KEY',
+    Boolean(env.ETHEREUM_UPLOAD_PRIVATE_KEY_FILE) &&
+      'ETHEREUM_UPLOAD_PRIVATE_KEY_FILE',
+    Boolean(env.ETHEREUM_UPLOAD_PRIVATE_KEY) && 'ETHEREUM_UPLOAD_PRIVATE_KEY',
   ].filter(Boolean) as string[];
   const solanaEnvs = [
-    env.SOLANA_UPLOAD_KEYPAIR_PATH && 'SOLANA_UPLOAD_KEYPAIR_PATH',
+    Boolean(env.SOLANA_UPLOAD_KEYPAIR_PATH) && 'SOLANA_UPLOAD_KEYPAIR_PATH',
   ].filter(Boolean) as string[];
 
   const groups = [
@@ -365,13 +371,19 @@ export function resolveUploadIdentity(
   if (arweaveEnvs.length > 0) {
     if (env.ARWEAVE_UPLOAD_KEY_FILE !== undefined) {
       const raw = loaders.readFile(env.ARWEAVE_UPLOAD_KEY_FILE);
-      const jwk = parseArweaveJwk(raw, `ARWEAVE_UPLOAD_KEY_FILE (${env.ARWEAVE_UPLOAD_KEY_FILE})`);
+      const jwk = parseArweaveJwk(
+        raw,
+        `ARWEAVE_UPLOAD_KEY_FILE (${env.ARWEAVE_UPLOAD_KEY_FILE})`,
+      );
       log.info('Upload identity: Arweave JWK (from file)', {
         path: env.ARWEAVE_UPLOAD_KEY_FILE,
       });
       return { mode: 'arweave', source: 'file', jwk };
     }
-    const jwk = parseArweaveJwk(env.ARWEAVE_UPLOAD_JWK!, 'ARWEAVE_UPLOAD_JWK env');
+    const jwk = parseArweaveJwk(
+      env.ARWEAVE_UPLOAD_JWK!,
+      'ARWEAVE_UPLOAD_JWK env',
+    );
     log.info('Upload identity: Arweave JWK (from env)');
     return { mode: 'arweave', source: 'env', jwk };
   }
@@ -416,9 +428,12 @@ export function resolveUploadIdentity(
   if (fallbackSolanaPath !== undefined) {
     const raw = loaders.readFile(fallbackSolanaPath);
     const secretKey = parseSolanaKeypair(raw, fallbackSolanaPath);
-    log.info('Upload identity: Solana keypair (fallback to observer/operator key)', {
-      path: fallbackSolanaPath,
-    });
+    log.info(
+      'Upload identity: Solana keypair (fallback to observer/operator key)',
+      {
+        path: fallbackSolanaPath,
+      },
+    );
     return {
       mode: 'solana',
       source: 'file',


### PR DESCRIPTION
## Why

`build-and-push.yml` runs `yarn lint:check` as a required matrix job. It has been failing on `develop` since the solana work merged (the observer has no PR-gating CI, so the debt accumulated unnoticed). Net effect: **no Solana observer image has published** since #85 (15+ days), including the merge of #87. This is the blocker for the AO→Solana cutover image.

Reproduce locally: `yarn lint:check` before this PR → **96 problems (88 errors, 8 warnings) across 17 files**.

## What

Restores green `lint:check` with **no runtime behavior change**:

| Class | Count | Fix |
|---|---|---|
| `prettier/prettier` | 67 | `yarn format:fix` |
| `eqeqeq` (`!= null`) | 1 | `!== undefined && !== null` |
| `@typescript-eslint/strict-boolean-expressions` (nullable string) | 18 | explicit `=== undefined`/`!== undefined`/`!== ''` checks |
| `@typescript-eslint/strict-boolean-expressions` (non-nullable object) | 2 | `!== undefined` |

The 21 manual fixes preserve the original "undefined or empty string = unset" semantics:

- `src/system.ts` — 13 nullable program-ID/keypair checks (throw-guards + spread ternaries on the two `SolanaARIOWriteable` blocks).
- `src/wallet-config.ts` — 5 `env.X && 'NAME'` patterns wrapped to satisfy strict-boolean (`&&` does not coerce; `Boolean()` is acceptable here since `no-extra-boolean-cast` only flags it in boolean-coercion contexts like `if`/`?:`).
- `src/epoch/errors.ts` — `current != null` → `current !== undefined && current !== null`; `if (e.message)` → explicit nullish+empty.
- `src/entropy/solana-epoch-entropy-source.ts` — defensive guards for `Address`/`Buffer` array elements (`!== undefined`).

## Validation

- `yarn lint:check` → exit 0 ✅
- `yarn build` (`tsc --project tsconfig.prod.json --noEmit`) → exit 0 ✅
- `mocha --no-warnings` → **331 passing** ✅

## Unblocks

Merge of this PR → push to `develop` → `build-and-push.yml` should reach the `push` job and publish `ghcr.io/ar-io/ar-io-observer:<sha>`, the SHA that the ar-io-node `solana → develop` PR will pin in `docker-compose.yaml` for the cutover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration validation for required keypair and program ID settings to reject empty strings and undefined values.
  * Improved error classification and message handling for clearer error reporting.

* **Refactor**
  * Refined conditional logic for cleaner code structure without behavioral changes.

* **Style**
  * Removed unnecessary ESLint suppression comments.
  * Improved code formatting and readability across configuration and utility modules.

* **Tests**
  * Updated test formatting for improved readability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ar-io/ar-io-observer/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->