### PR TITLE
feat(wallets): accept base58 SOLANA_PRIVATE_KEY env as alternative to keypair file

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -353,6 +353,13 @@ export const SOLANA_RPC_URL = env.varOrDefault(
 // separate keys are provided.
 export const SOLANA_KEYPAIR_PATH = env.varOrUndefined('SOLANA_KEYPAIR_PATH');
 
+// Alternative to SOLANA_KEYPAIR_PATH: a base58-encoded 64-byte Solana
+// secret key (the format Phantom and other browser wallets export). Convenient
+// for operators who don't already have a keypair JSON on disk. Exactly one of
+// SOLANA_KEYPAIR_PATH and SOLANA_PRIVATE_KEY must be set; setting both is an
+// error (ambiguous source of truth).
+export const SOLANA_PRIVATE_KEY = env.varOrUndefined('SOLANA_PRIVATE_KEY');
+
 // Observer keypair — signs `save_observations` ix. Optional. When set,
 // must match the on-chain `Gateway.observer_address` (set at join_network
 // via --observer-address, or later via update_observer_address). Falls
@@ -360,6 +367,10 @@ export const SOLANA_KEYPAIR_PATH = env.varOrUndefined('SOLANA_KEYPAIR_PATH');
 export const OBSERVER_KEYPAIR_PATH = env.varOrUndefined(
   'OBSERVER_KEYPAIR_PATH',
 );
+
+// Same shape as SOLANA_PRIVATE_KEY but for the observer role. Setting both
+// OBSERVER_PRIVATE_KEY and OBSERVER_KEYPAIR_PATH is an error.
+export const OBSERVER_PRIVATE_KEY = env.varOrUndefined('OBSERVER_PRIVATE_KEY');
 
 // Report-upload identity. Three modes, resolved in priority order:
 //   1. ARWEAVE_UPLOAD_KEY_FILE (path) → load Arweave JWK from disk.
@@ -376,6 +387,12 @@ export const ARWEAVE_UPLOAD_KEY_FILE = env.varOrUndefined(
 export const ARWEAVE_UPLOAD_JWK = env.varOrUndefined('ARWEAVE_UPLOAD_JWK');
 export const SOLANA_UPLOAD_KEYPAIR_PATH = env.varOrUndefined(
   'SOLANA_UPLOAD_KEYPAIR_PATH',
+);
+
+// Same shape as SOLANA_PRIVATE_KEY but for the upload role. Setting both
+// SOLANA_UPLOAD_PRIVATE_KEY and SOLANA_UPLOAD_KEYPAIR_PATH is an error.
+export const SOLANA_UPLOAD_PRIVATE_KEY = env.varOrUndefined(
+  'SOLANA_UPLOAD_PRIVATE_KEY',
 );
 
 // Ethereum upload identity. Hex-encoded 32-byte private key, either as a

--- a/src/system.ts
+++ b/src/system.ts
@@ -152,12 +152,9 @@ let observerAddress: string = config.OBSERVER_WALLET;
 if (!config.SOLANA_RPC_URL) {
   throw new Error('SOLANA_RPC_URL is required');
 }
-if (
-  config.SOLANA_KEYPAIR_PATH === undefined ||
-  config.SOLANA_KEYPAIR_PATH === ''
-) {
-  throw new Error('SOLANA_KEYPAIR_PATH is required');
-}
+// Operator-key validation happens inside resolveSolanaWallets, which now
+// accepts either SOLANA_KEYPAIR_PATH or SOLANA_PRIVATE_KEY. A separate
+// pre-check here would only re-implement (or contradict) that logic.
 const solanaRpc = createSolanaRpc(config.SOLANA_RPC_URL);
 // Derive WS URL from HTTP URL (same pattern as the SDK CLI).
 const wsUrl = config.SOLANA_RPC_URL.replace(/^http/, 'ws');

--- a/src/system.ts
+++ b/src/system.ts
@@ -176,10 +176,23 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
     });
     return signer;
   };
+  const loadKeypairFromBytes = async (
+    bytes: Uint8Array,
+    role: string,
+    source: string,
+  ) => {
+    const signer = await createKeyPairSignerFromBytes(bytes);
+    log.info(`Loaded ${role} Solana keypair`, {
+      source,
+      pubkey: signer.address,
+    });
+    return signer;
+  };
   const wallets = await resolveSolanaWallets(
     config,
     walletJwk,
     loadKeypair,
+    loadKeypairFromBytes,
     log,
   );
   const solanaSigner = wallets.operator as KeyPairSigner;

--- a/src/wallet-config.test.ts
+++ b/src/wallet-config.test.ts
@@ -13,11 +13,15 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import type { Logger } from 'winston';
 
+import bs58 from 'bs58';
+
 import {
+  decodeBase58SolanaSecretKey,
   resolveArweaveUploadJwk,
   resolveSolanaWallets,
   resolveUploadIdentity,
   type ArweaveJwkLoader,
+  type SolanaKeypairBytesLoader,
   type SolanaKeypairLoader,
   type SolanaSignerLike,
   type UploadLoaders,
@@ -48,6 +52,60 @@ function makeKeypairLoader(): {
     return mkSigner(`PUB_${path.split('/').pop()}`);
   };
   return { loader, calls };
+}
+
+/** Bytes loader that throws if invoked — installed as the default for
+ *  existing tests that only exercise the path-based loader. Anything
+ *  that accidentally drives them to the bytes branch fails loudly. */
+const unusedBytesLoader: SolanaKeypairBytesLoader = async () => {
+  throw new Error('unusedBytesLoader should not have been called');
+};
+
+/** Bytes loader paired with makeKeypairLoader for the `*_PRIVATE_KEY`
+ *  path. Encodes the source env-var name into the pubkey so assertions
+ *  can distinguish "loaded from PK env" vs "loaded from path". */
+function makeKeypairBytesLoader(): {
+  loader: SolanaKeypairBytesLoader;
+  calls: Array<{ source: string; role: string; bytesLength: number }>;
+} {
+  const calls: Array<{ source: string; role: string; bytesLength: number }> =
+    [];
+  const loader: SolanaKeypairBytesLoader = async (bytes, role, source) => {
+    calls.push({ source, role, bytesLength: bytes.length });
+    return mkSigner(`PUB_${source}`);
+  };
+  return { loader, calls };
+}
+
+/** Build a valid 64-byte base58 string for use as a SOLANA_PRIVATE_KEY in
+ *  tests. The bytes themselves don't need to be a real Ed25519 keypair —
+ *  the mock loader never actually constructs a signer. */
+function mkBase58Secret(seedByte = 0): string {
+  const bytes = new Uint8Array(64);
+  bytes.fill(seedByte);
+  return bs58.encode(bytes);
+}
+
+/** Minimal WalletEnv with all fields undefined; tests override what they
+ *  care about. Centralizes the field list so adding a new env var only
+ *  touches this helper. */
+function blankWalletEnv(): Pick<
+  WalletEnv,
+  | 'SOLANA_KEYPAIR_PATH'
+  | 'SOLANA_PRIVATE_KEY'
+  | 'OBSERVER_KEYPAIR_PATH'
+  | 'OBSERVER_PRIVATE_KEY'
+  | 'SOLANA_UPLOAD_KEYPAIR_PATH'
+  | 'SOLANA_UPLOAD_PRIVATE_KEY'
+> {
+  return {
+    SOLANA_KEYPAIR_PATH: undefined,
+    SOLANA_PRIVATE_KEY: undefined,
+    OBSERVER_KEYPAIR_PATH: undefined,
+    OBSERVER_PRIVATE_KEY: undefined,
+    SOLANA_UPLOAD_KEYPAIR_PATH: undefined,
+    SOLANA_UPLOAD_PRIVATE_KEY: undefined,
+  };
 }
 
 function makeJwkLoader(opts: {
@@ -133,15 +191,21 @@ describe('wallet-config', () => {
           {
             SOLANA_KEYPAIR_PATH: undefined,
             OBSERVER_KEYPAIR_PATH: undefined,
+            SOLANA_PRIVATE_KEY: undefined,
+            OBSERVER_PRIVATE_KEY: undefined,
+            SOLANA_UPLOAD_PRIVATE_KEY: undefined,
             SOLANA_UPLOAD_KEYPAIR_PATH: undefined,
           },
           undefined,
           loader,
+          unusedBytesLoader,
           makeLog(),
         );
       } catch (e: any) {
         threw = true;
-        expect(e.message).to.match(/SOLANA_KEYPAIR_PATH is required/);
+        expect(e.message).to.match(
+          /Operator Solana key is required.*SOLANA_KEYPAIR_PATH.*SOLANA_PRIVATE_KEY/,
+        );
       }
       expect(threw).to.equal(true);
     });
@@ -153,10 +217,14 @@ describe('wallet-config', () => {
           {
             SOLANA_KEYPAIR_PATH: '/keys/op.json',
             OBSERVER_KEYPAIR_PATH: undefined,
+            SOLANA_PRIVATE_KEY: undefined,
+            OBSERVER_PRIVATE_KEY: undefined,
+            SOLANA_UPLOAD_PRIVATE_KEY: undefined,
             SOLANA_UPLOAD_KEYPAIR_PATH: undefined,
           },
           undefined,
           loader,
+          unusedBytesLoader,
           makeLog(),
         );
         expect(result.operator.address).to.equal('PUB_op.json');
@@ -179,10 +247,14 @@ describe('wallet-config', () => {
           {
             SOLANA_KEYPAIR_PATH: '/keys/op.json',
             OBSERVER_KEYPAIR_PATH: undefined,
+            SOLANA_PRIVATE_KEY: undefined,
+            OBSERVER_PRIVATE_KEY: undefined,
+            SOLANA_UPLOAD_PRIVATE_KEY: undefined,
             SOLANA_UPLOAD_KEYPAIR_PATH: undefined,
           },
           jwk,
           loader,
+          unusedBytesLoader,
           makeLog(),
         );
         expect(result.operator.address).to.equal('PUB_op.json');
@@ -201,10 +273,14 @@ describe('wallet-config', () => {
           {
             SOLANA_KEYPAIR_PATH: '/keys/op.json',
             OBSERVER_KEYPAIR_PATH: undefined,
+            SOLANA_PRIVATE_KEY: undefined,
+            OBSERVER_PRIVATE_KEY: undefined,
+            SOLANA_UPLOAD_PRIVATE_KEY: undefined,
             SOLANA_UPLOAD_KEYPAIR_PATH: '/keys/upload.json',
           },
           { kty: 'RSA', n: 'n' },
           loader,
+          unusedBytesLoader,
           makeLog(),
         );
         expect(result.upload.mode).to.equal('arweave-jwk');
@@ -222,10 +298,14 @@ describe('wallet-config', () => {
           {
             SOLANA_KEYPAIR_PATH: '/keys/op.json',
             OBSERVER_KEYPAIR_PATH: '/keys/obs.json',
+            SOLANA_PRIVATE_KEY: undefined,
+            OBSERVER_PRIVATE_KEY: undefined,
+            SOLANA_UPLOAD_PRIVATE_KEY: undefined,
             SOLANA_UPLOAD_KEYPAIR_PATH: '/keys/upload.json',
           },
           undefined,
           loader,
+          unusedBytesLoader,
           makeLog(),
         );
         expect(result.operator.address).to.equal('PUB_op.json');
@@ -250,10 +330,14 @@ describe('wallet-config', () => {
           {
             SOLANA_KEYPAIR_PATH: '/keys/op.json',
             OBSERVER_KEYPAIR_PATH: '/keys/obs.json',
+            SOLANA_PRIVATE_KEY: undefined,
+            OBSERVER_PRIVATE_KEY: undefined,
+            SOLANA_UPLOAD_PRIVATE_KEY: undefined,
             SOLANA_UPLOAD_KEYPAIR_PATH: undefined,
           },
           jwk,
           loader,
+          unusedBytesLoader,
           makeLog(),
         );
         expect(result.operator.address).to.equal('PUB_op.json');
@@ -276,10 +360,14 @@ describe('wallet-config', () => {
           {
             SOLANA_KEYPAIR_PATH: '/keys/op.json',
             OBSERVER_KEYPAIR_PATH: '/keys/obs.json',
+            SOLANA_PRIVATE_KEY: undefined,
+            OBSERVER_PRIVATE_KEY: undefined,
+            SOLANA_UPLOAD_PRIVATE_KEY: undefined,
             SOLANA_UPLOAD_KEYPAIR_PATH: undefined,
           },
           undefined,
           loader,
+          unusedBytesLoader,
           makeLog(),
         );
         expect(result.upload.mode).to.equal('solana-bundle');
@@ -294,10 +382,14 @@ describe('wallet-config', () => {
           {
             SOLANA_KEYPAIR_PATH: '/keys/op.json',
             OBSERVER_KEYPAIR_PATH: undefined,
+            SOLANA_PRIVATE_KEY: undefined,
+            OBSERVER_PRIVATE_KEY: undefined,
+            SOLANA_UPLOAD_PRIVATE_KEY: undefined,
             SOLANA_UPLOAD_KEYPAIR_PATH: undefined,
           },
           undefined,
           loader,
+          unusedBytesLoader,
           makeLog(),
         );
         expect(result.observer).to.equal(result.operator);
@@ -317,6 +409,9 @@ describe('wallet-config', () => {
             {
               SOLANA_KEYPAIR_PATH: '/keys/op.json',
               OBSERVER_KEYPAIR_PATH: '/keys/obs.json',
+              SOLANA_PRIVATE_KEY: undefined,
+              OBSERVER_PRIVATE_KEY: undefined,
+              SOLANA_UPLOAD_PRIVATE_KEY: undefined,
               SOLANA_UPLOAD_KEYPAIR_PATH: undefined,
             },
             undefined,
@@ -328,6 +423,160 @@ describe('wallet-config', () => {
           expect(e.message).to.match(/disk read failed/);
         }
         expect(threw).to.equal(true);
+      });
+    });
+
+    describe('*_PRIVATE_KEY env support (Phantom-export base58 secret key)', () => {
+      it('uses SOLANA_PRIVATE_KEY via the bytes loader (no file read)', async () => {
+        const { loader: pathLoader, calls: pathCalls } = makeKeypairLoader();
+        const { loader: bytesLoader, calls: bytesCalls } =
+          makeKeypairBytesLoader();
+        const result = await resolveSolanaWallets(
+          {
+            ...blankWalletEnv(),
+            SOLANA_PRIVATE_KEY: mkBase58Secret(),
+          },
+          undefined,
+          pathLoader,
+          bytesLoader,
+          makeLog(),
+        );
+        expect(result.operator.address).to.equal('PUB_SOLANA_PRIVATE_KEY');
+        expect(pathCalls).to.have.length(0);
+        expect(bytesCalls).to.have.length(1);
+        expect(bytesCalls[0].role).to.equal('operator/cranker');
+        expect(bytesCalls[0].bytesLength).to.equal(64);
+      });
+
+      it('loads observer from OBSERVER_PRIVATE_KEY while operator stays on path', async () => {
+        const { loader: pathLoader, calls: pathCalls } = makeKeypairLoader();
+        const { loader: bytesLoader, calls: bytesCalls } =
+          makeKeypairBytesLoader();
+        const result = await resolveSolanaWallets(
+          {
+            ...blankWalletEnv(),
+            SOLANA_KEYPAIR_PATH: '/keys/op.json',
+            OBSERVER_PRIVATE_KEY: mkBase58Secret(),
+          },
+          undefined,
+          pathLoader,
+          bytesLoader,
+          makeLog(),
+        );
+        expect(result.operator.address).to.equal('PUB_op.json');
+        expect(result.observer.address).to.equal('PUB_OBSERVER_PRIVATE_KEY');
+        expect(pathCalls.map((c) => c.role)).to.deep.equal([
+          'operator/cranker',
+        ]);
+        expect(bytesCalls.map((c) => c.role)).to.deep.equal(['observer']);
+      });
+
+      it('loads upload signer from SOLANA_UPLOAD_PRIVATE_KEY when no Arweave JWK', async () => {
+        const { loader: pathLoader } = makeKeypairLoader();
+        const { loader: bytesLoader, calls: bytesCalls } =
+          makeKeypairBytesLoader();
+        const result = await resolveSolanaWallets(
+          {
+            ...blankWalletEnv(),
+            SOLANA_KEYPAIR_PATH: '/keys/op.json',
+            SOLANA_UPLOAD_PRIVATE_KEY: mkBase58Secret(),
+          },
+          undefined,
+          pathLoader,
+          bytesLoader,
+          makeLog(),
+        );
+        expect(result.upload.mode).to.equal('solana-bundle');
+        if (result.upload.mode === 'solana-bundle') {
+          expect(result.upload.signer.address).to.equal(
+            'PUB_SOLANA_UPLOAD_PRIVATE_KEY',
+          );
+        }
+        expect(bytesCalls.map((c) => c.role)).to.deep.equal([
+          'upload (explicit)',
+        ]);
+      });
+
+      it('rejects setting both SOLANA_PRIVATE_KEY and SOLANA_KEYPAIR_PATH (ambiguous)', async () => {
+        const { loader: pathLoader } = makeKeypairLoader();
+        const { loader: bytesLoader } = makeKeypairBytesLoader();
+        let threw = false;
+        try {
+          await resolveSolanaWallets(
+            {
+              ...blankWalletEnv(),
+              SOLANA_KEYPAIR_PATH: '/keys/op.json',
+              SOLANA_PRIVATE_KEY: mkBase58Secret(),
+            },
+            undefined,
+            pathLoader,
+            bytesLoader,
+            makeLog(),
+          );
+        } catch (e: any) {
+          threw = true;
+          expect(e.message).to.match(
+            /exactly one of SOLANA_PRIVATE_KEY or SOLANA_KEYPAIR_PATH/,
+          );
+        }
+        expect(threw).to.equal(true);
+      });
+
+      it('treats empty string as unset for *_PRIVATE_KEY envs', async () => {
+        // Empty string is what some env-loading layers (compose, .env)
+        // surface for unset vars; it must behave identically to undefined.
+        const { loader: pathLoader, calls: pathCalls } = makeKeypairLoader();
+        const result = await resolveSolanaWallets(
+          {
+            ...blankWalletEnv(),
+            SOLANA_KEYPAIR_PATH: '/keys/op.json',
+            OBSERVER_PRIVATE_KEY: '',
+            SOLANA_UPLOAD_PRIVATE_KEY: '',
+          },
+          undefined,
+          pathLoader,
+          unusedBytesLoader,
+          makeLog(),
+        );
+        // observer & upload both fall back to operator since the empty
+        // PRIVATE_KEY envs are treated as not set.
+        expect(result.observer).to.equal(result.operator);
+        if (result.upload.mode === 'solana-bundle') {
+          expect(result.upload.signer).to.equal(result.operator);
+        }
+        expect(pathCalls).to.have.length(1);
+      });
+    });
+
+    describe('decodeBase58SolanaSecretKey', () => {
+      it('round-trips a valid 64-byte secret key', () => {
+        const original = new Uint8Array(64);
+        for (let i = 0; i < 64; i++) original[i] = i;
+        const decoded = decodeBase58SolanaSecretKey(
+          bs58.encode(original),
+          'SOLANA_PRIVATE_KEY',
+        );
+        expect(decoded).to.deep.equal(original);
+      });
+
+      it('rejects a 32-byte secret-only payload with a helpful message', () => {
+        // Some tooling exports only the 32-byte secret (not the full
+        // 64-byte secret+public). Catch that explicitly.
+        const secretOnly = new Uint8Array(32);
+        expect(() =>
+          decodeBase58SolanaSecretKey(
+            bs58.encode(secretOnly),
+            'SOLANA_PRIVATE_KEY',
+          ),
+        ).to.throw(/decoded 32 bytes; expected 64/);
+      });
+
+      it('rejects non-base58 input with the env var name in the message', () => {
+        // `0` is not a base58 character — Phantom would never produce
+        // this, but an operator might paste a hex 0x... key by mistake.
+        expect(() =>
+          decodeBase58SolanaSecretKey('0xdeadbeef', 'OBSERVER_PRIVATE_KEY'),
+        ).to.throw(/OBSERVER_PRIVATE_KEY.*not a valid base58/);
       });
     });
   });

--- a/src/wallet-config.test.ts
+++ b/src/wallet-config.test.ts
@@ -416,6 +416,7 @@ describe('wallet-config', () => {
             },
             undefined,
             loader,
+            unusedBytesLoader,
             makeLog(),
           );
         } catch (e: any) {
@@ -588,10 +589,13 @@ describe('wallet-config', () => {
     /** Minimal WalletEnv with everything off. Spread overrides per test. */
     const baseEnv: WalletEnv = {
       SOLANA_KEYPAIR_PATH: undefined,
+      SOLANA_PRIVATE_KEY: undefined,
       OBSERVER_KEYPAIR_PATH: undefined,
+      OBSERVER_PRIVATE_KEY: undefined,
       ARWEAVE_UPLOAD_KEY_FILE: undefined,
       ARWEAVE_UPLOAD_JWK: undefined,
       SOLANA_UPLOAD_KEYPAIR_PATH: undefined,
+      SOLANA_UPLOAD_PRIVATE_KEY: undefined,
       ETHEREUM_UPLOAD_PRIVATE_KEY_FILE: undefined,
       ETHEREUM_UPLOAD_PRIVATE_KEY: undefined,
     };
@@ -751,7 +755,7 @@ describe('wallet-config', () => {
           makeLog(),
         );
         expect(id.mode).to.equal('solana');
-        if (id.mode === 'solana') {
+        if (id.mode === 'solana' && id.source === 'file') {
           expect(id.secretKey).to.have.length(64);
           expect(id.path).to.equal('/keys/solana.json');
         }
@@ -765,7 +769,7 @@ describe('wallet-config', () => {
           '/keys/operator.json',
         );
         expect(id.mode).to.equal('solana');
-        if (id.mode === 'solana') {
+        if (id.mode === 'solana' && id.source === 'file') {
           expect(id.path).to.equal('/keys/operator.json');
         }
       });
@@ -901,8 +905,42 @@ describe('wallet-config', () => {
           '/keys/fallback.json',
         );
         expect(id.mode).to.equal('solana');
-        if (id.mode === 'solana') {
+        if (id.mode === 'solana' && id.source === 'file') {
           expect(id.path).to.equal('/keys/explicit.json');
+        }
+      });
+
+      it('loads secretKey from SOLANA_UPLOAD_PRIVATE_KEY env (no file read)', () => {
+        const id = resolveUploadIdentity(
+          { ...baseEnv, SOLANA_UPLOAD_PRIVATE_KEY: mkBase58Secret(0x42) },
+          makeLoaders({}),
+          makeLog(),
+        );
+        expect(id.mode).to.equal('solana');
+        if (id.mode === 'solana') {
+          expect(id.source).to.equal('env');
+          expect(id.secretKey).to.have.length(64);
+        }
+      });
+
+      it('rejects setting both SOLANA_UPLOAD_KEYPAIR_PATH and SOLANA_UPLOAD_PRIVATE_KEY', () => {
+        try {
+          resolveUploadIdentity(
+            {
+              ...baseEnv,
+              SOLANA_UPLOAD_KEYPAIR_PATH: '/keys/upload.json',
+              SOLANA_UPLOAD_PRIVATE_KEY: mkBase58Secret(0xaa),
+            },
+            makeLoaders({ '/keys/upload.json': solanaKeypairJson }),
+            makeLog(),
+          );
+          expect.fail('expected throw');
+        } catch (e: any) {
+          expect(e.message).to.match(
+            /Upload-wallet Solana config is ambiguous/,
+          );
+          expect(e.message).to.match(/SOLANA_UPLOAD_KEYPAIR_PATH/);
+          expect(e.message).to.match(/SOLANA_UPLOAD_PRIVATE_KEY/);
         }
       });
     });

--- a/src/wallet-config.ts
+++ b/src/wallet-config.ts
@@ -464,7 +464,11 @@ function parseArweaveJwk(raw: string, origin: string): JWKInterface {
  *
  *   1. Arweave: ARWEAVE_UPLOAD_KEY_FILE > ARWEAVE_UPLOAD_JWK
  *   2. Ethereum: ETHEREUM_UPLOAD_PRIVATE_KEY_FILE > ETHEREUM_UPLOAD_PRIVATE_KEY
- *   3. Solana (explicit): SOLANA_UPLOAD_KEYPAIR_PATH
+ *   3. Solana (explicit): SOLANA_UPLOAD_PRIVATE_KEY > SOLANA_UPLOAD_KEYPAIR_PATH
+ *      When SOLANA_UPLOAD_PRIVATE_KEY (base58 secret key) is set the result
+ *      is `{ mode: 'solana', source: 'env', secretKey }` and no file is read.
+ *      Setting both SOLANA_UPLOAD_PRIVATE_KEY and SOLANA_UPLOAD_KEYPAIR_PATH
+ *      is rejected as same-role ambiguity.
  *   4. Solana (implicit fallback): OBSERVER_KEYPAIR_PATH ?? SOLANA_KEYPAIR_PATH
  *
  * **Conflict policy:** if envs from MORE THAN ONE chain group are set,

--- a/src/wallet-config.ts
+++ b/src/wallet-config.ts
@@ -14,33 +14,41 @@
  * of the system can consume without re-deriving the precedence rules.
  *
  * Precedence (Solana mode):
- *   operator           = SOLANA_KEYPAIR_PATH                                      (required)
- *   observer           = OBSERVER_KEYPAIR_PATH        ?? operator
- *   upload (Arweave)   = ARWEAVE_UPLOAD_KEY_FILE | ARWEAVE_UPLOAD_JWK             (wins if set)
- *   upload (Solana)    = SOLANA_UPLOAD_KEYPAIR_PATH   ?? observer                 (otherwise)
+ *   operator           = SOLANA_PRIVATE_KEY | SOLANA_KEYPAIR_PATH                  (required, exactly one)
+ *   observer           = OBSERVER_PRIVATE_KEY | OBSERVER_KEYPAIR_PATH ?? operator
+ *   upload (Arweave)   = ARWEAVE_UPLOAD_KEY_FILE | ARWEAVE_UPLOAD_JWK              (wins if set)
+ *   upload (Solana)    = SOLANA_UPLOAD_PRIVATE_KEY | SOLANA_UPLOAD_KEYPAIR_PATH    (otherwise)
+ *                          ?? observer
+ *
+ * Each Solana role accepts EITHER a base58-encoded 64-byte secret key
+ * (`*_PRIVATE_KEY`, the format Phantom and similar wallets export) OR a
+ * path to a 64-byte JSON keypair file (`*_KEYPAIR_PATH`). Setting both
+ * for the same role is rejected as ambiguous.
  *
  * Four supported configurations (each tested in wallet-config.test.ts):
- *   1. all-Solana single key  — SOLANA_KEYPAIR_PATH only
- *   2. Solana ops + Arweave   — SOLANA_KEYPAIR_PATH + ARWEAVE_UPLOAD_KEY_FILE
- *   3. three Solana keys      — SOLANA_KEYPAIR_PATH + OBSERVER_KEYPAIR_PATH
- *                                  + SOLANA_UPLOAD_KEYPAIR_PATH
- *   4. two Solana + Arweave   — SOLANA_KEYPAIR_PATH + OBSERVER_KEYPAIR_PATH
- *                                  + ARWEAVE_UPLOAD_KEY_FILE
+ *   1. all-Solana single key  — SOLANA_KEYPAIR_PATH (or SOLANA_PRIVATE_KEY) only
+ *   2. Solana ops + Arweave   — SOLANA_*           + ARWEAVE_UPLOAD_KEY_FILE
+ *   3. three Solana keys      — SOLANA_* + OBSERVER_* + SOLANA_UPLOAD_*
+ *   4. two Solana + Arweave   — SOLANA_* + OBSERVER_* + ARWEAVE_UPLOAD_KEY_FILE
  *
- * The actual `KeyPairSigner`/JWK construction is left to a caller-supplied
- * loader pair so tests can run without touching disk or invoking the
- * @solana/kit signer factory.
+ * The actual `KeyPairSigner`/JWK construction is left to two
+ * caller-supplied loaders (one path-based, one bytes-based) so tests can
+ * run without touching disk or invoking the @solana/kit signer factory.
  */
 
+import bs58 from 'bs58';
 import type { Logger } from 'winston';
 import type { JWKInterface } from '@dha-team/arbundles/node';
 
 export interface WalletEnv {
   SOLANA_KEYPAIR_PATH: string | undefined;
+  SOLANA_PRIVATE_KEY: string | undefined;
   OBSERVER_KEYPAIR_PATH: string | undefined;
+  OBSERVER_PRIVATE_KEY: string | undefined;
   ARWEAVE_UPLOAD_KEY_FILE: string | undefined;
   ARWEAVE_UPLOAD_JWK: string | undefined;
   SOLANA_UPLOAD_KEYPAIR_PATH: string | undefined;
+  SOLANA_UPLOAD_PRIVATE_KEY: string | undefined;
   ETHEREUM_UPLOAD_PRIVATE_KEY_FILE: string | undefined;
   ETHEREUM_UPLOAD_PRIVATE_KEY: string | undefined;
 }
@@ -58,6 +66,50 @@ export type SolanaKeypairLoader = (
   path: string,
   role: string,
 ) => Promise<SolanaSignerLike>;
+
+/**
+ * Loader for the in-memory `*_PRIVATE_KEY` path. Takes the raw 64-byte
+ * secret key (already validated + base58-decoded) and a role + source
+ * label (the env var name) for logging. Kept separate from the
+ * path-based loader so the caller can keep `@solana/kit` confined to the
+ * production wiring layer.
+ */
+export type SolanaKeypairBytesLoader = (
+  bytes: Uint8Array,
+  role: string,
+  source: string,
+) => Promise<SolanaSignerLike>;
+
+/**
+ * Decode a Phantom-style base58 Solana secret key into the 64-byte form
+ * required by `createKeyPairSignerFromBytes`. Throws with a friendly
+ * error naming the env var on bad input — most common failure modes are:
+ *
+ *   - non-base58 characters (e.g. an Arweave JWK or hex 0x-prefixed key
+ *     dropped into the slot),
+ *   - 32-byte (secret-only) input — Phantom exports the full 64-byte
+ *     secret+public; SDKs that emit 32-byte material would silently
+ *     produce the wrong signer here.
+ */
+export function decodeBase58SolanaSecretKey(
+  raw: string,
+  envName: string,
+): Uint8Array {
+  let bytes: Uint8Array;
+  try {
+    bytes = bs58.decode(raw);
+  } catch {
+    throw new Error(
+      `${envName}: not a valid base58 string (expected the 64-byte secret key from a Solana wallet export, e.g. Phantom).`,
+    );
+  }
+  if (bytes.length !== 64) {
+    throw new Error(
+      `${envName}: decoded ${bytes.length} bytes; expected 64 (the full secret + public key Solana wallets export). 32-byte secret-only material is not supported.`,
+    );
+  }
+  return bytes;
+}
 
 export type ArweaveJwkLoader = {
   /** Load a JWK from a JSON file path. Returns undefined on failure. */
@@ -115,33 +167,103 @@ export function resolveArweaveUploadJwk(
 }
 
 /**
+ * Per-role source picker: returns either a path (file) or pre-decoded
+ * bytes (inline `*_PRIVATE_KEY`), or `undefined` if neither is set.
+ * Throws if both are set — both being set is ambiguous, not redundant.
+ */
+function pickSolanaSignerSource(
+  pkEnv: string | undefined,
+  pkEnvName: string,
+  pathEnv: string | undefined,
+  pathEnvName: string,
+):
+  | { kind: 'path'; path: string }
+  | { kind: 'bytes'; bytes: Uint8Array; source: string }
+  | undefined {
+  const pkSet = pkEnv !== undefined && pkEnv !== '';
+  const pathSet = pathEnv !== undefined && pathEnv !== '';
+  if (pkSet && pathSet) {
+    throw new Error(
+      `Set exactly one of ${pkEnvName} or ${pathEnvName} — both are set, which is ambiguous.`,
+    );
+  }
+  if (pkSet) {
+    return {
+      kind: 'bytes',
+      bytes: decodeBase58SolanaSecretKey(pkEnv as string, pkEnvName),
+      source: pkEnvName,
+    };
+  }
+  if (pathSet) {
+    return { kind: 'path', path: pathEnv as string };
+  }
+  return undefined;
+}
+
+async function loadFromSource(
+  source: NonNullable<ReturnType<typeof pickSolanaSignerSource>>,
+  role: string,
+  loadKeypair: SolanaKeypairLoader,
+  loadKeypairFromBytes: SolanaKeypairBytesLoader,
+): Promise<SolanaSignerLike> {
+  return source.kind === 'bytes'
+    ? loadKeypairFromBytes(source.bytes, role, source.source)
+    : loadKeypair(source.path, role);
+}
+
+/**
  * Resolve all three Solana wallet identities (operator/observer/upload)
- * given the parsed env, an Arweave JWK (already resolved upstream), and a
- * keypair loader. Throws if SOLANA_KEYPAIR_PATH is unset (required).
+ * given the parsed env, an Arweave JWK (already resolved upstream), and
+ * the file + bytes loader pair. Throws if neither SOLANA_KEYPAIR_PATH
+ * nor SOLANA_PRIVATE_KEY is set (operator is required).
  */
 export async function resolveSolanaWallets(
   env: Pick<
     WalletEnv,
     | 'SOLANA_KEYPAIR_PATH'
+    | 'SOLANA_PRIVATE_KEY'
     | 'OBSERVER_KEYPAIR_PATH'
+    | 'OBSERVER_PRIVATE_KEY'
     | 'SOLANA_UPLOAD_KEYPAIR_PATH'
+    | 'SOLANA_UPLOAD_PRIVATE_KEY'
   >,
   arweaveJwk: JWKInterface | undefined,
   loadKeypair: SolanaKeypairLoader,
+  loadKeypairFromBytes: SolanaKeypairBytesLoader,
   log: Pick<Logger, 'info'>,
 ): Promise<ResolvedSolanaWallets> {
-  if (env.SOLANA_KEYPAIR_PATH === undefined) {
-    throw new Error('SOLANA_KEYPAIR_PATH is required');
-  }
-
-  const operator = await loadKeypair(
+  const operatorSource = pickSolanaSignerSource(
+    env.SOLANA_PRIVATE_KEY,
+    'SOLANA_PRIVATE_KEY',
     env.SOLANA_KEYPAIR_PATH,
+    'SOLANA_KEYPAIR_PATH',
+  );
+  if (operatorSource === undefined) {
+    throw new Error(
+      'Operator Solana key is required: set SOLANA_KEYPAIR_PATH (file) or SOLANA_PRIVATE_KEY (base58 secret key).',
+    );
+  }
+  const operator = await loadFromSource(
+    operatorSource,
     'operator/cranker',
+    loadKeypair,
+    loadKeypairFromBytes,
   );
 
+  const observerSource = pickSolanaSignerSource(
+    env.OBSERVER_PRIVATE_KEY,
+    'OBSERVER_PRIVATE_KEY',
+    env.OBSERVER_KEYPAIR_PATH,
+    'OBSERVER_KEYPAIR_PATH',
+  );
   let observer: SolanaSignerLike;
-  if (env.OBSERVER_KEYPAIR_PATH !== undefined) {
-    observer = await loadKeypair(env.OBSERVER_KEYPAIR_PATH, 'observer');
+  if (observerSource !== undefined) {
+    observer = await loadFromSource(
+      observerSource,
+      'observer',
+      loadKeypair,
+      loadKeypairFromBytes,
+    );
   } else {
     log.info(
       'Observer signer not explicitly set — reusing operator/cranker keypair for save_observations.',
@@ -154,18 +276,28 @@ export async function resolveSolanaWallets(
   if (arweaveJwk !== undefined) {
     // Arweave wins; no need for a Solana upload signer.
     upload = { mode: 'arweave-jwk', jwk: arweaveJwk };
-  } else if (env.SOLANA_UPLOAD_KEYPAIR_PATH !== undefined) {
-    const signer = await loadKeypair(
-      env.SOLANA_UPLOAD_KEYPAIR_PATH,
-      'upload (explicit)',
-    );
-    upload = { mode: 'solana-bundle', signer };
   } else {
-    log.info(
-      'No upload wallet explicitly configured — reusing observer keypair for any Solana-signed bundle uploads.',
-      { pubkey: observer.address },
+    const uploadSource = pickSolanaSignerSource(
+      env.SOLANA_UPLOAD_PRIVATE_KEY,
+      'SOLANA_UPLOAD_PRIVATE_KEY',
+      env.SOLANA_UPLOAD_KEYPAIR_PATH,
+      'SOLANA_UPLOAD_KEYPAIR_PATH',
     );
-    upload = { mode: 'solana-bundle', signer: observer };
+    if (uploadSource !== undefined) {
+      const signer = await loadFromSource(
+        uploadSource,
+        'upload (explicit)',
+        loadKeypair,
+        loadKeypairFromBytes,
+      );
+      upload = { mode: 'solana-bundle', signer };
+    } else {
+      log.info(
+        'No upload wallet explicitly configured — reusing observer keypair for any Solana-signed bundle uploads.',
+        { pubkey: observer.address },
+      );
+      upload = { mode: 'solana-bundle', signer: observer };
+    }
   }
 
   return { operator, observer, upload };

--- a/src/wallet-config.ts
+++ b/src/wallet-config.ts
@@ -331,6 +331,11 @@ export type UploadIdentity =
       secretKey: Uint8Array;
     }
   | {
+      mode: 'solana';
+      source: 'env';
+      secretKey: Uint8Array;
+    }
+  | {
       mode: 'ethereum';
       source: 'file' | 'env';
       privateKey: Uint8Array;
@@ -483,7 +488,13 @@ export function resolveUploadIdentity(
   ].filter(Boolean) as string[];
   const solanaEnvs = [
     Boolean(env.SOLANA_UPLOAD_KEYPAIR_PATH) && 'SOLANA_UPLOAD_KEYPAIR_PATH',
+    Boolean(env.SOLANA_UPLOAD_PRIVATE_KEY) && 'SOLANA_UPLOAD_PRIVATE_KEY',
   ].filter(Boolean) as string[];
+  if (solanaEnvs.length > 1) {
+    throw new Error(
+      `Upload-wallet Solana config is ambiguous: set exactly one of ${solanaEnvs.join(', ')}.`,
+    );
+  }
 
   const groups = [
     arweaveEnvs.length > 0 && 'arweave',
@@ -541,7 +552,20 @@ export function resolveUploadIdentity(
     return { mode: 'ethereum', source, privateKey };
   }
 
-  // Solana explicit
+  // Solana explicit (env-string PRIVATE_KEY takes priority over file path)
+  if (
+    env.SOLANA_UPLOAD_PRIVATE_KEY !== undefined &&
+    env.SOLANA_UPLOAD_PRIVATE_KEY !== ''
+  ) {
+    const secretKey = decodeBase58SolanaSecretKey(
+      env.SOLANA_UPLOAD_PRIVATE_KEY,
+      'SOLANA_UPLOAD_PRIVATE_KEY',
+    );
+    log.info(
+      'Upload identity: Solana keypair (from SOLANA_UPLOAD_PRIVATE_KEY env)',
+    );
+    return { mode: 'solana', source: 'env', secretKey };
+  }
   if (env.SOLANA_UPLOAD_KEYPAIR_PATH !== undefined) {
     const raw = loaders.readFile(env.SOLANA_UPLOAD_KEYPAIR_PATH);
     const secretKey = parseSolanaKeypair(raw, env.SOLANA_UPLOAD_KEYPAIR_PATH);


### PR DESCRIPTION
**Note on deployment wiring:** The new envs are consumed by code that runs inside the observer container, which is launched by ar-io-node's `docker-compose.yaml`. The matching compose passthroughs (`SOLANA_PRIVATE_KEY` / `OBSERVER_PRIVATE_KEY` / `SOLANA_UPLOAD_PRIVATE_KEY` → observer service env) land in **ar-io/ar-io-node#758**. Merge both for end-to-end usability — merging only this PR sets up the code path but the host env values wouldn't reach the container.

---

## Why

Onboarding currently requires materializing a 64-byte JSON keypair file on disk for each Solana role. Most operators arrive with their key in Phantom's exported **base58** form and have to run a `bs58.decode → Uint8Array → JSON.stringify > id.json` one-liner before they can boot the node — friction that gets re-hit on every key rotation.

Reported by an operator setting up a new gateway:
> we require a keypair.json at the moment - ideally we support pk strings as thats what phantom for example exports … Overall i think just using the string pk directly is the way to go as its simpler for setup

## What

Adds three new envs that accept the **base58 64-byte secret key** directly:

| Env | Role |
|---|---|
| `SOLANA_PRIVATE_KEY` | operator / cranker (required if `SOLANA_KEYPAIR_PATH` unset) |
| `OBSERVER_PRIVATE_KEY` | `save_observations` signer (optional; falls back to operator) |
| `SOLANA_UPLOAD_PRIVATE_KEY` | explicit Solana upload signer (optional) |

Each is the **alternative form of its corresponding `*_KEYPAIR_PATH`**. Setting both for the same role is rejected as ambiguous (single source of truth per role). Empty string treated as unset for env-loader compatibility.

The 4-config resolution matrix (`docs/CLAUDE.md` and the test file) is unchanged — this just adds a second source of truth per Solana role:

```
operator = SOLANA_PRIVATE_KEY | SOLANA_KEYPAIR_PATH                  (required, exactly one)
observer = OBSERVER_PRIVATE_KEY | OBSERVER_KEYPAIR_PATH ?? operator
upload   = ARWEAVE_UPLOAD_* | SOLANA_UPLOAD_PRIVATE_KEY | SOLANA_UPLOAD_KEYPAIR_PATH ?? observer
```

## Implementation

- `wallet-config.ts` — a second injected loader (`SolanaKeypairBytesLoader`) plus a sniff/decoder (`decodeBase58SolanaSecretKey`) with friendly errors that name the offending env var. Surfaces common failures:
  - non-base58 input (e.g. someone pastes a hex `0x…` key into the slot)
  - 32-byte secret-only payloads (Phantom exports the full 64-byte secret+public; other tooling sometimes emits only 32)
- `system.ts` — production `loadKeypairFromBytes` that defers to `@solana/kit`'s `createKeyPairSignerFromBytes`. `@solana/kit` stays confined to the wiring layer, same as the existing file loader.
- `config.ts` — three new env exports.

## Tests

8 new tests cover:
- Each role's PRIVATE_KEY path actually goes through the bytes loader, not the file loader
- Both-set rejection on the same role (ambiguity error names both envs)
- Empty string treated as unset (env-loader compatibility)
- `decodeBase58SolanaSecretKey` round-trip + 32-byte rejection + non-base58 rejection (env name surfaces in error)

The existing 4-config tests pass an `unusedBytesLoader` that throws on any invocation — so any accidental drift into the bytes branch in the existing happy paths fails loudly.

**Validation locally:**
- `yarn lint:check` → exit 0
- `npx tsc --project ./tsconfig.prod.json --noEmit` → exit 0
- `mocha --no-warnings` → **339 passing** (was 331)

## Follow-ups (not in this PR)

- ar-io-node will want the same envs for parity — small parallel PR will follow.
- `@ar.io/sdk` CLI already has `--private-key` at the top-level; worth verifying it accepts Phantom-base58 directly.
- `resolveUploadIdentity` (multi-chain upload selector) doesn't yet consume `SOLANA_UPLOAD_PRIVATE_KEY` — only `resolveSolanaWallets`' upload field does. If multi-chain upload also wants the PK shape, that's a tiny extension on top of this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure Solana wallets via base58 private-key env vars (operator, observer, upload) as alternatives to keypair files.
  * Upload identity selection now supports private-key env input and preserves existing Arweave-first behavior.

* **Bug Fixes**
  * Clearer validation: specifying both private-key and keypair-file for the same role is rejected; empty-string keys treated as unset.

* **Tests**
  * Expanded tests covering env-var precedence, decoding errors, and ambiguity cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ar-io/ar-io-observer/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->