### PR TITLE
fix(observations): attribute failed-gateway summary to the assessed gateway, include ArNS

### DIFF
--- a/src/store/failed-gateway-summary.test.ts
+++ b/src/store/failed-gateway-summary.test.ts
@@ -1,0 +1,168 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * Unit tests for `getFailedGatewaySummaryFromReport` — the collapse of an
+ * ObserverReport into the failed-gateway wallet list submitted via
+ * `save_observations`. Covers ownership attribution (including the
+ * shared-infrastructure case where a host serves a wallet it isn't
+ * registered under) and ArNS-only failures.
+ */
+import { expect } from 'chai';
+
+import { getFailedGatewaySummaryFromReport } from './failed-gateway-summary.js';
+import { GatewayAssessments, ObserverReport } from '../types.js';
+
+const WALLET_A = 'wallet-a-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const WALLET_B = 'wallet-b-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const WALLET_C = 'wallet-c-ccccccccccccccccccccccccccccccccccccccc';
+
+function assessment({
+  expectedWallets,
+  observedWallet,
+  ownershipPass,
+  arnsPass,
+}: {
+  expectedWallets: string[];
+  observedWallet: string | null;
+  ownershipPass: boolean;
+  arnsPass: boolean;
+}): GatewayAssessments[string] {
+  return {
+    ownershipAssessment: {
+      expectedWallets,
+      observedWallet,
+      pass: ownershipPass,
+    },
+    arnsAssessments: {
+      prescribedNames: {},
+      chosenNames: {},
+      pass: arnsPass,
+    },
+    pass: ownershipPass && arnsPass,
+  };
+}
+
+function reportOf(gatewayAssessments: GatewayAssessments): ObserverReport {
+  return {
+    formatVersion: 1,
+    observerAddress: 'observer',
+    epochStartTimestamp: 0,
+    epochEndTimestamp: 0,
+    epochStartHeight: 0,
+    epochIndex: 0,
+    generatedAt: 0,
+    gatewayAssessments,
+  };
+}
+
+describe('getFailedGatewaySummaryFromReport', () => {
+  it('omits a fully passing gateway', () => {
+    const report = reportOf({
+      'gw.example': assessment({
+        expectedWallets: [WALLET_A],
+        observedWallet: WALLET_A,
+        ownershipPass: true,
+        arnsPass: true,
+      }),
+    });
+    expect(getFailedGatewaySummaryFromReport(report)).to.deep.equal([]);
+  });
+
+  it('fails a gateway that passes ownership but fails ArNS', () => {
+    const report = reportOf({
+      'gw.example': assessment({
+        expectedWallets: [WALLET_A],
+        observedWallet: WALLET_A,
+        ownershipPass: true,
+        arnsPass: false,
+      }),
+    });
+    expect(getFailedGatewaySummaryFromReport(report)).to.deep.equal([WALLET_A]);
+  });
+
+  it('fails all expected wallets when no wallet responded', () => {
+    const report = reportOf({
+      'gw.example': assessment({
+        expectedWallets: [WALLET_A, WALLET_B],
+        observedWallet: null,
+        ownershipPass: false,
+        arnsPass: false,
+      }),
+    });
+    expect(getFailedGatewaySummaryFromReport(report)).to.deep.equal([
+      WALLET_A,
+      WALLET_B,
+    ]);
+  });
+
+  it('fails only the non-controlling wallet on a shared fqdn', () => {
+    // Two gateways register the same fqdn; only the wallet that actually
+    // serves it (WALLET_A) controls it, so WALLET_B is failed.
+    const report = reportOf({
+      'shared.example': assessment({
+        expectedWallets: [WALLET_A, WALLET_B],
+        observedWallet: WALLET_A,
+        ownershipPass: true,
+        arnsPass: true,
+      }),
+    });
+    expect(getFailedGatewaySummaryFromReport(report)).to.deep.equal([WALLET_B]);
+  });
+
+  it('attributes an unexpected observed wallet to the assessed gateway, not the wallet owner', () => {
+    // Regression for the shared-infrastructure bug: gateway-a is registered
+    // under WALLET_A but its node serves WALLET_C (which belongs to a
+    // separate, healthy gateway sharing the same infrastructure). The
+    // failure must land on gateway-a (WALLET_A), and the healthy WALLET_C
+    // gateway must NOT be penalized.
+    const report = reportOf({
+      'gateway-a.example': assessment({
+        expectedWallets: [WALLET_A],
+        observedWallet: WALLET_C,
+        ownershipPass: false,
+        arnsPass: true,
+      }),
+      'gateway-c.example': assessment({
+        expectedWallets: [WALLET_C],
+        observedWallet: WALLET_C,
+        ownershipPass: true,
+        arnsPass: true,
+      }),
+    });
+    const failed = getFailedGatewaySummaryFromReport(report);
+    expect(failed).to.deep.equal([WALLET_A]);
+    expect(failed).to.not.include(WALLET_C);
+  });
+
+  it('deduplicates and sorts wallets across multiple hosts', () => {
+    const report = reportOf({
+      'b.example': assessment({
+        expectedWallets: [WALLET_B],
+        observedWallet: null,
+        ownershipPass: false,
+        arnsPass: false,
+      }),
+      'a.example': assessment({
+        expectedWallets: [WALLET_A],
+        observedWallet: WALLET_A,
+        ownershipPass: true,
+        arnsPass: false,
+      }),
+      // WALLET_B appears again (claims a.example too but doesn't control it).
+      'a2.example': assessment({
+        expectedWallets: [WALLET_A, WALLET_B],
+        observedWallet: WALLET_A,
+        ownershipPass: true,
+        arnsPass: true,
+      }),
+    });
+    expect(getFailedGatewaySummaryFromReport(report)).to.deep.equal([
+      WALLET_A,
+      WALLET_B,
+    ]);
+  });
+});

--- a/src/store/failed-gateway-summary.test.ts
+++ b/src/store/failed-gateway-summary.test.ts
@@ -25,11 +25,16 @@ function assessment({
   observedWallet,
   ownershipPass,
   arnsPass,
+  pass,
 }: {
   expectedWallets: string[];
   observedWallet: string | null;
   ownershipPass: boolean;
   arnsPass: boolean;
+  // Composite gateway `pass`. Defaults to `ownershipPass && arnsPass`, but can
+  // be set independently to model dimensions the report folds in beyond those
+  // two (offset enforcement, majority vote) — the summary must track it.
+  pass?: boolean;
 }): GatewayAssessments[string] {
   return {
     ownershipAssessment: {
@@ -42,7 +47,7 @@ function assessment({
       chosenNames: {},
       pass: arnsPass,
     },
-    pass: ownershipPass && arnsPass,
+    pass: pass ?? (ownershipPass && arnsPass),
   };
 }
 
@@ -79,6 +84,24 @@ describe('getFailedGatewaySummaryFromReport', () => {
         observedWallet: WALLET_A,
         ownershipPass: true,
         arnsPass: false,
+      }),
+    });
+    expect(getFailedGatewaySummaryFromReport(report)).to.deep.equal([WALLET_A]);
+  });
+
+  it('fails the controlling wallet when composite pass is false despite ownership + ArNS passing', () => {
+    // The report's per-gateway `pass` also folds in offset enforcement and a
+    // majority vote across observations, so a gateway can pass ownership AND
+    // ArNS yet still be `pass: false` overall. The summary must track the
+    // composite `pass` (single source of truth), otherwise the on-chain
+    // bitmap diverges from the report.
+    const report = reportOf({
+      'gw.example': assessment({
+        expectedWallets: [WALLET_A],
+        observedWallet: WALLET_A,
+        ownershipPass: true,
+        arnsPass: true,
+        pass: false, // e.g. offset assessment failed under enforcement
       }),
     });
     expect(getFailedGatewaySummaryFromReport(report)).to.deep.equal([WALLET_A]);

--- a/src/store/failed-gateway-summary.ts
+++ b/src/store/failed-gateway-summary.ts
@@ -14,8 +14,10 @@ import { ObserverReport } from '../types.js';
  * A gateway is identified by its registered wallet(s) (`expectedWallets`).
  * For each assessed host:
  *   - The wallet that actually controls the host (the one matching
- *     `observedWallet`) is failed if EITHER its ownership OR its ArNS
- *     assessment failed.
+ *     `observedWallet`) is failed iff the gateway's overall assessment
+ *     failed — the report's composite `pass` (ownership AND ArNS AND
+ *     offset, majority-voted), so the summary can never diverge from the
+ *     per-gateway `pass` the report carries.
  *   - Any other expected wallet is failed: it claims the host but a
  *     different wallet responded, so it does not control it.
  *   - If no wallet responded at all, every expected wallet is failed.
@@ -34,20 +36,19 @@ export function getFailedGatewaySummaryFromReport(
   const failedGatewaySummary = new Set<string>();
   Object.values(observerReport.gatewayAssessments).forEach(
     (gatewayAssessment) => {
-      const {
-        expectedWallets,
-        observedWallet,
-        pass: ownershipPass,
-      } = gatewayAssessment.ownershipAssessment;
-      const arnsPass = gatewayAssessment.arnsAssessments.pass;
+      const { expectedWallets, observedWallet } =
+        gatewayAssessment.ownershipAssessment;
 
       if (observedWallet !== null) {
         for (const wallet of expectedWallets) {
           if (wallet === observedWallet) {
-            // This wallet controls the host; it fails if EITHER ownership
-            // or ArNS resolution failed (the report's overall pass folds
-            // both in, but they are tracked separately here).
-            if (!ownershipPass || !arnsPass) {
+            // This wallet controls the host; it fails iff the gateway's
+            // overall assessment failed. Use the report's composite `pass`
+            // (ownership AND ArNS AND offset, majority-voted across
+            // observations) as the single source of truth so the on-chain
+            // bitmap always matches the report — rather than re-deriving it
+            // from a subset of the assessment dimensions.
+            if (!gatewayAssessment.pass) {
               failedGatewaySummary.add(wallet);
             }
           } else {

--- a/src/store/failed-gateway-summary.ts
+++ b/src/store/failed-gateway-summary.ts
@@ -7,18 +7,26 @@
 import { ObserverReport } from '../types.js';
 
 /**
- * Collapse the per-host ownership-assessment view from an ObserverReport
- * into the flat list of gateway wallets that should be reported failed
- * for `save_observations`.
+ * Collapse the per-host assessment view from an ObserverReport into the
+ * flat list of gateway wallets that should be reported failed for
+ * `save_observations`.
  *
- * For each assessment:
- *   - If the observed wallet matched an expected wallet AND ownership
- *     passed, drop it.
- *   - If multiple wallets were expected, every non-matching one is
- *     marked failed (they don't actually control the gateway).
- *   - If the observed wallet wasn't in the expected set, it's also
- *     marked failed (unauthorized control).
- *   - If no wallet responded, all expected wallets are marked failed.
+ * A gateway is identified by its registered wallet(s) (`expectedWallets`).
+ * For each assessed host:
+ *   - The wallet that actually controls the host (the one matching
+ *     `observedWallet`) is failed if EITHER its ownership OR its ArNS
+ *     assessment failed.
+ *   - Any other expected wallet is failed: it claims the host but a
+ *     different wallet responded, so it does not control it.
+ *   - If no wallet responded at all, every expected wallet is failed.
+ *
+ * The failure is always attributed to the gateway UNDER ASSESSMENT (its
+ * expected wallets) — never to the owner of an unexpected `observedWallet`.
+ * A host that serves a wallet it isn't registered under is a failure of
+ * that host's own gateway(s); the observed wallet's owner (which may be a
+ * healthy, unrelated gateway that merely shares infrastructure) must not be
+ * penalized. The assessed host's own expected wallets already capture that
+ * failure via the loop below.
  */
 export function getFailedGatewaySummaryFromReport(
   observerReport: ObserverReport,
@@ -31,21 +39,24 @@ export function getFailedGatewaySummaryFromReport(
         observedWallet,
         pass: ownershipPass,
       } = gatewayAssessment.ownershipAssessment;
+      const arnsPass = gatewayAssessment.arnsAssessments.pass;
 
       if (observedWallet !== null) {
         for (const wallet of expectedWallets) {
           if (wallet === observedWallet) {
-            if (!ownershipPass) {
+            // This wallet controls the host; it fails if EITHER ownership
+            // or ArNS resolution failed (the report's overall pass folds
+            // both in, but they are tracked separately here).
+            if (!ownershipPass || !arnsPass) {
               failedGatewaySummary.add(wallet);
             }
           } else {
+            // A registered wallet that does not control the observed host.
             failedGatewaySummary.add(wallet);
           }
         }
-        if (!expectedWallets.includes(observedWallet)) {
-          failedGatewaySummary.add(observedWallet);
-        }
       } else {
+        // No wallet responded — every expected wallet failed.
         for (const wallet of expectedWallets) {
           failedGatewaySummary.add(wallet);
         }


### PR DESCRIPTION
Fixes #107.

## Problem

`getFailedGatewaySummaryFromReport` (`src/store/failed-gateway-summary.ts`), which collapses an `ObserverReport` into the failed-gateway wallet list submitted via `save_observations`, had two defects that let a **healthy gateway be reported failed by every observer, every epoch** — including by its own observer.

1. **Inverted attribution.** When a host's `/ar-io/info` returned a wallet not in that host's registered `expectedWallets`, the code did `failedGatewaySummary.add(observedWallet)` — penalizing the **owner of the observed wallet** rather than the host that served it. On shared infrastructure (e.g. a decommissioning gateway whose domain is repointed at another gateway's node, so it now serves that other gateway's wallet), the healthy gateway whose wallet is served gets marked failed across the network, while the actually-misconfigured host's own failure is the thing that should be recorded.

2. **ArNS ignored.** The summary was built purely from `ownershipAssessment`, so a gateway that passed ownership but failed ArNS was never added — the on-chain bitmap diverged from the report's own per-gateway `pass`.

## Fix

- Remove the erroneous `add(observedWallet)`. The assessed host's own `expectedWallets` already capture the failure via the loop (an expected wallet that isn't the observed one is failed as non-controlling; if none responded, all expected wallets fail). Failure is now always attributed to the gateway **under assessment**, never to an unrelated wallet owner.
- Fail the controlling wallet on **either** an ownership **or** an ArNS failure, so the bitmap matches the report.

Updated the function's doc comment to describe the corrected semantics.

## Tests

New `src/store/failed-gateway-summary.test.ts` covering:
- fully passing gateway → omitted
- ownership pass + ArNS fail → failed
- no wallet responded → all expected wallets failed
- shared fqdn (multi-wallet) → only the non-controlling wallet failed
- **regression:** host serving an unexpected wallet → the assessed gateway is failed and the observed wallet's owner is **not** penalized
- dedup + sort across hosts

Verified logic locally against the module in isolation; the full mocha suite runs in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failed gateway reporting using the combined ownership, ArNS, and offset assessment results.
  * Correctly attributes failures to the gateway being assessed, including shared infrastructure.
  * Reports all expected wallets as failed when no wallet responds.
  * Excludes unexpected wallet responses from failure results.
  * Prevents duplicate failures and keeps results consistently sorted.

* **Tests**
  * Added coverage for passing gateways, composite failures, missing responses, shared hosts, unexpected wallets, deduplication, and sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->