### PR TITLE
feat(epoch-cranker): let crankEpochStep own returned-name pruning (SDK solana.37)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.0.0-solana.33",
+    "@ar.io/sdk": "^4.0.0-solana.37",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/src/epoch/epoch-cranker.ts
+++ b/src/epoch/epoch-cranker.ts
@@ -212,6 +212,11 @@ export class EpochCranker {
         enableClose: this.config.closeEpochs,
         epochRetention: this.config.epochRetention ?? 7,
         nameRegistryAccount: this.config.nameRegistryAccount,
+        // Returned-name pruning is folded into the epoch step (solana.36+):
+        // tie it to the same cleanup config the runCleanup phases use.
+        enablePrune: this.config.enableCleanup !== false,
+        pruneBatchSize: this.config.cleanupBatchSize,
+        pruneScanIntervalMs: this.config.cleanupMinIntervalMs,
       });
       action = result.action;
       if (result.action === 'idle') {
@@ -297,33 +302,11 @@ export class EpochCranker {
       }
     }
 
-    // Phase 2: ArNS expired returned names — gated on `next_returned_names_prune_timestamp`.
-    if (budget.remaining > 0) {
-      try {
-        const cfg = await ario.getArnsConfigRaw();
-        if (cfg && Number(cfg.nextReturnedNamesPruneTimestamp) <= now) {
-          const expired = await ario.getExpiredReturnedNames(now);
-          while (expired.length > 0 && budget.remaining > 0) {
-            const batch = expired
-              .splice(0, batchSize)
-              .map((r: any) => r.pubkey);
-            try {
-              await ario.pruneReturnedNames({
-                maxNames: batch.length,
-                returnedNames: batch,
-              });
-              budget.remaining--;
-              log.info('Pruned expired ReturnedNames', { count: batch.length });
-            } catch (err) {
-              this.handleError(err, 'prune_returned_names');
-              break;
-            }
-          }
-        }
-      } catch (err) {
-        this.handleError(err, 'cleanup_returned_names_scan');
-      }
-    }
+    // Phase 2: ArNS expired returned names — now owned by `crankEpochStep`
+    // (@ar.io/sdk ≥ solana.36). It scans the ReturnedName PDAs directly in the
+    // epoch step's idle exits, WITHOUT the stale `next_returned_names_prune_timestamp`
+    // gate that stranded imported returned names. Removed from runCleanup so
+    // there's a single source of truth — see the crankEpochStep call in runCycle.
 
     // Phase 3: Deficient gateways → prune_gateway, plus Gone gateways → finalize_gone.
     if (budget.remaining > 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,12 +23,13 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.0.0-solana.33":
-  version "4.0.0-solana.33"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.0-solana.33.tgz#8de648e2dbce9646a477f2fcb77ecfb7ccfad982"
-  integrity sha512-CMLgrtcjgSA4ANbpsiHTLspWj/W1qrfm15XYvXQLrk2BbTnXJjMeo6EepjkMFITvP5RG0CMFCJeSVQ+P1gPRZw==
+"@ar.io/sdk@^4.0.0-solana.37":
+  version "4.0.0-solana.38"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.0-solana.38.tgz#5251996acc911c855d7077e438d90187cdd5fb8e"
+  integrity sha512-bJ376RwgX/qZkVEQ3gP7Q0kg5Uo0+ieWAttsaW+rMLMFqXikSW2+t2ghpSrKeRsZv6jATyDO6AoAeZ5luqy+xQ==
   dependencies:
     "@ar.io/solana-contracts" "0.7.0-staging.17"
+    "@noble/hashes" "^1.8.0"
     "@solana-program/address-lookup-table" "^0.11.0"
     "@solana-program/compute-budget" "^0.15.0"
     "@solana-program/token" "^0.13.0"
@@ -996,7 +997,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.1.tgz#5738f6d765710921e7a751e00c20ae091ed8db0f"
   integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
 
-"@noble/hashes@^1.5.0":
+"@noble/hashes@^1.5.0", "@noble/hashes@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==


### PR DESCRIPTION
`@ar.io/sdk` solana.36+ folds expired-`ReturnedName` pruning into `crankEpochStep` (ar-io/ar-io-sdk#662). It scans the `ReturnedName` PDAs **directly** in the epoch step's idle exits, **without** the stale `next_returned_names_prune_timestamp` gate that stranded imported returned names.

**The bug it fixes:** on staging-v2, 22 expired returned-name auctions (e.g. `mymail`) never pruned because the gate sat at `2026-06-17` while the names were due now — so they lingered on the "recently returned" list and blocked `buy_name`.

## Changes
- Bump `@ar.io/sdk` → `^4.0.0-solana.37` (lockfile regenerated **yarn-classic v1**, not Berry).
- Pass `enablePrune` / `pruneBatchSize` / `pruneScanIntervalMs` through to `crankEpochStep`, tied to the existing cleanup config (`ENABLE_CLEANUP` / `CLEANUP_BATCH_SIZE` / `CLEANUP_MIN_INTERVAL_MS`).
- **Remove the hand-rolled returned-names phase** from `runCleanup` — `crankEpochStep` is now the single source of truth. Records + gateway cleanup stay in `runCleanup` for now.

## Validation
`tsc -p tsconfig.prod.json` clean (0 errors); **346 tests pass**; lint + build green. The underlying prune was already validated live on staging-v2 (22 names cleared, list 101 → 79). Keep in sync with the standalone `ar-io-cranker` (companion change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK dependency from version 4.0.0-solana.33 to 4.0.0-solana.37.

* **Refactor**
  * Streamlined epoch cleanup operations by delegating returned-name pruning to the SDK layer, consolidating pruning controls and reducing cleanup workflow complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->