### PR TITLE
release: promote develop → main (Phase 4 close-observation firehose fix + @ar.io/sdk 4.0.3 stable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "4.0.2-alpha.10",
+    "@ar.io/sdk": "^4.0.3",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/src/epoch/epoch-cranker.test.ts
+++ b/src/epoch/epoch-cranker.test.ts
@@ -34,6 +34,9 @@ const noopLog: EpochCrankerConfig['log'] = {
 interface MockCounters {
   getEpochRawCalls: number[];
   closeObservationCalls: Array<{ epochIndex: number; observer: string }>;
+  getEpochObserversCalls: number[];
+  // Phase 4 must NEVER brute-force the whole registry anymore (the firehose).
+  registryGatewayCalls: number;
 }
 
 /**
@@ -49,6 +52,8 @@ function makeCranker(opts: {
   const counters: MockCounters = {
     getEpochRawCalls: [],
     closeObservationCalls: [],
+    getEpochObserversCalls: [],
+    registryGatewayCalls: 0,
   };
 
   const contract: any = {
@@ -69,7 +74,17 @@ function makeCranker(opts: {
         ? { rewardsDistributed: 1 }
         : null;
     },
-    getRegistryGatewayAddresses: async () => opts.observerAddrs,
+    // The fixed Phase 4 enumerates the epoch's real observers, not the whole
+    // registry. getEpochObservers returns only the submitters with a live PDA.
+    getEpochObservers: async (epochIndex: number) => {
+      counters.getEpochObserversCalls.push(epochIndex);
+      return opts.observerAddrs;
+    },
+    // Kept so we can assert Phase 4 NEVER calls it (the old brute-force path).
+    getRegistryGatewayAddresses: async () => {
+      counters.registryGatewayCalls++;
+      return opts.observerAddrs;
+    },
     closeObservation: async (p: { epochIndex: number; observer: string }) => {
       counters.closeObservationCalls.push({
         epochIndex: p.epochIndex,
@@ -171,6 +186,44 @@ describe('EpochCranker cleanup continuity floor', () => {
       { epochIndex: 462, observer: 'obsB' },
       { epochIndex: 462, observer: 'obsC' },
     ]);
+    // The observers came from getEpochObservers(closeTarget), NOT a brute-force
+    // walk of the whole gateway registry.
+    expect(counters.getEpochObserversCalls).to.deep.equal([462]);
+    expect(counters.registryGatewayCalls).to.equal(0);
+  });
+
+  it('closes ONLY the epoch observers and NEVER walks the gateway registry (firehose fix)', async () => {
+    // Old Phase 4 fired close_observation at every registry gateway (~643),
+    // ~98% of which had no PDA → AccountNotInitialized firehose. The fix
+    // enumerates the epoch's real observers instead.
+    const { cranker, counters } = makeCranker({
+      existingEpochs: new Set([462]),
+      observerAddrs: ['obsA', 'obsB'], // the only two that actually observed
+    });
+
+    await runCleanup(cranker, 470);
+
+    expect(counters.closeObservationCalls).to.deep.equal([
+      { epochIndex: 462, observer: 'obsA' },
+      { epochIndex: 462, observer: 'obsB' },
+    ]);
+    expect(counters.registryGatewayCalls).to.equal(0);
+  });
+
+  it('fires ZERO close_observation when an existing epoch has no live observers (the 643→0 case)', async () => {
+    // Exactly the production case proven on mainnet: epoch 460 exists and is
+    // distributed, but getEpochObservers returns [] (all already closed) — the
+    // old code still fired at all 643 registry gateways. The fix does nothing.
+    const { cranker, counters } = makeCranker({
+      existingEpochs: new Set([462]),
+      observerAddrs: [], // no live Observation PDAs for this epoch
+    });
+
+    await runCleanup(cranker, 470);
+
+    expect(counters.getEpochObserversCalls).to.deep.equal([462]);
+    expect(counters.closeObservationCalls).to.have.length(0);
+    expect(counters.registryGatewayCalls).to.equal(0);
   });
 
   it('skips Phase 4 entirely when currentEpochIndex is within the retention window', async () => {

--- a/src/epoch/epoch-cranker.ts
+++ b/src/epoch/epoch-cranker.ts
@@ -355,11 +355,20 @@ export class EpochCranker {
     }
 
     // Phase 4: Old observations from epochs older than `currentEpochIndex - retention`.
-    // The Observation PDA seed is `(epochIndex, observer)`. We need the
-    // observer addresses — easiest source is the active GatewayRegistry.
-    // Anyone NOT in the current registry won't be found, but observers are
-    // gateways so coverage should be reasonable. closeObservation no-ops on
-    // missing PDAs (Anchor returns AccountNotInitialized).
+    // The Observation PDA seed is `(epochIndex, observer)`. We close exactly the
+    // observers that actually submitted — `getEpochObservers` enumerates the
+    // real Observation PDAs for the epoch (one getProgramAccounts scan) and
+    // returns ~the submitting observers (tens), NOT the whole GatewayRegistry.
+    //
+    // This previously walked `getRegistryGatewayAddresses()` (the ENTIRE active
+    // registry, ~643 gateways) and fired close_observation at every one, relying
+    // on closeObservation to no-op (Anchor `AccountNotInitialized`/3012) for the
+    // ~98% that never observed. With `budget.remaining` only decrementing on
+    // SUCCESS, those hundreds of guaranteed-failing tx-simulations did not
+    // throttle the loop, so each cleanup cycle emitted hundreds of failures and
+    // hammered the RPC into 429s (the close_observation firehose). Enumerating
+    // the real observers turns ~643 mostly-failing attempts into ~tens that all
+    // succeed.
     //
     // CONTINUITY FLOOR: after the AO→Solana cutover, `current_epoch_index`
     // jumped straight to ~454 with NO epochs 0..453 on-chain. closeTarget
@@ -421,7 +430,7 @@ export class EpochCranker {
             ) {
               this.firstExistingEpochIndex = closeTarget;
             }
-            const observerAddrs = await ario.getRegistryGatewayAddresses?.();
+            const observerAddrs = await ario.getEpochObservers?.(closeTarget);
             if (Array.isArray(observerAddrs)) {
               for (const observer of observerAddrs) {
                 if (budget.remaining <= 0) break;

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@4.0.2-alpha.10":
-  version "4.0.2-alpha.10"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.2-alpha.10.tgz#b29119a5eea6d975df72e5805c5e66b3ad49c4ad"
-  integrity sha512-ZLe5ix4wimViLgP0O3UdV54IQ4HeOJZMRMUb91mVgdpO8R1EyX7wheOcabTu+Dd4nf5Der07Hj5K3Jkrqp36hA==
+"@ar.io/sdk@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.3.tgz#1c852322ad71458600f540ab4082b0c9c7704e41"
+  integrity sha512-r4QIm9UWE4OxT3pMBK4ZI3tM1VeVRIQt3llw7pd9hw7sYscreDF+apIteeYRHNGFnDmA2pvElH6qTTpWuM3EBg==
   dependencies:
     "@ar.io/solana-contracts" "1.0.1"
     "@noble/hashes" "^1.8.0"
@@ -6979,16 +6979,7 @@ strict-event-emitter@^0.5.1:
   resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
   integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7020,14 +7011,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7551,16 +7535,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Promotes `develop` → `main` (release marker). Two commits, four files — cranker-only, no assessment-path changes.

## Included

- **#105 — `fix(epoch-cranker): enumerate epoch observers in Phase 4, not the whole registry`**
  Phase 4 cleanup previously issued `close_observation` against the *entire* gateway registry (~640) instead of the epoch's actual observers. ~98% of those had no Observation PDA → Anchor `AccountNotInitialized` (3012) on a tight loop, and `budget--` only ran on success so failures never throttled → log firehose + RPC 429 storm.
- **#104 — `chore(deps): bump @ar.io/sdk 4.0.2-alpha.10 → ^4.0.3 (stable)`**
  Moves off the alpha SDK onto the stable release.

`main` currently lacks both, so **main-based cranker deployments still run the firehose**; this promotion fixes that on the release channel.

## Production evidence (24h, running develop HEAD in mainnet cranking)

| Signal | Result |
|---|---|
| `AccountNotInitialized` | **0** (the #105 target) |
| `CloseObservation` spam | **0** |
| Log volume | **~7.7k lines/24h** (was ~3.5M/day pre-#105) |
| Real RPC 429s | **0** |
| Crank tx failures (InstructionError/Custom/sim) | **0** |
| Restarts / OOM | 0 / none (25h uptime) |
| Errors / warns | 1 / 1 (a transient RPC 503 on ALT reclaim cleanup; one benign "submission window closed") |

Reports submit on-chain each epoch; cranking (tally/distribute/prescribe) is active and clean.

## Risk

Low. Diff is limited to `src/epoch/epoch-cranker.ts` (+ its test) and the SDK dep bump. No changes to the observation/assessment path. Expect the usual squash-induced conflicts on this promotion — resolve by taking develop's tree wholesale (develop is the source of truth).

## Note

This ships **cranker fixes only**. It does not change the reference-gateway assessment defaults, so it will not alter operators' gateway-assessment fail rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)