### PR TITLE
feat(info): expose Solana programIds on /ar-io/observer/info

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -18,6 +18,18 @@ components:
     ReportSink:
       type: string
       nullable: true
+    SolanaProgramId:
+      type: string
+      nullable: true
+      description: Base58-encoded Solana program ID (32-44 chars). `null`/omitted when the corresponding ARIO_*_PROGRAM_ID env is unset.
+    SolanaProgramIds:
+      type: object
+      description: Identifiers of the four ARIO Solana programs this observer is configured against. Mirrors `programIds` exposed by `ar-io-node`'s `/ar-io/info`. Unset fields are omitted from the response.
+      properties:
+        core: { '$ref': '#/components/schemas/SolanaProgramId' }
+        gar:  { '$ref': '#/components/schemas/SolanaProgramId' }
+        arns: { '$ref': '#/components/schemas/SolanaProgramId' }
+        ant:  { '$ref': '#/components/schemas/SolanaProgramId' }
     DataHash:
       type: string
       nullable: true
@@ -36,9 +48,9 @@ components:
        message: { type: string }
     Info:
      type: object
-     properties: 
+     properties:
        wallet: { '$ref': '#/components/schemas/ArweaveWallet' }
-       processId: { '$ref': '#/components/schemas/ArweaveId' }
+       programIds: { '$ref': '#/components/schemas/SolanaProgramIds' }
        reportSink: { '$ref': '#/components/schemas/ReportSink' }
     OwnershipAssessment:
       type: object

--- a/src/server.ts
+++ b/src/server.ts
@@ -80,8 +80,18 @@ app.get('/ar-io/observer/healthcheck', async (_req, res) => {
 });
 
 app.get('/ar-io/observer/info', (_req, res) => {
+  // Mirrors the ar-io-node `/ar-io/info` shape so operators can
+  // cross-check that the gateway and its observer are pointed at the
+  // same Solana network. Undefined IDs are omitted by JSON.stringify,
+  // so unset fields drop out of the response automatically.
   res.status(200).send({
     wallet: walletAddress,
+    programIds: {
+      core: config.ARIO_CORE_PROGRAM_ID,
+      gar: config.ARIO_GAR_PROGRAM_ID,
+      arns: config.ARIO_ARNS_PROGRAM_ID,
+      ant: config.ARIO_ANT_PROGRAM_ID,
+    },
     reportSink: config.REPORT_DATA_SINK,
   });
 });


### PR DESCRIPTION
## Why

The pre-Solana `/ar-io/observer/info` carried an AO `processId` field that identified the network. After the AO→Solana cutover that field disappeared (no AO process) and nothing replaced it — leaving operators no programmatic way to confirm an observer is pointed at the same Solana network as the gateway it's paired with.

Before this PR:
```json
{"wallet":"3imVBaMThy…","reportSink":"turbo"}
```

After:
```json
{
  "wallet": "3imVBaMThy…",
  "programIds": {
    "core": "5iU1xZ4o…",
    "gar":  "KpZMWCMe…",
    "arns": "2YjqZEYT…",
    "ant":  "9SuQQKKW…"
  },
  "reportSink": "turbo"
}
```

The shape **exactly mirrors what `ar-io-node`'s `/ar-io/info` already exposes** (verified against a live gateway today), so cross-checking is a single field equality.

## What

- `src/server.ts` — `/ar-io/observer/info` handler returns a `programIds` object built from the existing `config.ARIO_{CORE,GAR,ARNS,ANT}_PROGRAM_ID` exports. Unset IDs are omitted from the response automatically (`JSON.stringify` drops `undefined` properties), so an observer running with only a subset configured surfaces only what's set — no `null` clutter.
- `docs/openapi.yaml` — `Info` schema swaps the legacy `processId` field for `programIds`; new `SolanaProgramId` / `SolanaProgramIds` schemas documenting the shape and the "unset → omitted" semantics.

## Validation

- `yarn lint:check` → exit 0
- `npx tsc --project tsconfig.prod.json --noEmit` → exit 0
- `mocha --no-warnings` → **331 passing**, 0 fail

## Companion PRs (separate, already up)

- ar-io/ar-io-observer#89 — base58 `*_PRIVATE_KEY` envs for the operator/observer/upload roles.
- ar-io/ar-io-node#758 — base58 `OBSERVER_PRIVATE_KEY` env for HTTPSIG signing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API specification to include new Solana program ID schemas
  * Modified `/ar-io/observer/info` endpoint response to include program IDs for core, gar, arns, and ant configurations, replacing the previous process ID field

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ar-io/ar-io-observer/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->