### PR TITLE
fix(epoch-cranker): enumerate epoch observers in Phase 4, not the whole registry

### DIFF
--- a/src/epoch/epoch-cranker.test.ts
+++ b/src/epoch/epoch-cranker.test.ts
@@ -34,6 +34,9 @@ const noopLog: EpochCrankerConfig['log'] = {
 interface MockCounters {
   getEpochRawCalls: number[];
   closeObservationCalls: Array<{ epochIndex: number; observer: string }>;
+  getEpochObserversCalls: number[];
+  // Phase 4 must NEVER brute-force the whole registry anymore (the firehose).
+  registryGatewayCalls: number;
 }
 
 /**
@@ -49,6 +52,8 @@ function makeCranker(opts: {
   const counters: MockCounters = {
     getEpochRawCalls: [],
     closeObservationCalls: [],
+    getEpochObserversCalls: [],
+    registryGatewayCalls: 0,
   };
 
   const contract: any = {
@@ -69,7 +74,17 @@ function makeCranker(opts: {
         ? { rewardsDistributed: 1 }
         : null;
     },
-    getRegistryGatewayAddresses: async () => opts.observerAddrs,
+    // The fixed Phase 4 enumerates the epoch's real observers, not the whole
+    // registry. getEpochObservers returns only the submitters with a live PDA.
+    getEpochObservers: async (epochIndex: number) => {
+      counters.getEpochObserversCalls.push(epochIndex);
+      return opts.observerAddrs;
+    },
+    // Kept so we can assert Phase 4 NEVER calls it (the old brute-force path).
+    getRegistryGatewayAddresses: async () => {
+      counters.registryGatewayCalls++;
+      return opts.observerAddrs;
+    },
     closeObservation: async (p: { epochIndex: number; observer: string }) => {
       counters.closeObservationCalls.push({
         epochIndex: p.epochIndex,
@@ -171,6 +186,44 @@ describe('EpochCranker cleanup continuity floor', () => {
       { epochIndex: 462, observer: 'obsB' },
       { epochIndex: 462, observer: 'obsC' },
     ]);
+    // The observers came from getEpochObservers(closeTarget), NOT a brute-force
+    // walk of the whole gateway registry.
+    expect(counters.getEpochObserversCalls).to.deep.equal([462]);
+    expect(counters.registryGatewayCalls).to.equal(0);
+  });
+
+  it('closes ONLY the epoch observers and NEVER walks the gateway registry (firehose fix)', async () => {
+    // Old Phase 4 fired close_observation at every registry gateway (~643),
+    // ~98% of which had no PDA → AccountNotInitialized firehose. The fix
+    // enumerates the epoch's real observers instead.
+    const { cranker, counters } = makeCranker({
+      existingEpochs: new Set([462]),
+      observerAddrs: ['obsA', 'obsB'], // the only two that actually observed
+    });
+
+    await runCleanup(cranker, 470);
+
+    expect(counters.closeObservationCalls).to.deep.equal([
+      { epochIndex: 462, observer: 'obsA' },
+      { epochIndex: 462, observer: 'obsB' },
+    ]);
+    expect(counters.registryGatewayCalls).to.equal(0);
+  });
+
+  it('fires ZERO close_observation when an existing epoch has no live observers (the 643→0 case)', async () => {
+    // Exactly the production case proven on mainnet: epoch 460 exists and is
+    // distributed, but getEpochObservers returns [] (all already closed) — the
+    // old code still fired at all 643 registry gateways. The fix does nothing.
+    const { cranker, counters } = makeCranker({
+      existingEpochs: new Set([462]),
+      observerAddrs: [], // no live Observation PDAs for this epoch
+    });
+
+    await runCleanup(cranker, 470);
+
+    expect(counters.getEpochObserversCalls).to.deep.equal([462]);
+    expect(counters.closeObservationCalls).to.have.length(0);
+    expect(counters.registryGatewayCalls).to.equal(0);
   });
 
   it('skips Phase 4 entirely when currentEpochIndex is within the retention window', async () => {

--- a/src/epoch/epoch-cranker.ts
+++ b/src/epoch/epoch-cranker.ts
@@ -355,11 +355,20 @@ export class EpochCranker {
     }
 
     // Phase 4: Old observations from epochs older than `currentEpochIndex - retention`.
-    // The Observation PDA seed is `(epochIndex, observer)`. We need the
-    // observer addresses — easiest source is the active GatewayRegistry.
-    // Anyone NOT in the current registry won't be found, but observers are
-    // gateways so coverage should be reasonable. closeObservation no-ops on
-    // missing PDAs (Anchor returns AccountNotInitialized).
+    // The Observation PDA seed is `(epochIndex, observer)`. We close exactly the
+    // observers that actually submitted — `getEpochObservers` enumerates the
+    // real Observation PDAs for the epoch (one getProgramAccounts scan) and
+    // returns ~the submitting observers (tens), NOT the whole GatewayRegistry.
+    //
+    // This previously walked `getRegistryGatewayAddresses()` (the ENTIRE active
+    // registry, ~643 gateways) and fired close_observation at every one, relying
+    // on closeObservation to no-op (Anchor `AccountNotInitialized`/3012) for the
+    // ~98% that never observed. With `budget.remaining` only decrementing on
+    // SUCCESS, those hundreds of guaranteed-failing tx-simulations did not
+    // throttle the loop, so each cleanup cycle emitted hundreds of failures and
+    // hammered the RPC into 429s (the close_observation firehose). Enumerating
+    // the real observers turns ~643 mostly-failing attempts into ~tens that all
+    // succeed.
     //
     // CONTINUITY FLOOR: after the AO→Solana cutover, `current_epoch_index`
     // jumped straight to ~454 with NO epochs 0..453 on-chain. closeTarget
@@ -421,7 +430,7 @@ export class EpochCranker {
             ) {
               this.firstExistingEpochIndex = closeTarget;
             }
-            const observerAddrs = await ario.getRegistryGatewayAddresses?.();
+            const observerAddrs = await ario.getEpochObservers?.(closeTarget);
             if (Array.isArray(observerAddrs)) {
               for (const observer of observerAddrs) {
                 if (budget.remaining <= 0) break;


### PR DESCRIPTION
## Problem — the close_observation firehose

Phase 4 cleanup closed old-epoch observations by walking the **entire active gateway registry** (~643) and firing `close_observation` at every gateway, relying on the ~98% that never observed to no-op via Anchor `AccountNotInitialized` (3012). Because `budget.remaining` only decrements on **success**, those hundreds of guaranteed-failing tx-simulations never throttled the loop — so each cleanup cycle emitted hundreds of failures and drove the Solana RPC into 429s.

Measured on mainnet: **~7,000 failing `CloseObservation` simulations per 20 min (~509K/day)**; e.g. close-target epoch 460 had **643 attempts, 0 real Observation PDAs**.

## Fix

Enumerate the epoch's actual observers via `getEpochObservers(closeTarget)` — one `getProgramAccounts` scan returning only the submitters with a live Observation PDA (tens) — instead of `getRegistryGatewayAddresses()` (all 643). ~643 mostly-failing attempts become ~tens that all succeed; the 643→0 idle case does nothing. Phase 4 calls `close_observation` singular per-observer, so a stray stale-index ghost can't poison the others.

```diff
- const observerAddrs = await ario.getRegistryGatewayAddresses?.();
+ const observerAddrs = await ario.getEpochObservers?.(closeTarget);
```

## Tests

Added "never walks the registry (firehose fix)" and the 643→0 "no live observers" case; existing continuity-floor + retention tests preserved and now also assert the registry brute-force is never invoked. Full suite green.

## Validation

Built into an image from this exact commit (develop #104 + fix), deployed to a live mainnet cranker, and confirmed the `CloseObservation`/`AccountNotInitialized` firehose drops to ~0 across cleanup cycles while epoch progression + rent reclaim continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleanup now closes observations only for live observers in the current epoch, instead of scanning the full registry.
  * Fixed cases where observation closing could run unnecessarily when an epoch has no active observers.
  * Added stronger coverage to ensure registry-wide lookups are no longer used during this cleanup path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->