### PR TITLE
fix(report-sink): raise default gateway-failure threshold 0.8 → 0.95

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -350,7 +350,7 @@ function parseFractionEnv(name: string, defaultValue: string): number {
  */
 export const OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD = parseFractionEnv(
   'OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD',
-  '0.8',
+  '0.95',
 );
 
 export const SOLANA_RPC_URL = env.varOrDefault(

--- a/src/config.ts
+++ b/src/config.ts
@@ -341,12 +341,15 @@ function parseFractionEnv(name: string, defaultValue: string): number {
  * blasting the network with false negatives — if everything looks
  * broken, assume the observer is the problem and refuse to ship.
  *
- * Production default `0.8` is correct on a healthy network. On devnet
- * (where most gateways are intentional stubs that don't serve HTTP),
- * 100% failure is the honest answer and the gate falsely suppresses
- * legitimate reports — set to `1.0` there so only the literal "every
- * gateway failed including ourselves" case is filtered (which can't
- * happen with `>` semantics, so 1.0 effectively disables the gate).
+ * Default `0.95`: only a near-total-failure report (~95%+) is suppressed —
+ * the signature of a real observer misconfig. Early on a fresh network the
+ * long tail of registered gateways legitimately fails assessment (5xx / TLS /
+ * conn-refused) while the operator's own gateways pass, so a lower gate (e.g.
+ * `0.8`) would suppress honest, high-but-legitimate reports. On devnet (where
+ * most gateways are intentional stubs that don't serve HTTP), 100% failure is
+ * the honest answer — set to `1.0` there so only the literal "every gateway
+ * failed including ourselves" case is filtered (which can't happen with `>`
+ * semantics, so 1.0 effectively disables the gate).
  */
 export const OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD = parseFractionEnv(
   'OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD',

--- a/src/store/pipeline-report-sink.test.ts
+++ b/src/store/pipeline-report-sink.test.ts
@@ -138,7 +138,7 @@ describe('PipelineReportSink', function () {
   });
 
   describe('saveReport - threshold logic', function () {
-    it('should process all sinks when less than 80% of gateways fail', async function () {
+    it('should process all sinks when failure is below the default threshold', async function () {
       const sinks: ReportSinkEntry[] = [
         { name: 'sink1', sink: mockSink1 },
         { name: 'sink2', sink: mockSink2 },
@@ -162,19 +162,21 @@ describe('PipelineReportSink', function () {
       expect(result).to.have.property('sink2Processed', true);
     });
 
-    it('should process all sinks when exactly 80% of gateways fail', async function () {
+    it('should process all sinks at exactly the default 95% threshold', async function () {
       const sinks: ReportSinkEntry[] = [
         { name: 'sink1', sink: mockSink1 },
         { name: 'sink2', sink: mockSink2 },
       ];
 
+      // No explicit threshold → exercises the 0.95 default. `>` semantics mean
+      // exactly-at-threshold still forwards.
       pipelineReportSink = new PipelineReportSink({
         log: logStub,
         sinks,
       });
 
-      // 80% failure rate (8 out of 10)
-      const report = createMockReport(10, 8);
+      // 95% failure rate (19 out of 20) — exactly the default, so it forwards.
+      const report = createMockReport(20, 19);
       const reportInfo: ReportInfo = { report };
 
       const result = await pipelineReportSink.saveReport(reportInfo);
@@ -186,19 +188,20 @@ describe('PipelineReportSink', function () {
       expect(result).to.have.property('sink2Processed', true);
     });
 
-    it('should skip all sinks when more than 80% of gateways fail', async function () {
+    it('should skip all sinks when failure exceeds the default 95% threshold', async function () {
       const sinks: ReportSinkEntry[] = [
         { name: 'sink1', sink: mockSink1 },
         { name: 'sink2', sink: mockSink2 },
       ];
 
+      // No explicit threshold → exercises the 0.95 default.
       pipelineReportSink = new PipelineReportSink({
         log: logStub,
         sinks,
       });
 
-      // 90% failure rate (9 out of 10)
-      const report = createMockReport(10, 9);
+      // 96% failure rate (96 out of 100) — above the 0.95 default.
+      const report = createMockReport(100, 96);
       const reportInfo: ReportInfo = { report };
 
       const result = await pipelineReportSink.saveReport(reportInfo);
@@ -208,15 +211,15 @@ describe('PipelineReportSink', function () {
       expect((logStub.error as sinon.SinonStub).calledOnce).to.be.true;
 
       const errorCall = (logStub.error as sinon.SinonStub).firstCall;
-      expect(errorCall.args[0]).to.include('More than 80% of gateways failed');
+      expect(errorCall.args[0]).to.include('More than 95% of gateways failed');
       expect(errorCall.args[0]).to.include(
         'Please check your observer configuration',
       );
       expect(errorCall.args[1]).to.deep.include({
-        totalGateways: 10,
-        failedGateways: 9,
-        failurePercentage: '90.00%',
-        threshold: '80%',
+        totalGateways: 100,
+        failedGateways: 96,
+        failurePercentage: '96.00%',
+        threshold: '95%',
       });
 
       expect(result).to.equal(reportInfo);

--- a/src/store/pipeline-report-sink.ts
+++ b/src/store/pipeline-report-sink.ts
@@ -47,7 +47,8 @@ export class PipelineReportSink implements ReportSink {
     /**
      * Fraction in `[0, 1]`. If the share of gateways reported as failed
      * exceeds this value, the pipeline drops the report instead of
-     * forwarding to downstream sinks. Defaults to 0.8 (production safe).
+     * forwarding to downstream sinks. Defaults to 0.95 (suppresses only a
+     * near-total-failure report — the real observer-misconfig signature).
      * On environments where a high real failure rate is expected
      * (e.g. devnet with stub gateways), raise to 1.0 to disable the
      * gate — the `>` comparison means a threshold of 1.0 can never

--- a/src/store/pipeline-report-sink.ts
+++ b/src/store/pipeline-report-sink.ts
@@ -19,7 +19,12 @@ import * as winston from 'winston';
 
 import { ReportInfo, ReportSink } from '../types.js';
 
-const DEFAULT_MAX_GATEWAY_FAILURE_THRESHOLD = 0.8;
+// 0.95: only block a near-total-failure report (~95%+), the signature of a real
+// observer misconfig. Early on a fresh network the long tail of registered
+// gateways legitimately fails assessment (5xx/TLS/conn-refused) while the
+// operator's own gateways pass, so a lower gate (e.g. 0.8) would suppress honest
+// high-but-legitimate reports. Override via OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD.
+const DEFAULT_MAX_GATEWAY_FAILURE_THRESHOLD = 0.95;
 
 export interface ReportSinkEntry {
   name: string;


### PR DESCRIPTION
## What
Raise the default `OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD` from **0.8 → 0.95**.

## Why
This threshold gates publishing an observation report when more than the given fraction of assessed gateways fail — a guard against a misconfigured observer flooding the network with bogus all-fail reports.

Early on a fresh network, the long tail of registered gateways legitimately fails assessment (5xx / TLS / connection-refused) while the operator's own gateways pass. At `0.8`, an honest report with a high-but-legitimate failure rate (~80–90%) gets suppressed. `0.95` still blocks a **near-total** failure report (~95%+) — the real signature of "my observer is broken" — while letting honest high-failure reports through. Operators can still override per-deployment via the env var.

## Changes
- `src/config.ts` — env-parse default `'0.8'` → `'0.95'`.
- `src/store/pipeline-report-sink.ts` — `DEFAULT_MAX_GATEWAY_FAILURE_THRESHOLD` `0.8` → `0.95` (with rationale comment).
- `src/store/pipeline-report-sink.test.ts` — re-anchored the threshold-logic tests to the 0.95 boundary (exactly-95% forwards, 96% drops with `threshold: '95%'`). Explicit-threshold tests (0.5, 1.0) unchanged.

Full suite passes (346); `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default gateway failure threshold from **80%** to **95%**, allowing pipeline reports to continue during broader gateway disruption.
* **Tests**
  * Updated and expanded `saveReport` threshold coverage to validate behavior at the default **95%** value, including “exactly at threshold” and “exceeds threshold” scenarios, along with updated logged error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->