### PR TITLE
fix(epoch-cranker): only finalize_gone chain-eligible gateways

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.0.0",
+    "@ar.io/sdk": "4.0.2-alpha.8",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/src/epoch/epoch-cranker.test.ts
+++ b/src/epoch/epoch-cranker.test.ts
@@ -62,6 +62,7 @@ function makeCranker(opts: {
     // Phase 3
     getDeficientGateways: async () => [],
     getGoneGateways: async () => [],
+    getFinalizableGoneGateways: async () => [],
     // Phase 4 — the unit under test.
     getEpochRaw: async (epochIndex: number) => {
       counters.getEpochRawCalls.push(epochIndex);

--- a/src/epoch/epoch-cranker.test.ts
+++ b/src/epoch/epoch-cranker.test.ts
@@ -61,7 +61,6 @@ function makeCranker(opts: {
     getExpiredReturnedNames: async () => [],
     // Phase 3
     getDeficientGateways: async () => [],
-    getGoneGateways: async () => [],
     getFinalizableGoneGateways: async () => [],
     // Phase 4 — the unit under test.
     getEpochRaw: async (epochIndex: number) => {

--- a/src/epoch/epoch-cranker.ts
+++ b/src/epoch/epoch-cranker.ts
@@ -331,7 +331,14 @@ export class EpochCranker {
     }
     if (budget.remaining > 0) {
       try {
-        const gone = await ario.getGoneGateways();
+        // Only gateways whose leave window has elapsed AND have no remaining
+        // delegated stake are actually finalize_gone-able. getGoneGateways()
+        // over-returns every Leaving gateway, so finalizing per result reverts
+        // (LeaveWindowNotExpired / 6079) on every not-yet-eligible one each
+        // cycle — pure noise. getFinalizableGoneGateways(now) pre-filters to the
+        // on-chain eligibility conditions. Requires @ar.io/sdk with
+        // ar-io/ar-io-sdk#685.
+        const gone = await ario.getFinalizableGoneGateways(now);
         for (const g of gone) {
           if (budget.remaining <= 0) break;
           try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,12 +23,12 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.0.tgz#15e189f81f18a4be911cfefe5db2bed8e35eae37"
-  integrity sha512-ey6Eyt/qEYP3dv53rcmO7RjflQq9vVwcsispQ+CXvsv1zMi6x7PMAPth1ItRL+1akn3Y2R+dLyQclCR3KSGghA==
+"@ar.io/sdk@4.0.2-alpha.8":
+  version "4.0.2-alpha.8"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.2-alpha.8.tgz#f69ef6622a4349b0334d8b92a5a775e4edad7f18"
+  integrity sha512-pKGQs4S40N+jQM7Daog1eGbliiJ6koHaqOQk6gpy9qxNmeaIWCITlv7KL7OX9NuyfAEMnu9sSTFDflH8Y7FxCQ==
   dependencies:
-    "@ar.io/solana-contracts" "1.0.0"
+    "@ar.io/solana-contracts" "1.0.1"
     "@noble/hashes" "^1.8.0"
     "@solana-program/address-lookup-table" "^0.11.0"
     "@solana-program/compute-budget" "^0.15.0"
@@ -40,10 +40,10 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/solana-contracts@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.0.tgz#56ec1354542991899c5d641a8221ee2b33b8b99d"
-  integrity sha512-/rmxIyViK9USkedcn4zrHWkg+tGBE160PSbJ2xwEcugtXDSOf5Cc0E6R8YoG7HT5oKkU0QY1QEeSeVvcYgMYBQ==
+"@ar.io/solana-contracts@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.1.tgz#1a16958d54540222b77def81d5d39e7402b8b69c"
+  integrity sha512-zD7OepkzzWb1SIHRDxSo3y+dzRh9gu+43eI2DBJLtQ+7EkT3Py8v9kHQ40UcRC8CReHHTO74RDty6Hwx5JYVGA==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
✅ **Unblocked & ready** — [ar-io/ar-io-sdk#685](https://github.com/ar-io/ar-io-sdk/pull/685) is merged and released as `@ar.io/sdk@4.0.2-alpha.8`; this PR bumps to it.

## Problem
Phase-3 cleanup (`runCleanup`) called `ario.getGoneGateways()` — **every** `status === Leaving` gateway — then `finalizeGone()` on each. Gateways whose on-chain leave window hasn't elapsed revert with `LeaveWindowNotExpired` (Anchor 6079). On AR.IO mainnet epoch go-live this produced **~280 simulation-failure stack traces per 10 minutes** from a single operator, burying real logs. No SOL cost, no wedge — pure noise.

## Fix
Use `ario.getFinalizableGoneGateways(now)` (added in #685), which pre-filters to the two on-chain `finalize_gone` preconditions: leave window elapsed (`now >= leaveTimestamp`) **and** no remaining delegated stake. `now` is the cycle timestamp already computed at the top of `runCleanup`.

## Verification (live mainnet, against `@ar.io/sdk@4.0.2-alpha.8`)
- `getGoneGateways()` → **71** Leaving gateways (old behavior attempts all → 38 revert)
- `getFinalizableGoneGateways(now)` → **33** eligible (new behavior, **0** of the 38 reverts)
- All 38 filtered-out confirmed not-finalizable on-chain: 37 leave-window-not-elapsed (the `6079` source), 1 with remaining delegated stake.

## Tests / build
- `@ar.io/sdk` bumped to `4.0.2-alpha.8`; `SolanaARIOReadable.prototype.getFinalizableGoneGateways` confirmed present at runtime.
- Cranker test mock updated; `tsc --project tsconfig.prod.json` clean; full observer suite passes (346 tests).

## After merge
Rebuild the observer image → bump `OBSERVER_IMAGE_TAG` on deployments (same flow as the compound fix `#670 → #97 → db292b8e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)