### PR TITLE
chore(deps): bump @ar.io/sdk → 4.0.2-alpha.10 (finalize_gone leave-window fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "4.0.2-alpha.8",
+    "@ar.io/sdk": "4.0.2-alpha.10",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@4.0.2-alpha.8":
-  version "4.0.2-alpha.8"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.2-alpha.8.tgz#f69ef6622a4349b0334d8b92a5a775e4edad7f18"
-  integrity sha512-pKGQs4S40N+jQM7Daog1eGbliiJ6koHaqOQk6gpy9qxNmeaIWCITlv7KL7OX9NuyfAEMnu9sSTFDflH8Y7FxCQ==
+"@ar.io/sdk@4.0.2-alpha.10":
+  version "4.0.2-alpha.10"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.2-alpha.10.tgz#b29119a5eea6d975df72e5805c5e66b3ad49c4ad"
+  integrity sha512-ZLe5ix4wimViLgP0O3UdV54IQ4HeOJZMRMUb91mVgdpO8R1EyX7wheOcabTu+Dd4nf5Der07Hj5K3Jkrqp36hA==
   dependencies:
     "@ar.io/solana-contracts" "1.0.1"
     "@noble/hashes" "^1.8.0"


### PR DESCRIPTION
## What

Bumps `@ar.io/sdk` from `4.0.2-alpha.8` → `4.0.2-alpha.10`.

## Why

`alpha.10` ships the corrected `finalize_gone` eligibility check ([ar-io-sdk #687](https://github.com/ar-io/ar-io-sdk/pull/687)). The epoch-cranker's phase-3 cleanup loop calls `getFinalizableGoneGateways(now)` before issuing `finalize_gone`. The previously-pinned `alpha.8` (#685) only checked `leaveTimestamp <= now`, but the on-chain GC window is:

```
leaveTimestamp + GATEWAY_LEAVE_PERIOD (90d) + 7 * max(leaveEpochDuration, epoch_duration)  ≈ 97 days
```

So `alpha.8` returned gateways still inside their ~97-day cooldown, and the cranker reverted `LeaveWindowNotExpired` (Anchor 6079) on every not-yet-eligible gateway, every cleanup cycle — pure log/RPC noise (no SOL cost, but constant error spam).

## Verification

- **Mainnet, deployed alpha.8:** `getGoneGateways = 111`, `getFinalizableGoneGateways = 71` (false-eligible) → ~71 reverts/cycle, 0 successes.
- **Mainnet, alpha.10:** `getGoneGateways = 111`, `getFinalizableGoneGateways = 0` (correct — all currently in cooldown) → 0 finalize attempts.
- `yarn build` clean; `yarn test` 346 passing.

No code changes — dependency + lockfile only.