### PR TITLE
fix(epoch-cranker): SDK→solana.29 cold-start fix + floor 3007 cleanup noise

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "4.0.0-solana.26",
+    "@ar.io/sdk": "4.0.0-solana.29",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/src/epoch/epoch-cranker.test.ts
+++ b/src/epoch/epoch-cranker.test.ts
@@ -16,7 +16,7 @@ import { EpochCranker, type EpochCrankerConfig } from './epoch-cranker.js';
  * Solana. The cleanup loop used to fire `close_observation` at
  * `currentEpochIndex - retention - 1` — which lands in that never-existed
  * range — for every registry observer, producing N guaranteed
- * AccountNotInitialized (3007) misses per cycle (the RPC-429 noise floor).
+ * AccountOwnedByWrongProgram (3007) misses per cycle (the RPC-429 noise floor).
  *
  * These tests prove the floor: cleanup never attempts close_observation at
  * an epoch index below the lowest epoch that actually exists, and it

--- a/src/epoch/epoch-cranker.test.ts
+++ b/src/epoch/epoch-cranker.test.ts
@@ -1,0 +1,188 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { expect } from 'chai';
+
+import { EpochCranker, type EpochCrankerConfig } from './epoch-cranker.js';
+
+/**
+ * Tests for the cleanup continuity floor (Phase 4 close_observation).
+ *
+ * After the AO→Solana cutover the network jumped `current_epoch_index`
+ * straight to the AO-continuity value (~454) with NO epochs 0..453 on
+ * Solana. The cleanup loop used to fire `close_observation` at
+ * `currentEpochIndex - retention - 1` — which lands in that never-existed
+ * range — for every registry observer, producing N guaranteed
+ * AccountNotInitialized (3007) misses per cycle (the RPC-429 noise floor).
+ *
+ * These tests prove the floor: cleanup never attempts close_observation at
+ * an epoch index below the lowest epoch that actually exists, and it
+ * eliminates the wasted RPC calls rather than swallowing the error.
+ */
+
+const noopLog: EpochCrankerConfig['log'] = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  verbose: () => undefined,
+};
+
+interface MockCounters {
+  getEpochRawCalls: number[];
+  closeObservationCalls: Array<{ epochIndex: number; observer: string }>;
+}
+
+/**
+ * Build an EpochCranker whose `contract` is a stub that no-ops every
+ * cleanup phase except Phase 4, and whose `getEpochRaw` existence is
+ * controlled by `existingEpochs`.
+ */
+function makeCranker(opts: {
+  existingEpochs: Set<number>;
+  observerAddrs: string[];
+  epochRetention?: number;
+}): { cranker: EpochCranker; counters: MockCounters } {
+  const counters: MockCounters = {
+    getEpochRawCalls: [],
+    closeObservationCalls: [],
+  };
+
+  const contract: any = {
+    // Phase 1/2 — gate off via a far-future prune timestamp.
+    getArnsConfigRaw: async () => ({
+      nextRecordsPruneTimestamp: Number.MAX_SAFE_INTEGER,
+      nextReturnedNamesPruneTimestamp: Number.MAX_SAFE_INTEGER,
+    }),
+    getExpiredArnsRecords: async () => [],
+    getExpiredReturnedNames: async () => [],
+    // Phase 3
+    getDeficientGateways: async () => [],
+    getGoneGateways: async () => [],
+    // Phase 4 — the unit under test.
+    getEpochRaw: async (epochIndex: number) => {
+      counters.getEpochRawCalls.push(epochIndex);
+      return opts.existingEpochs.has(epochIndex)
+        ? { rewardsDistributed: 1 }
+        : null;
+    },
+    getRegistryGatewayAddresses: async () => opts.observerAddrs,
+    closeObservation: async (p: { epochIndex: number; observer: string }) => {
+      counters.closeObservationCalls.push({
+        epochIndex: p.epochIndex,
+        observer: p.observer,
+      });
+      // Simulate the on-chain 3007 when the PDA was never initialized.
+      if (!opts.existingEpochs.has(p.epochIndex)) {
+        throw new Error(
+          'AnchorError ... Error Number: 3007 ... AccountOwnedByWrongProgram',
+        );
+      }
+      return { id: 'sig' };
+    },
+    // Phase 5/6/7
+    getEmptyDelegations: async () => [],
+    getDrainedWithdrawals: async () => [],
+    getExpiredPrimaryNameRequests: async () => [],
+    reclaimLookupTableRent: async () => ({
+      deactivated: 0,
+      closed: 0,
+      candidates: 0,
+    }),
+  };
+
+  const config: EpochCrankerConfig = {
+    contract: contract as any,
+    rpc: {} as any,
+    signer: {} as any,
+    pollIntervalMs: 1000,
+    batchSize: 18,
+    closeEpochs: true,
+    epochRetention: opts.epochRetention ?? 7,
+    log: noopLog,
+    getEpochSettings: async () => ({
+      currentEpochIndex: 0,
+      genesisTimestamp: 0,
+      epochDuration: 0,
+      enabled: true,
+    }),
+  };
+
+  return { cranker: new EpochCranker(config), counters };
+}
+
+// Reach the private runCleanup directly — it's the unit under test and is
+// otherwise only reachable through the throttled, settings-gated runCycle.
+function runCleanup(cranker: EpochCranker, currentEpochIndex: number) {
+  return (cranker as any).runCleanup(currentEpochIndex);
+}
+
+describe('EpochCranker cleanup continuity floor', () => {
+  it('does NOT call close_observation when the target epoch never existed (continuity gap)', async () => {
+    // Continuity cutover: currentEpochIndex 454, NO epochs exist yet.
+    // closeTarget = 454 - 7 - 1 = 446, which never existed on-chain.
+    const { cranker, counters } = makeCranker({
+      existingEpochs: new Set(),
+      observerAddrs: ['obsA', 'obsB', 'obsC'],
+    });
+
+    await runCleanup(cranker, 454);
+
+    // The whole observer fan-out is skipped — zero wasted tx-simulations.
+    expect(counters.closeObservationCalls).to.have.length(0);
+    // Exactly ONE cheap existence probe replaces N closeObservation calls.
+    expect(counters.getEpochRawCalls).to.deep.equal([446]);
+  });
+
+  it('caches the floor so subsequent cycles skip even the existence probe', async () => {
+    const { cranker, counters } = makeCranker({
+      existingEpochs: new Set(),
+      observerAddrs: ['obsA', 'obsB'],
+    });
+
+    // First cycle discovers the floor (probes once).
+    await runCleanup(cranker, 454);
+    expect(counters.getEpochRawCalls).to.deep.equal([446]);
+
+    // Second cycle at the same index: closeTarget (446) < cached floor (447),
+    // so we short-circuit with NO RPC at all.
+    await runCleanup(cranker, 454);
+    expect(counters.getEpochRawCalls).to.deep.equal([446]); // unchanged
+    expect(counters.closeObservationCalls).to.have.length(0);
+  });
+
+  it('DOES call close_observation for every observer once the target epoch exists', async () => {
+    // Healthy steady state: closeTarget = 470 - 7 - 1 = 462 exists on-chain.
+    const { cranker, counters } = makeCranker({
+      existingEpochs: new Set([462]),
+      observerAddrs: ['obsA', 'obsB', 'obsC'],
+    });
+
+    await runCleanup(cranker, 470);
+
+    // Retention semantics preserved: one close_observation per observer at
+    // the (existing) close target.
+    expect(counters.getEpochRawCalls).to.deep.equal([462]);
+    expect(counters.closeObservationCalls).to.deep.equal([
+      { epochIndex: 462, observer: 'obsA' },
+      { epochIndex: 462, observer: 'obsB' },
+      { epochIndex: 462, observer: 'obsC' },
+    ]);
+  });
+
+  it('skips Phase 4 entirely when currentEpochIndex is within the retention window', async () => {
+    // currentEpochIndex (5) < retention + 1 (8): no close target yet.
+    const { cranker, counters } = makeCranker({
+      existingEpochs: new Set(),
+      observerAddrs: ['obsA'],
+    });
+
+    await runCleanup(cranker, 5);
+
+    expect(counters.getEpochRawCalls).to.have.length(0);
+    expect(counters.closeObservationCalls).to.have.length(0);
+  });
+});

--- a/src/epoch/epoch-cranker.ts
+++ b/src/epoch/epoch-cranker.ts
@@ -113,7 +113,8 @@ export class EpochCranker {
    * close-observation target with `getEpochRaw`) and cached so we never
    * walk the registry firing `close_observation` at epochs that can't
    * hold any Observation PDA — every such call is a guaranteed
-   * AccountNotInitialized (3007) miss, and at registry scale that's
+   * AccountOwnedByWrongProgram (3007) miss (the never-created PDA is still
+   * SystemProgram-owned), and at registry scale that's
    * hundreds of wasted RPC tx-simulations per cycle (the 3007 noise
    * floor that trips RPC 429s). `null` = not yet discovered.
    */
@@ -374,7 +375,7 @@ export class EpochCranker {
     // jumped straight to ~454 with NO epochs 0..453 on-chain. closeTarget
     // (`currentEpochIndex - retention - 1`) lands in that never-existed range
     // for a long time, so firing `close_observation` at it for every registry
-    // observer is N guaranteed AccountNotInitialized (3007) misses per cycle —
+    // observer is N guaranteed AccountOwnedByWrongProgram (3007) misses per cycle —
     // the noise floor that trips RPC 429s. We floor closeTarget to the lowest
     // epoch that actually exists: skip the whole loop (no RPC) when closeTarget
     // is below a discovered floor, and discover that floor with ONE cheap

--- a/src/epoch/epoch-cranker.ts
+++ b/src/epoch/epoch-cranker.ts
@@ -103,6 +103,21 @@ export class EpochCranker {
    * minutes-to-hours timescale, polling more often is wasted RPC.
    */
   private lastCleanupRunMs = 0;
+  /**
+   * Lowest epoch index that has ever existed on-chain (the AO→Solana
+   * continuity floor). Epochs below this were NEVER created on Solana:
+   * at enablement `admin_set_current_epoch_index` jumped the counter
+   * straight to the AO-continuity value (~454) and the SDK cold start
+   * created `epoch[currentIndex]` — epochs 0..currentIndex-1 have no
+   * account on-chain. Discovered lazily by `runCleanup` (probe the
+   * close-observation target with `getEpochRaw`) and cached so we never
+   * walk the registry firing `close_observation` at epochs that can't
+   * hold any Observation PDA — every such call is a guaranteed
+   * AccountNotInitialized (3007) miss, and at registry scale that's
+   * hundreds of wasted RPC tx-simulations per cycle (the 3007 noise
+   * floor that trips RPC 429s). `null` = not yet discovered.
+   */
+  private firstExistingEpochIndex: number | null = null;
 
   constructor(config: EpochCrankerConfig) {
     this.config = config;
@@ -354,27 +369,83 @@ export class EpochCranker {
     // Anyone NOT in the current registry won't be found, but observers are
     // gateways so coverage should be reasonable. closeObservation no-ops on
     // missing PDAs (Anchor returns AccountNotInitialized).
+    //
+    // CONTINUITY FLOOR: after the AO→Solana cutover, `current_epoch_index`
+    // jumped straight to ~454 with NO epochs 0..453 on-chain. closeTarget
+    // (`currentEpochIndex - retention - 1`) lands in that never-existed range
+    // for a long time, so firing `close_observation` at it for every registry
+    // observer is N guaranteed AccountNotInitialized (3007) misses per cycle —
+    // the noise floor that trips RPC 429s. We floor closeTarget to the lowest
+    // epoch that actually exists: skip the whole loop (no RPC) when closeTarget
+    // is below a discovered floor, and discover that floor with ONE cheap
+    // `getEpochRaw` read (replacing N wasted closeObservation tx-simulations).
     const retention = this.config.epochRetention ?? 7;
     if (budget.remaining > 0 && currentEpochIndex >= retention + 1) {
       try {
-        const observerAddrs = await ario.getRegistryGatewayAddresses?.();
         // Walk the prior `retention` window (older epochs are candidates,
         // newer ones may still be referenced). One epoch per cycle keeps the
         // search bounded.
         const closeTarget = currentEpochIndex - retention - 1;
-        if (Array.isArray(observerAddrs)) {
-          for (const observer of observerAddrs) {
-            if (budget.remaining <= 0) break;
-            try {
-              await ario.closeObservation({
-                epochIndex: closeTarget,
-                observer,
-              });
-              budget.remaining--;
-            } catch (err) {
-              // Most calls miss (no obs PDA for that observer/epoch). Don't spam.
-              const cat = this.handleError(err, 'close_observation');
-              if (cat === 'real') break;
+
+        // Floor check 1 (no RPC): a previously-discovered floor already tells
+        // us closeTarget never existed on-chain. Skip without touching the RPC.
+        if (
+          this.firstExistingEpochIndex !== null &&
+          closeTarget < this.firstExistingEpochIndex
+        ) {
+          log.debug('Skipping close_observation below continuity floor', {
+            closeTarget,
+            firstExistingEpochIndex: this.firstExistingEpochIndex,
+          });
+        } else {
+          // Floor check 2 (one cheap account read): does the close-target
+          // epoch account even exist? `getEpochRaw` returns null for epochs
+          // that were never created (the continuity gap). No epoch account ⇒
+          // no Observation PDAs keyed on it ⇒ nothing to close. Record the
+          // floor so subsequent cycles short-circuit at check 1 above.
+          const targetEpoch = await ario.getEpochRaw?.(closeTarget);
+          if (targetEpoch === null || targetEpoch === undefined) {
+            // closeTarget never existed. The real floor is somewhere above it;
+            // remember closeTarget+1 as a conservative lower bound so we stop
+            // re-probing this index every cycle while currentEpochIndex creeps
+            // up. (Once enough epochs accrue that closeTarget >= the genuine
+            // first epoch, this read will succeed and we proceed below.)
+            this.firstExistingEpochIndex = Math.max(
+              this.firstExistingEpochIndex ?? 0,
+              closeTarget + 1,
+            );
+            log.debug(
+              'close_observation target epoch never existed; skipping',
+              {
+                closeTarget,
+                firstExistingEpochIndex: this.firstExistingEpochIndex,
+              },
+            );
+          } else {
+            // closeTarget exists → it's at or above the continuity floor.
+            // Pin the floor here so we never probe below it again.
+            if (
+              this.firstExistingEpochIndex === null ||
+              closeTarget < this.firstExistingEpochIndex
+            ) {
+              this.firstExistingEpochIndex = closeTarget;
+            }
+            const observerAddrs = await ario.getRegistryGatewayAddresses?.();
+            if (Array.isArray(observerAddrs)) {
+              for (const observer of observerAddrs) {
+                if (budget.remaining <= 0) break;
+                try {
+                  await ario.closeObservation({
+                    epochIndex: closeTarget,
+                    observer,
+                  });
+                  budget.remaining--;
+                } catch (err) {
+                  // Most calls miss (no obs PDA for that observer/epoch). Don't spam.
+                  const cat = this.handleError(err, 'close_observation');
+                  if (cat === 'real') break;
+                }
+              }
             }
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@4.0.0-solana.26":
-  version "4.0.0-solana.26"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.0-solana.26.tgz#7699e87ee6f060364332a39bbfb24862959552c2"
-  integrity sha512-15MaIRpv0ShlQE3BYh0hV+Fl6BqCuXX4EJiH0AqCjNd5MXX9RJBPJUO0Jth6VxaJrWltkpmRPh0L4zlwRcpoRA==
+"@ar.io/sdk@4.0.0-solana.29":
+  version "4.0.0-solana.29"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.0-solana.29.tgz#86d9d832c3ad9c614474644395a3a1b46ac39885"
+  integrity sha512-EOtbjFtnEO7gR8qkXM+1sSc+nexgjrWkvWvEkzPnBtZ7lmP1I4mtgHtuajx1XyfUzNyTqeHeg5KkFGyiYFv1YQ==
   dependencies:
     "@ar.io/solana-contracts" "0.5.0-staging.15"
     "@solana-program/address-lookup-table" "^0.11.0"


### PR DESCRIPTION
Two related fixes for the AO→Solana epoch-continuity cutover (the network enables at `current_epoch_index ≈ 454` with no prior epochs on-chain).

## 1. Bump `@ar.io/sdk` 4.0.0-solana.26 → .29
Picks up the `crankEpochStep` **cold-start fix** (ar-io-sdk #654): when the live epoch (`currentIndex-1`) is missing at a continuity cold start, the SDK now creates `epoch[currentIndex]` instead of idling `waiting_for_epoch` forever. Verified the fix is present in the installed `lib/esm/solana/io-writeable.js`.

## 2. Floor the Phase-4 observation cleanup at the continuity epoch
`runCleanup` Phase 4 computed `closeTarget = currentEpochIndex - retention - 1` (~446) and fanned `closeObservation` out to **every** registry observer each cycle. Post-cutover, epochs 0–453 never existed on Solana, so each call is a guaranteed Anchor **3007 (AccountNotInitialized)** miss — classified `already_done` and silently burning RPC simulations (~464 errors/30min on a live gateway, tripping 429s).

Fix: cache `firstExistingEpochIndex`; skip with **zero RPC** below the known floor; otherwise probe `getEpochRaw(closeTarget)` **once** and skip the whole observer fan-out if the epoch never existed (else pin the floor and run the close loop). Eliminates the wasted calls rather than swallowing the errors. Retention semantics for real epochs are unchanged. Adds `epoch-cranker.test.ts` (4 cases). **346 tests pass.**

## Reviewer notes
- `yarn.lock` kept in **v1 (classic)** format — the env's Yarn Berry tried to convert it; please confirm `yarn install --frozen-lockfile` on the yarn-classic toolchain.
- There is a **pre-existing** `src/tracing.ts` OpenTelemetry transitive-dep build error on `develop` (unrelated to this change; `tsc --noEmit` is clean). Flagging so a red `yarn build` job isn't mistaken for this PR.
- The standalone `ar-io-cranker` has the identical Phase-4 bug — fixed in a parallel PR to keep the two in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@ar.io/sdk` dependency to version `4.0.0-solana.29`

* **Tests**
  * Added comprehensive test coverage for epoch cleanup operations, validating epoch existence checks and observation closure behavior across multiple scenarios

* **Bug Fixes**
  * Improved epoch cleanup efficiency with state caching to reduce redundant operations on non-existent epochs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->