### PR TITLE
feat(ipfs): protocol-aware assessment + trustless verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,40 @@ curl localhost:5050/ar-io/observer/healthcheck
 The current report is accessible at the `/ar-io/observer/reports/current`
 endpoint.
 
+## IPFS-target ArNS names
+
+ArNS names can point at IPFS content (`AntRecord.target_protocol = 1`, a CID). The
+observer assesses these **trustlessly**: a name whose reference-resolved
+`resolvedId` is a valid CID is fetched from the target gateway's `?format=raw`
+endpoint and the returned block is verified against the CID's multihash — no trust
+in a reference gateway's bytes.
+
+Scoring per IPFS name:
+
+- **PASS** — the served raw block hashes to the CID.
+- **FAIL** — the gateway serves 200 bytes that do **not** hash to the CID (a
+  proven-wrong answer). The decision never trusts the gateway's own
+  `x-arns-resolved-id` header.
+- **NEUTRAL** (excluded from the pass/fail denominator) — not served / non-200 /
+  timeout / non-`application/vnd.ipld.raw` / empty body / unverifiable multihash.
+  A gateway is never failed for availability, and a non-IPFS gateway (which 404s
+  the name) is neutral, not failed.
+
+This runs on the live `ContinuousObserver → GatewayAssessor` path; the report
+`formatVersion` is `3` (adds `protocol` + `outcome`). On-chain submission is
+unchanged (still a per-gateway pass/fail bitmap) — no contract change.
+
+Relevant configuration:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `IPFS_ASSESSMENT_TIMEOUT_MS` | `35000` | Request/response deadline for the `?format=raw` fetch. Set `>=` the gateway's IPFS retrieval budget so slow-but-valid cold-IPFS content isn't misclassified. |
+| `REFERENCE_GATEWAY_HOSTS` | `turbo-gateway.com,ar-io.net` | Gateways used to resolve the name→CID binding. **Recommended:** point this at your **own** co-located gateway configured to resolve ArNS **on-demand** (from chain) — then the binding is authoritative (chain-derived) and local rather than trusting external gateways. When deployed via the ar-io-node compose this defaults to the node's `ARNS_ROOT_HOST`. |
+
+Multi-block (UnixFS/dag-pb) CIDs are verified at the **DAG root block** today; full
+leaf/DAG sampling (the analog of Arweave chunk/offset proofs) is a planned
+follow-up.
+
 ### Docker
 
 Build and run the container:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "got": "^14.4.6",
     "lru-cache": "^11.2.1",
     "middleware-async": "^1.3.5",
-    "multiformats": "^13",
+    "multiformats": "^13.4.2",
     "node-cache": "^5.1.2",
     "p-map": "^7.0.3",
     "prom-client": "^15.1.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "got": "^14.4.6",
     "lru-cache": "^11.2.1",
     "middleware-async": "^1.3.5",
+    "multiformats": "^13",
     "node-cache": "^5.1.2",
     "p-map": "^7.0.3",
     "prom-client": "^15.1.3",

--- a/src/assessment/gateway-assessor.test.ts
+++ b/src/assessment/gateway-assessor.test.ts
@@ -1,0 +1,173 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { expect } from 'chai';
+import nock from 'nock';
+import { createLogger, transports } from 'winston';
+import { CID } from 'multiformats/cid';
+import { sha256 } from 'multiformats/hashes/sha2';
+import * as rawCodec from 'multiformats/codecs/raw';
+
+import { GatewayAssessor } from './gateway-assessor.js';
+import { ArnsResolution } from '../types.js';
+
+const testLog = createLogger({
+  transports: [new transports.Console({ silent: true })],
+});
+const RAW_CT = { 'content-type': 'application/vnd.ipld.raw' };
+
+const rawCidFor = async (bytes: Uint8Array) =>
+  CID.create(1, rawCodec.code, await sha256.digest(bytes)).toString();
+
+// The live path: ContinuousObserver -> GatewayAssessor.assessGatewayArns.
+describe('GatewayAssessor (live path) — IPFS', function () {
+  const host = 'gw.example.com';
+  const name = 'ipfsname';
+  let assessor: GatewayAssessor;
+  let currentRef: ArnsResolution;
+
+  const ipfsRef = (cid: string | null): ArnsResolution => ({
+    statusCode: 200,
+    resolvedId: cid,
+    ttlSeconds: '900',
+    contentLength: '10',
+    contentType: 'application/octet-stream',
+    dataHashDigest: null,
+    protocol: 'ipfs',
+    timings: null,
+  });
+
+  beforeEach(function () {
+    nock.cleanAll();
+    assessor = new GatewayAssessor({
+      referenceGateway: {
+        getArnsResolution: async () => ({
+          host: 'ref',
+          resolution: currentRef,
+        }),
+        checkChunkAvailability: async () => ({ host: 'ref', available: false }),
+        getChunkMetadata: async () => ({ host: 'ref', metadata: null }),
+      } as any,
+      nodeReleaseVersion: 'test',
+      nameAssessmentConcurrency: 4,
+      log: testLog,
+    });
+    assessor.initializeForEpoch({ entropy: Buffer.from('e'), namesCount: 10 });
+  });
+
+  afterEach(() => nock.cleanAll());
+
+  it('PASS: gateway serves a raw block that verifies against the CID', async function () {
+    const bytes = Buffer.from('trustless bytes');
+    const cid = await rawCidFor(bytes);
+    currentRef = ipfsRef(cid);
+    nock(`https://${name}.${host}`)
+      .get('/?format=raw')
+      .reply(200, bytes, { ...RAW_CT, 'x-arns-resolved-id': cid });
+
+    const r = await assessor.assessArnsName({ host, arnsName: name });
+    expect(r.outcome).to.equal('pass');
+    expect(r.pass).to.equal(true);
+    expect(r.protocol).to.equal('ipfs');
+  });
+
+  it('FAIL: gateway agrees on the CID but serves non-matching bytes', async function () {
+    const cid = await rawCidFor(Buffer.from('real'));
+    currentRef = ipfsRef(cid);
+    nock(`https://${name}.${host}`)
+      .get('/?format=raw')
+      .reply(200, Buffer.from('tampered'), {
+        ...RAW_CT,
+        'x-arns-resolved-id': cid,
+      });
+
+    const r = await assessor.assessArnsName({ host, arnsName: name });
+    expect(r.outcome).to.equal('fail');
+  });
+
+  it('FAIL: liar serves garbage with a bogus resolvedId cannot dodge to neutral', async function () {
+    const cidReal = await rawCidFor(Buffer.from('real content'));
+    const cidBogus = await rawCidFor(Buffer.from('unrelated'));
+    currentRef = ipfsRef(cidReal);
+    // Serves garbage that hashes to NEITHER cidReal NOR the bogus id it claims.
+    nock(`https://${name}.${host}`)
+      .get('/?format=raw')
+      .reply(200, Buffer.from('garbage'), {
+        ...RAW_CT,
+        'x-arns-resolved-id': cidBogus,
+      });
+
+    const r = await assessor.assessArnsName({ host, arnsName: name });
+    expect(r.outcome).to.equal('fail');
+  });
+
+  it('NEUTRAL: binding disagreement where the gateway serves its claimed CID authentically', async function () {
+    const cidOld = await rawCidFor(Buffer.from('old'));
+    const newBytes = Buffer.from('new');
+    const cidNew = await rawCidFor(newBytes);
+    currentRef = ipfsRef(cidOld);
+    nock(`https://${name}.${host}`)
+      .get('/?format=raw')
+      .reply(200, newBytes, { ...RAW_CT, 'x-arns-resolved-id': cidNew });
+
+    const r = await assessor.assessArnsName({ host, arnsName: name });
+    expect(r.outcome).to.equal('neutral');
+  });
+
+  it('NEUTRAL: gateway does not serve the block (404 — e.g. a non-IPFS gateway)', async function () {
+    currentRef = ipfsRef(await rawCidFor(Buffer.from('x')));
+    nock(`https://${name}.${host}`).get('/?format=raw').reply(404);
+
+    const r = await assessor.assessArnsName({ host, arnsName: name });
+    expect(r.outcome).to.equal('neutral');
+  });
+
+  it('NEUTRAL: a 200 that is not application/vnd.ipld.raw (HTML error page) is not a fail', async function () {
+    const cid = await rawCidFor(Buffer.from('real'));
+    currentRef = ipfsRef(cid);
+    nock(`https://${name}.${host}`)
+      .get('/?format=raw')
+      .reply(200, '<html>error</html>', {
+        'content-type': 'text/html',
+        'x-arns-resolved-id': cid,
+      });
+
+    const r = await assessor.assessArnsName({ host, arnsName: name });
+    expect(r.outcome).to.equal('neutral');
+  });
+
+  it('assessGatewayArns excludes neutral names from the pass rate', async function () {
+    // One PASS (raw block verifies) + one NEUTRAL (404). Pass rate must be 1/1.
+    const bytes = Buffer.from('served');
+    const cid = await rawCidFor(bytes);
+    currentRef = ipfsRef(cid); // both names resolve to the same ipfs CID here
+    nock(`https://passname.${host}`)
+      .get('/?format=raw')
+      .reply(200, bytes, { ...RAW_CT, 'x-arns-resolved-id': cid });
+    nock(`https://neutralname.${host}`).get('/?format=raw').reply(404);
+
+    const result = await assessor.assessGatewayArns({
+      host,
+      prescribedNames: ['passname'],
+      chosenNames: ['neutralname'],
+    });
+
+    // 1 pass, 1 neutral (excluded) => rate 1/1 => pass true. If neutral were
+    // counted as fail, rate would be 1/2 = 0.5 < 0.8 => fail.
+    expect(result.pass).to.equal(true);
+  });
+});

--- a/src/assessment/gateway-assessor.test.ts
+++ b/src/assessment/gateway-assessor.test.ts
@@ -115,17 +115,20 @@ describe('GatewayAssessor (live path) — IPFS', function () {
     expect(r.outcome).to.equal('fail');
   });
 
-  it('NEUTRAL: binding disagreement where the gateway serves its claimed CID authentically', async function () {
-    const cidOld = await rawCidFor(Buffer.from('old'));
-    const newBytes = Buffer.from('new');
-    const cidNew = await rawCidFor(newBytes);
-    currentRef = ipfsRef(cidOld);
+  it('FAIL: bytes not matching the reference CID cannot dodge via a self-minted resolvedId', async function () {
+    // The gateway serves bytes that don't hash to the reference CID and echoes a
+    // CID minted from those bytes. That self-consistent "proof" is worthless (the
+    // gateway controls both), so it is FAIL, not neutral.
+    const cidRef = await rawCidFor(Buffer.from('old'));
+    const served = Buffer.from('attacker');
+    const cidSelf = await rawCidFor(served);
+    currentRef = ipfsRef(cidRef);
     nock(`https://${name}.${host}`)
       .get('/?format=raw')
-      .reply(200, newBytes, { ...RAW_CT, 'x-arns-resolved-id': cidNew });
+      .reply(200, served, { ...RAW_CT, 'x-arns-resolved-id': cidSelf });
 
     const r = await assessor.assessArnsName({ host, arnsName: name });
-    expect(r.outcome).to.equal('neutral');
+    expect(r.outcome).to.equal('fail');
   });
 
   it('NEUTRAL: gateway does not serve the block (404 — e.g. a non-IPFS gateway)', async function () {

--- a/src/assessment/gateway-assessor.ts
+++ b/src/assessment/gateway-assessor.ts
@@ -21,9 +21,15 @@ import { Got } from 'got';
 import pMap from 'p-map';
 import { Logger } from 'winston';
 
+import * as config from '../config.js';
 import { createGatewayHttpClient } from '../lib/http-client.js';
 import * as metrics from '../metrics.js';
-import { assessOwnership, getArnsResolution } from '../observer.js';
+import {
+  arnsNameOutcome,
+  assessIpfsNameTrustless,
+  assessOwnership,
+  getArnsResolution,
+} from '../observer.js';
 import {
   ArnsNameAssessment,
   ArnsNameAssessments,
@@ -156,6 +162,21 @@ export class GatewayAssessor {
 
     const referenceResolution =
       await this.referenceResolutionCache.get(arnsName);
+    const protocol = referenceResolution.protocol ?? 'arweave';
+
+    // IPFS-protocol names are verified trustlessly against the CID (shared with
+    // the Observer path so scoring can't diverge). A gateway that doesn't serve
+    // the name scores NEUTRAL (excluded from the denominator); only a gateway that
+    // serves provably-wrong bytes scores FAIL.
+    if (protocol === 'ipfs') {
+      return assessIpfsNameTrustless({
+        host,
+        arnsName,
+        referenceResolution,
+        got: this.gotClient,
+        timeoutMs: config.IPFS_ASSESSMENT_TIMEOUT_MS,
+      });
+    }
 
     const arnsResolutionTimer = metrics.arnsResolutionHistogram.startTimer();
     const gatewayResolution = await getArnsResolution({
@@ -192,6 +213,8 @@ export class GatewayAssessor {
       resolvedId: gatewayResolution.resolvedId ?? null,
       expectedDataHash: referenceResolution.dataHashDigest ?? null,
       resolvedDataHash: gatewayResolution.dataHashDigest ?? null,
+      protocol,
+      outcome: pass ? 'pass' : 'fail',
       failureReason,
       pass,
       timings: gatewayResolution?.timings?.phases,
@@ -227,6 +250,7 @@ export class GatewayAssessor {
             resolvedId: null,
             expectedDataHash: null,
             resolvedDataHash: null,
+            outcome: 'fail' as const,
             failureReason: errorMessage?.slice(0, 512),
             pass: false,
           };
@@ -258,14 +282,22 @@ export class GatewayAssessor {
       this.assessArnsNames({ host, names: chosenNames }),
     ]);
 
-    // Calculate pass rate
+    // Calculate pass rate. NEUTRAL names (e.g. an IPFS name a gateway doesn't
+    // serve, or content unavailable network-wide) are EXCLUDED from both the
+    // numerator and the denominator so they can neither pass nor fail the gateway.
+    // If every graded name is neutral there is nothing to grade -> pass (don't
+    // fail a gateway on absence of evidence).
     const allAssessments = [
       ...Object.values(prescribedAssessments),
       ...Object.values(chosenAssessments),
     ];
-    const totalNames = allAssessments.length;
-    const passingNames = allAssessments.filter((a) => a.pass).length;
-    const passRate = totalNames > 0 ? passingNames / totalNames : 0;
+    const gradedNames = allAssessments.filter(
+      (a) => arnsNameOutcome(a) !== 'neutral',
+    ).length;
+    const passingNames = allAssessments.filter(
+      (a) => arnsNameOutcome(a) === 'pass',
+    ).length;
+    const passRate = gradedNames > 0 ? passingNames / gradedNames : 1;
 
     return {
       prescribedNames: prescribedAssessments,

--- a/src/assessment/gateway-assessor.ts
+++ b/src/assessment/gateway-assessor.ts
@@ -29,6 +29,7 @@ import {
   assessIpfsNameTrustless,
   assessOwnership,
   getArnsResolution,
+  isIpfsAssessable,
 } from '../observer.js';
 import {
   ArnsNameAssessment,
@@ -168,7 +169,7 @@ export class GatewayAssessor {
     // the Observer path so scoring can't diverge). A gateway that doesn't serve
     // the name scores NEUTRAL (excluded from the denominator); only a gateway that
     // serves provably-wrong bytes scores FAIL.
-    if (protocol === 'ipfs') {
+    if (isIpfsAssessable(referenceResolution)) {
       return assessIpfsNameTrustless({
         host,
         arnsName,

--- a/src/config.ts
+++ b/src/config.ts
@@ -227,6 +227,15 @@ export const REFERENCE_GATEWAY_CONSENSUS_SIZE = +env.varOrDefault(
   '3',
 );
 
+// Request/response deadline for the trustless IPFS raw-block fetch. Must be >=
+// the gateway's own IPFS retrieval budget (ar-io-node IPFS_KUBO_REQUEST_TIMEOUT_MS
+// defaults to 30s) so legitimately-slow cold IPFS retrieval isn't misclassified;
+// also bounds the fetch so a slow-drip gateway can't hang report generation.
+export const IPFS_ASSESSMENT_TIMEOUT_MS = +env.varOrDefault(
+  'IPFS_ASSESSMENT_TIMEOUT_MS',
+  '35000',
+);
+
 if (REFERENCE_GATEWAY_CONSENSUS_SIZE < 1) {
   throw new Error(
     `Invalid configuration: REFERENCE_GATEWAY_CONSENSUS_SIZE (${REFERENCE_GATEWAY_CONSENSUS_SIZE}) must be at least 1.`,

--- a/src/lib/ipfs-cid.test.ts
+++ b/src/lib/ipfs-cid.test.ts
@@ -18,6 +18,7 @@
 import { expect } from 'chai';
 import { CID } from 'multiformats/cid';
 import { sha256 } from 'multiformats/hashes/sha2';
+import * as Digest from 'multiformats/hashes/digest';
 import * as raw from 'multiformats/codecs/raw';
 
 import { verifyBytesAgainstCid, isValidCid } from './ipfs-cid.js';
@@ -64,6 +65,16 @@ describe('ipfs-cid', () => {
       const arweaveId = 'zt6spBgLNvJ7cMxCVPtRbEnYr7A9zZ1YxtXmefGc7lk';
       expect(
         await verifyBytesAgainstCid(arweaveId, new Uint8Array([0])),
+      ).to.equal('unsupported');
+    });
+
+    it('returns unsupported (not fail) for a sha256-coded CID with a truncated digest', async () => {
+      // A malformed multihash: sha2-256 code (0x12) but a 16-byte digest. Must be
+      // 'unsupported' -> neutral, never 'fail' against an honest gateway.
+      const badDigest = Digest.create(sha256.code, new Uint8Array(16));
+      const cid = CID.createV1(raw.code, badDigest).toString();
+      expect(
+        await verifyBytesAgainstCid(cid, new Uint8Array([1, 2, 3])),
       ).to.equal('unsupported');
     });
   });

--- a/src/lib/ipfs-cid.test.ts
+++ b/src/lib/ipfs-cid.test.ts
@@ -1,0 +1,78 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { expect } from 'chai';
+import { CID } from 'multiformats/cid';
+import { sha256 } from 'multiformats/hashes/sha2';
+import * as raw from 'multiformats/codecs/raw';
+
+import { verifyBytesAgainstCid, isValidCid } from './ipfs-cid.js';
+
+const DAG_PB_CODE = 0x70;
+
+async function rawCidFor(bytes: Uint8Array): Promise<string> {
+  const hash = await sha256.digest(bytes);
+  return CID.create(1, raw.code, hash).toString();
+}
+
+describe('ipfs-cid', () => {
+  describe('verifyBytesAgainstCid', () => {
+    it('passes when bytes hash to a raw (single-block) CID', async () => {
+      const bytes = new TextEncoder().encode('hello ar.io ipfs');
+      const cid = await rawCidFor(bytes);
+      expect(await verifyBytesAgainstCid(cid, bytes)).to.equal('pass');
+    });
+
+    it('passes for a dag-pb (UnixFS root) block — verification is codec-agnostic', async () => {
+      // The CID of a dag-pb block is the hash of the block bytes themselves —
+      // exactly what ?format=raw returns for a UnixFS root. We don't need to
+      // parse the block; matching the multihash is the proof.
+      const block = new Uint8Array([10, 20, 30, 40, 50]);
+      const hash = await sha256.digest(block);
+      const cid = CID.create(1, DAG_PB_CODE, hash).toString();
+      expect(await verifyBytesAgainstCid(cid, block)).to.equal('pass');
+    });
+
+    it('fails when the bytes are tampered', async () => {
+      const bytes = new TextEncoder().encode('original content');
+      const cid = await rawCidFor(bytes);
+      const tampered = new TextEncoder().encode('original contenX');
+      expect(await verifyBytesAgainstCid(cid, tampered)).to.equal('fail');
+    });
+
+    it('fails when the CID names entirely different content', async () => {
+      const cidA = await rawCidFor(new TextEncoder().encode('A'));
+      const bytesB = new TextEncoder().encode('B');
+      expect(await verifyBytesAgainstCid(cidA, bytesB)).to.equal('fail');
+    });
+
+    it('returns unsupported for a non-CID string (e.g. an Arweave tx id)', async () => {
+      const arweaveId = 'zt6spBgLNvJ7cMxCVPtRbEnYr7A9zZ1YxtXmefGc7lk';
+      expect(
+        await verifyBytesAgainstCid(arweaveId, new Uint8Array([0])),
+      ).to.equal('unsupported');
+    });
+  });
+
+  describe('isValidCid', () => {
+    it('accepts a v1 CID and rejects a non-CID', async () => {
+      const cid = await rawCidFor(new TextEncoder().encode('x'));
+      expect(isValidCid(cid)).to.equal(true);
+      expect(isValidCid('not-a-cid')).to.equal(false);
+    });
+  });
+});

--- a/src/lib/ipfs-cid.ts
+++ b/src/lib/ipfs-cid.ts
@@ -1,0 +1,74 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { CID } from 'multiformats/cid';
+import { sha256 } from 'multiformats/hashes/sha2';
+
+export type CidVerification = 'pass' | 'fail' | 'unsupported';
+
+/**
+ * Trustlessly verify that `bytes` are the block named by `cidString`.
+ *
+ * The bytes MUST be the raw block the CID directly addresses — i.e. what an IPFS
+ * trustless gateway returns for `?format=raw`. For a raw-codec CID that block is
+ * the file itself; for a UnixFS/dag-pb CID it is the DAG's root block. In both
+ * cases the CID's multihash is the hash of exactly those bytes, so a match proves
+ * the gateway served the authentic block — no reference gateway required.
+ *
+ * Returns:
+ *  - 'pass'        the bytes hash to the CID's multihash
+ *  - 'fail'        the bytes do NOT hash to the CID's multihash
+ *  - 'unsupported' `cidString` is not a CID, or uses a multihash we can't verify
+ *                  (only sha2-256 is supported today — it covers ~all IPFS content)
+ */
+export async function verifyBytesAgainstCid(
+  cidString: string,
+  bytes: Uint8Array,
+): Promise<CidVerification> {
+  let cid: CID;
+  try {
+    cid = CID.parse(cidString);
+  } catch {
+    // Not a CID (e.g. an Arweave transaction id) — nothing to verify here.
+    return 'unsupported';
+  }
+
+  if (cid.multihash.code !== sha256.code) {
+    return 'unsupported';
+  }
+
+  const computed = await sha256.digest(bytes);
+  return equalBytes(computed.digest, cid.multihash.digest) ? 'pass' : 'fail';
+}
+
+/** True if `cidString` parses as a valid CID. */
+export function isValidCid(cidString: string): boolean {
+  try {
+    CID.parse(cidString);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/src/lib/ipfs-cid.ts
+++ b/src/lib/ipfs-cid.ts
@@ -53,7 +53,14 @@ export async function verifyBytesAgainstCid(
     return 'unsupported';
   }
 
-  if (cid.multihash.code !== sha256.code) {
+  // Require a full sha2-256 multihash (code + 32-byte digest). A truncated or
+  // otherwise malformed digest is 'unsupported' (-> neutral), not 'fail', so an
+  // honest gateway serving the correct block is never failed on our inability to
+  // verify the CID.
+  if (
+    cid.multihash.code !== sha256.code ||
+    cid.multihash.digest.length !== 32
+  ) {
     return 'unsupported';
   }
 

--- a/src/lib/ipfs-cid.ts
+++ b/src/lib/ipfs-cid.ts
@@ -21,13 +21,19 @@ import { sha256 } from 'multiformats/hashes/sha2';
 export type CidVerification = 'pass' | 'fail' | 'unsupported';
 
 /**
- * Trustlessly verify that `bytes` are the block named by `cidString`.
+ * Trustlessly verify that `bytes` are the block the CID directly addresses — i.e.
+ * what an IPFS trustless gateway returns for `?format=raw`. The CID's multihash is
+ * the hash of exactly those bytes, so a match proves the gateway holds and served
+ * the authentic addressed block, with no reference-gateway trust.
  *
- * The bytes MUST be the raw block the CID directly addresses — i.e. what an IPFS
- * trustless gateway returns for `?format=raw`. For a raw-codec CID that block is
- * the file itself; for a UnixFS/dag-pb CID it is the DAG's root block. In both
- * cases the CID's multihash is the hash of exactly those bytes, so a match proves
- * the gateway served the authentic block — no reference gateway required.
+ * SCOPE (important): this proves possession of the ADDRESSED BLOCK only.
+ *  - raw-codec CID (0x55): the block IS the whole content — verification is
+ *    complete.
+ *  - dag-pb/UnixFS CID (0x70): the block is the DAG ROOT only. A match proves the
+ *    gateway holds the authentic root manifest, but NOT that it holds/serves the
+ *    leaf blocks, nor that its assembled (`GET /`) response returns the same
+ *    bytes. Full-DAG / leaf verification and the assembled-path check are the
+ *    deferred Phase 3 (IPFS block sampling, the analog of Arweave offset proofs).
  *
  * Returns:
  *  - 'pass'        the bytes hash to the CID's multihash

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -688,6 +688,55 @@ describe('Observer', function () {
         expect(failureRate).to.equal(0);
       });
 
+      it('excludes neutral names from the failure rate (numerator and denominator)', function () {
+        // ownership passes; one name is NEUTRAL and one FAILS. Neutral must be
+        // dropped from both counts: graded = ownership + failing = 2, failed = 1
+        // => 0.5. If neutral were (wrongly) counted as a failure it would be
+        // 2/3 ≈ 0.667.
+        const report: ObserverReport = createReport({
+          gatewayAssessments: {
+            'gw.com': {
+              ownershipAssessment: {
+                expectedWallets: ['w'],
+                observedWallet: 'w',
+                pass: true,
+              },
+              arnsAssessments: {
+                prescribedNames: {
+                  ipfsNeutral: {
+                    pass: false,
+                    outcome: 'neutral',
+                    assessedAt: 100,
+                    expectedId: 'bafyCID',
+                    resolvedId: null,
+                    expectedDataHash: null,
+                    resolvedDataHash: null,
+                    protocol: 'ipfs',
+                    failureReason: 'neutral: gateway does not support IPFS',
+                  },
+                  arweaveFail: {
+                    pass: false,
+                    outcome: 'fail',
+                    assessedAt: 100,
+                    expectedId: 'id1',
+                    resolvedId: 'id2',
+                    expectedDataHash: null,
+                    resolvedDataHash: null,
+                    failureReason: 'resolvedId mismatch',
+                  },
+                },
+                chosenNames: {},
+                pass: false,
+              },
+              pass: false,
+            },
+          },
+        });
+
+        const failureRate = (observer as any).calculateFailureRate(report);
+        expect(failureRate).to.equal(0.5);
+      });
+
       it('should calculate correct failure rate for single gateway', function () {
         const report: ObserverReport = createReport({
           gatewayAssessments: {

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -24,6 +24,7 @@ import sinon from 'sinon';
 import { customHashPRNG } from './lib/prng.js';
 import * as metrics from './metrics.js';
 import {
+  assessOwnership,
   generateRandomRanges,
   getArnsResolution,
   Observer,
@@ -107,6 +108,37 @@ describe('Observer', function () {
       expect(result.contentLength).to.equal(String(data.length));
       expect(result.dataHashDigest).to.equal(expectedHash);
       expect(result.timings).to.be.a.string;
+    });
+
+    it('captures the x-arns-protocol header as protocol', async function () {
+      const data = Buffer.alloc(40, 'b').toString();
+      const headers = {
+        'Content-Type': defaultContentType,
+        'x-arns-resolved-id': 'bafyCID',
+        'x-arns-ttl-seconds': defaultArnsTtlSeconds,
+        'x-arns-protocol': 'ipfs',
+        'Content-Length': String(data.length),
+      };
+      nock(url).head('/').reply(200, undefined, headers);
+      nock(url).get('/').reply(200, data, headers);
+
+      const result = await getArnsResolution({ url, got, entropy });
+      expect(result.protocol).to.equal('ipfs');
+    });
+
+    it('defaults protocol to null when the header is absent', async function () {
+      const data = Buffer.alloc(40, 'c').toString();
+      const headers = {
+        'Content-Type': defaultContentType,
+        'x-arns-resolved-id': defaultArnsResolvedId,
+        'x-arns-ttl-seconds': defaultArnsTtlSeconds,
+        'Content-Length': String(data.length),
+      };
+      nock(url).head('/').reply(200, undefined, headers);
+      nock(url).get('/').reply(200, data, headers);
+
+      const result = await getArnsResolution({ url, got, entropy });
+      expect(result.protocol).to.equal(null);
     });
 
     it('should use range requests to hash data for responses over 1MiB', async function () {
@@ -490,6 +522,63 @@ describe('Observer', function () {
     afterEach(function () {
       sinon.restore();
       nock.cleanAll();
+    });
+
+    describe('IPFS protocol awareness (Phase 1)', function () {
+      const entropy = Buffer.from('e');
+
+      it('assessOwnership reports supportsIpfs=true from /ar-io/info', async function () {
+        nock('https://gw-ipfs.example.com')
+          .get('/ar-io/info')
+          .reply(200, { wallet: 'WALLET', ipfs: { enabled: true } });
+        const result = await assessOwnership({
+          host: 'gw-ipfs.example.com',
+          expectedWallets: ['WALLET'],
+        });
+        expect(result.pass).to.equal(true);
+        expect(result.supportsIpfs).to.equal(true);
+      });
+
+      it('assessOwnership reports supportsIpfs=false when ipfs is absent', async function () {
+        nock('https://gw-plain.example.com')
+          .get('/ar-io/info')
+          .reply(200, { wallet: 'WALLET' });
+        const result = await assessOwnership({
+          host: 'gw-plain.example.com',
+          expectedWallets: ['WALLET'],
+        });
+        expect(result.supportsIpfs).to.equal(false);
+      });
+
+      it('scores an IPFS name NEUTRAL on a gateway without IPFS support, without probing it', async function () {
+        // Reference says the name resolves via IPFS. The gateway does NOT support
+        // IPFS, so the name must be neutral — and no request should be made to the
+        // gateway (no nock is registered for it; a probe would error).
+        (observer as any).referenceGatewayResolutionCache = {
+          get: async () => ({
+            statusCode: 200,
+            resolvedId: 'bafyCID',
+            ttlSeconds: '900',
+            contentLength: '10',
+            contentType: 'image/jpeg',
+            dataHashDigest: 'h',
+            protocol: 'ipfs',
+            timings: null,
+          }),
+        };
+
+        const result = await observer.assessArnsName({
+          host: 'gw-without-ipfs.example.com',
+          arnsName: 'ipfsname',
+          entropy,
+          supportsIpfs: false,
+        });
+
+        expect(result.outcome).to.equal('neutral');
+        expect(result.protocol).to.equal('ipfs');
+        expect(result.pass).to.equal(false);
+        expect(result.resolvedId).to.equal(null);
+      });
     });
 
     describe('calculateFailureRate', function () {

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -20,6 +20,9 @@ import got from 'got';
 import nock from 'nock';
 import crypto from 'node:crypto';
 import sinon from 'sinon';
+import { CID } from 'multiformats/cid';
+import { sha256 } from 'multiformats/hashes/sha2';
+import * as rawCodec from 'multiformats/codecs/raw';
 
 import { customHashPRNG } from './lib/prng.js';
 import * as metrics from './metrics.js';
@@ -578,6 +581,100 @@ describe('Observer', function () {
         expect(result.protocol).to.equal('ipfs');
         expect(result.pass).to.equal(false);
         expect(result.resolvedId).to.equal(null);
+      });
+    });
+
+    describe('IPFS trustless verification (Phase 2)', function () {
+      const entropy = Buffer.from('e');
+      const host = 'gw.example.com';
+      const arnsName = 'ipfsname';
+
+      const setReferenceCid = (cid: string | null) => {
+        (observer as any).referenceGatewayResolutionCache = {
+          get: async () => ({
+            statusCode: 200,
+            resolvedId: cid,
+            ttlSeconds: '900',
+            contentLength: '10',
+            contentType: 'application/octet-stream',
+            dataHashDigest: null,
+            protocol: 'ipfs',
+            timings: null,
+          }),
+        };
+      };
+
+      const rawCidFor = async (bytes: Uint8Array) =>
+        CID.create(1, rawCodec.code, await sha256.digest(bytes)).toString();
+
+      it('PASSES when the gateway serves a raw block that verifies against the CID', async function () {
+        const bytes = Buffer.from('trustless ipfs bytes');
+        const cid = await rawCidFor(bytes);
+        setReferenceCid(cid);
+        nock(`https://${arnsName}.${host}`)
+          .get('/?format=raw')
+          .reply(200, bytes, { 'x-arns-resolved-id': cid });
+
+        const result = await observer.assessArnsName({
+          host,
+          arnsName,
+          entropy,
+          supportsIpfs: true,
+        });
+
+        expect(result.outcome).to.equal('pass');
+        expect(result.pass).to.equal(true);
+        expect(result.protocol).to.equal('ipfs');
+      });
+
+      it('FAILS when the gateway serves bytes that do not match the CID', async function () {
+        const cid = await rawCidFor(Buffer.from('the real content'));
+        setReferenceCid(cid);
+        nock(`https://${arnsName}.${host}`)
+          .get('/?format=raw')
+          .reply(200, Buffer.from('tampered content'), {
+            'x-arns-resolved-id': cid,
+          });
+
+        const result = await observer.assessArnsName({
+          host,
+          arnsName,
+          entropy,
+          supportsIpfs: true,
+        });
+
+        expect(result.outcome).to.equal('fail');
+        expect(result.pass).to.equal(false);
+      });
+
+      it('FAILS when a supporting gateway does not serve the block', async function () {
+        const cid = await rawCidFor(Buffer.from('x'));
+        setReferenceCid(cid);
+        nock(`https://${arnsName}.${host}`).get('/?format=raw').reply(404);
+
+        const result = await observer.assessArnsName({
+          host,
+          arnsName,
+          entropy,
+          supportsIpfs: true,
+        });
+
+        expect(result.outcome).to.equal('fail');
+        expect(result.resolvedStatusCode).to.equal(404);
+      });
+
+      it('scores NEUTRAL when the reference binding is unavailable', async function () {
+        setReferenceCid(null);
+        // No nock: the gateway must not be probed when there is no binding.
+        const result = await observer.assessArnsName({
+          host,
+          arnsName,
+          entropy,
+          supportsIpfs: true,
+        });
+
+        expect(result.outcome).to.equal('neutral');
+        expect(result.pass).to.equal(false);
       });
     });
 

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -30,6 +30,7 @@ import {
   assessOwnership,
   generateRandomRanges,
   getArnsResolution,
+  getIpfsRawBlock,
   Observer,
 } from './observer.js';
 import { ReferenceGatewaySource } from './types.js';
@@ -528,8 +529,6 @@ describe('Observer', function () {
     });
 
     describe('IPFS protocol awareness (Phase 1)', function () {
-      const entropy = Buffer.from('e');
-
       it('assessOwnership reports supportsIpfs=true from /ar-io/info', async function () {
         nock('https://gw-ipfs.example.com')
           .get('/ar-io/info')
@@ -551,36 +550,6 @@ describe('Observer', function () {
           expectedWallets: ['WALLET'],
         });
         expect(result.supportsIpfs).to.equal(false);
-      });
-
-      it('scores an IPFS name NEUTRAL on a gateway without IPFS support, without probing it', async function () {
-        // Reference says the name resolves via IPFS. The gateway does NOT support
-        // IPFS, so the name must be neutral — and no request should be made to the
-        // gateway (no nock is registered for it; a probe would error).
-        (observer as any).referenceGatewayResolutionCache = {
-          get: async () => ({
-            statusCode: 200,
-            resolvedId: 'bafyCID',
-            ttlSeconds: '900',
-            contentLength: '10',
-            contentType: 'image/jpeg',
-            dataHashDigest: 'h',
-            protocol: 'ipfs',
-            timings: null,
-          }),
-        };
-
-        const result = await observer.assessArnsName({
-          host: 'gw-without-ipfs.example.com',
-          arnsName: 'ipfsname',
-          entropy,
-          supportsIpfs: false,
-        });
-
-        expect(result.outcome).to.equal('neutral');
-        expect(result.protocol).to.equal('ipfs');
-        expect(result.pass).to.equal(false);
-        expect(result.resolvedId).to.equal(null);
       });
     });
 
@@ -619,7 +588,6 @@ describe('Observer', function () {
           host,
           arnsName,
           entropy,
-          supportsIpfs: true,
         });
 
         expect(result.outcome).to.equal('pass');
@@ -627,27 +595,28 @@ describe('Observer', function () {
         expect(result.protocol).to.equal('ipfs');
       });
 
-      it('FAILS when the gateway serves bytes that do not match the CID', async function () {
+      it('FAILS when the gateway agrees on the CID but serves non-matching bytes', async function () {
         const cid = await rawCidFor(Buffer.from('the real content'));
         setReferenceCid(cid);
         nock(`https://${arnsName}.${host}`)
           .get('/?format=raw')
           .reply(200, Buffer.from('tampered content'), {
-            'x-arns-resolved-id': cid,
+            'x-arns-resolved-id': cid, // gateway agrees on the binding
           });
 
         const result = await observer.assessArnsName({
           host,
           arnsName,
           entropy,
-          supportsIpfs: true,
         });
 
         expect(result.outcome).to.equal('fail');
         expect(result.pass).to.equal(false);
       });
 
-      it('FAILS when a supporting gateway does not serve the block', async function () {
+      it('scores NEUTRAL (not fail) when the gateway does not serve the block', async function () {
+        // A non-IPFS gateway routes the CID down its Arweave path and 404s —
+        // availability is not proof of misbehaviour, so it is neutral.
         const cid = await rawCidFor(Buffer.from('x'));
         setReferenceCid(cid);
         nock(`https://${arnsName}.${host}`).get('/?format=raw').reply(404);
@@ -656,11 +625,32 @@ describe('Observer', function () {
           host,
           arnsName,
           entropy,
-          supportsIpfs: true,
         });
 
-        expect(result.outcome).to.equal('fail');
+        expect(result.outcome).to.equal('neutral');
         expect(result.resolvedStatusCode).to.equal(404);
+      });
+
+      it('scores NEUTRAL on a binding disagreement (stale reference vs mid-epoch repoint)', async function () {
+        // Reference still points at cidOld; the gateway serves cidNew's block and
+        // reports cidNew. Bytes do not match cidOld, but the gateway agrees with
+        // ITSELF — a stale-cache binding race, not corrupt bytes. => neutral.
+        const cidOld = await rawCidFor(Buffer.from('old content'));
+        const newBytes = Buffer.from('new content');
+        const cidNew = await rawCidFor(newBytes);
+        setReferenceCid(cidOld);
+        nock(`https://${arnsName}.${host}`)
+          .get('/?format=raw')
+          .reply(200, newBytes, { 'x-arns-resolved-id': cidNew });
+
+        const result = await observer.assessArnsName({
+          host,
+          arnsName,
+          entropy,
+        });
+
+        expect(result.outcome).to.equal('neutral');
+        expect(result.pass).to.equal(false);
       });
 
       it('scores NEUTRAL when the reference binding is unavailable', async function () {
@@ -670,11 +660,25 @@ describe('Observer', function () {
           host,
           arnsName,
           entropy,
-          supportsIpfs: true,
         });
 
         expect(result.outcome).to.equal('neutral');
         expect(result.pass).to.equal(false);
+      });
+
+      it('getIpfsRawBlock returns bytes:null on timeout instead of hanging', async function () {
+        nock('https://slow.example.com')
+          .get('/?format=raw')
+          .delay(300)
+          .reply(200, Buffer.from('too late'));
+
+        const result = await getIpfsRawBlock({
+          url: 'https://slow.example.com/?format=raw',
+          got,
+          timeoutMs: 50,
+        });
+
+        expect(result.bytes).to.equal(null);
       });
     });
 

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -31,6 +31,7 @@ import {
   generateRandomRanges,
   getArnsResolution,
   getIpfsRawBlock,
+  isIpfsAssessable,
   Observer,
 } from './observer.js';
 import { ReferenceGatewaySource } from './types.js';
@@ -64,6 +65,46 @@ function createReport(
 }
 
 describe('Observer', function () {
+  describe('isIpfsAssessable', function () {
+    const base = {
+      statusCode: 200,
+      ttlSeconds: '900',
+      contentLength: '1',
+      contentType: 'x',
+      dataHashDigest: null,
+      timings: null,
+    };
+
+    it('true only when protocol=ipfs AND resolvedId is a valid CID', async function () {
+      const cid = 'bafkreie2b7epkp5fadjerwtagfme2ukirn7nhoflpe4s43yvnoxtddw4m4';
+      expect(
+        isIpfsAssessable({ ...base, protocol: 'ipfs', resolvedId: cid }),
+      ).to.equal(true);
+    });
+
+    it('false when protocol=ipfs but resolvedId is not a CID (poisoned reference)', async function () {
+      // A poisoned reference must not flip an Arweave name onto the neutral-capable
+      // IPFS path with a non-CID resolvedId.
+      expect(
+        isIpfsAssessable({
+          ...base,
+          protocol: 'ipfs',
+          resolvedId: 'zt6spBgLNvJ7cMxCVPtRbEnYr7A9zZ1YxtXmefGc7lk',
+        }),
+      ).to.equal(false);
+    });
+
+    it('false for an arweave-protocol name', async function () {
+      expect(
+        isIpfsAssessable({
+          ...base,
+          protocol: 'arweave',
+          resolvedId: 'anything',
+        }),
+      ).to.equal(false);
+    });
+  });
+
   describe('getArnsResolution', function () {
     const url = 'https://arnsname.gateway.com';
     const invalidUrl = 'http://invalidhost.invaliddomain';
@@ -635,19 +676,20 @@ describe('Observer', function () {
         expect(result.resolvedStatusCode).to.equal(404);
       });
 
-      it('scores NEUTRAL on a binding disagreement (stale reference vs mid-epoch repoint)', async function () {
-        // Reference still points at cidOld; the gateway serves cidNew's block and
-        // reports cidNew. Bytes do not match cidOld, but the gateway agrees with
-        // ITSELF — a stale-cache binding race, not corrupt bytes. => neutral.
-        const cidOld = await rawCidFor(Buffer.from('old content'));
-        const newBytes = Buffer.from('new content');
-        const cidNew = await rawCidFor(newBytes);
-        setReferenceCid(cidOld);
+      it('FAILS when served bytes do not match the reference CID, even if the gateway self-reports a matching CID', async function () {
+        // The gateway serves bytes that do not hash to the reference CID and echoes
+        // a CID it minted from those very bytes. That "self-consistent" proof means
+        // nothing (the gateway controls both), so it must be FAIL — trusting the
+        // gateway's own resolvedId would let any garbage dodge to neutral.
+        const cidRef = await rawCidFor(Buffer.from('old content'));
+        const servedBytes = Buffer.from('attacker content');
+        const cidSelf = await rawCidFor(servedBytes);
+        setReferenceCid(cidRef);
         nock(`https://${arnsName}.${host}`)
           .get('/?format=raw')
-          .reply(200, newBytes, {
+          .reply(200, servedBytes, {
             'content-type': 'application/vnd.ipld.raw',
-            'x-arns-resolved-id': cidNew,
+            'x-arns-resolved-id': cidSelf,
           });
 
         const result = await observer.assessArnsName({
@@ -656,20 +698,7 @@ describe('Observer', function () {
           entropy,
         });
 
-        expect(result.outcome).to.equal('neutral');
-        expect(result.pass).to.equal(false);
-      });
-
-      it('scores NEUTRAL when the reference binding is unavailable', async function () {
-        setReferenceCid(null);
-        // No nock: the gateway must not be probed when there is no binding.
-        const result = await observer.assessArnsName({
-          host,
-          arnsName,
-          entropy,
-        });
-
-        expect(result.outcome).to.equal('neutral');
+        expect(result.outcome).to.equal('fail');
         expect(result.pass).to.equal(false);
       });
 

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -75,14 +75,17 @@ describe('Observer', function () {
       timings: null,
     };
 
-    it('true only when protocol=ipfs AND resolvedId is a valid CID', async function () {
-      const cid = 'bafkreie2b7epkp5fadjerwtagfme2ukirn7nhoflpe4s43yvnoxtddw4m4';
+    const cid = 'bafkreie2b7epkp5fadjerwtagfme2ukirn7nhoflpe4s43yvnoxtddw4m4';
+
+    it('true when resolvedId is a valid CID, EVEN IF the protocol header is absent', async function () {
+      // The consensused CID is the ground truth; an older pool gateway that omits
+      // x-arns-protocol must not flip a real IPFS name off the trustless path.
       expect(
-        isIpfsAssessable({ ...base, protocol: 'ipfs', resolvedId: cid }),
+        isIpfsAssessable({ ...base, protocol: null, resolvedId: cid }),
       ).to.equal(true);
     });
 
-    it('false when protocol=ipfs but resolvedId is not a CID (poisoned reference)', async function () {
+    it('false when resolvedId is not a CID, even if protocol=ipfs (poisoned reference)', async function () {
       // A poisoned reference must not flip an Arweave name onto the neutral-capable
       // IPFS path with a non-CID resolvedId.
       expect(
@@ -94,12 +97,12 @@ describe('Observer', function () {
       ).to.equal(false);
     });
 
-    it('false for an arweave-protocol name', async function () {
+    it('false for an Arweave name (tx id is not a valid CID)', async function () {
       expect(
         isIpfsAssessable({
           ...base,
           protocol: 'arweave',
-          resolvedId: 'anything',
+          resolvedId: 'zt6spBgLNvJ7cMxCVPtRbEnYr7A9zZ1YxtXmefGc7lk',
         }),
       ).to.equal(false);
     });

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -582,7 +582,10 @@ describe('Observer', function () {
         setReferenceCid(cid);
         nock(`https://${arnsName}.${host}`)
           .get('/?format=raw')
-          .reply(200, bytes, { 'x-arns-resolved-id': cid });
+          .reply(200, bytes, {
+            'content-type': 'application/vnd.ipld.raw',
+            'x-arns-resolved-id': cid,
+          });
 
         const result = await observer.assessArnsName({
           host,
@@ -601,6 +604,7 @@ describe('Observer', function () {
         nock(`https://${arnsName}.${host}`)
           .get('/?format=raw')
           .reply(200, Buffer.from('tampered content'), {
+            'content-type': 'application/vnd.ipld.raw',
             'x-arns-resolved-id': cid, // gateway agrees on the binding
           });
 
@@ -641,7 +645,10 @@ describe('Observer', function () {
         setReferenceCid(cidOld);
         nock(`https://${arnsName}.${host}`)
           .get('/?format=raw')
-          .reply(200, newBytes, { 'x-arns-resolved-id': cidNew });
+          .reply(200, newBytes, {
+            'content-type': 'application/vnd.ipld.raw',
+            'x-arns-resolved-id': cidNew,
+          });
 
         const result = await observer.assessArnsName({
           host,

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -31,6 +31,7 @@ import {
   anchorChunkMetadata,
 } from './lib/chunk-metadata-anchor.js';
 import { customHashPRNG } from './lib/prng.js';
+import { verifyBytesAgainstCid } from './lib/ipfs-cid.js';
 import {
   parseTxPath,
   safeBigIntToNumber,
@@ -263,6 +264,94 @@ export async function getArnsResolution({
   }
 
   return getHashWithinFirstMiB();
+}
+
+// A single IPFS block is bounded (~1-2 MiB by protocol); cap the read so a
+// misbehaving gateway can't stream an unbounded body into memory.
+export const MAX_IPFS_RAW_BLOCK_BYTES = 4 * 1024 * 1024; // 4 MiB
+
+/**
+ * Fetch the raw IPLD block for an ArNS name from a gateway's trustless endpoint
+ * (`?format=raw`) so it can be verified against the CID. Streams with a hard byte
+ * cap. Returns `bytes: null` when the gateway did not serve a 200 block (or it
+ * exceeded the cap); `statusCode`/`resolvedId` are surfaced for diagnostics.
+ */
+export async function getIpfsRawBlock({
+  url,
+  got,
+}: {
+  url: string;
+  got: Got;
+}): Promise<{
+  statusCode: number;
+  resolvedId: string | null;
+  bytes: Buffer | null;
+}> {
+  return new Promise((resolve, reject) => {
+    const stream = got.stream.get(url, {
+      headers: {
+        'Accept-Encoding': 'identity',
+        Accept: 'application/vnd.ipld.raw',
+      },
+    });
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let statusCode = 0;
+    let resolvedId: string | null = null;
+    let settled = false;
+    const done = (v: {
+      statusCode: number;
+      resolvedId: string | null;
+      bytes: Buffer | null;
+    }) => {
+      if (!settled) {
+        settled = true;
+        resolve(v);
+      }
+    };
+
+    stream.on('response', (resp) => {
+      statusCode = resp.statusCode;
+      resolvedId =
+        (resp.headers['x-arns-resolved-id'] as string | undefined) ?? null;
+      if (statusCode !== 200) {
+        stream.destroy();
+        done({ statusCode, resolvedId, bytes: null });
+      }
+    });
+
+    stream.on('data', (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > MAX_IPFS_RAW_BLOCK_BYTES) {
+        stream.destroy();
+        done({ statusCode, resolvedId, bytes: null });
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    stream.on('end', () => {
+      done({ statusCode, resolvedId, bytes: Buffer.concat(chunks) });
+    });
+
+    stream.on('error', (error: RequestError) => {
+      const rs = error.response?.statusCode;
+      if (rs !== undefined) {
+        done({
+          statusCode: rs,
+          resolvedId:
+            (error.response?.headers?.['x-arns-resolved-id'] as
+              | string
+              | undefined) ?? resolvedId,
+          bytes: null,
+        });
+      } else if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    });
+  });
 }
 
 export async function assessOwnership({
@@ -1887,6 +1976,97 @@ export class Observer {
     }
   }
 
+  // Trustlessly assess an IPFS-protocol ArNS name: fetch the gateway's raw block
+  // (`?format=raw`) and verify it against the CID the name resolves to (the
+  // reference binding). No reference-gateway byte trust; the CID is the proof.
+  private async assessIpfsNameTrustlessly({
+    host,
+    arnsName,
+    referenceResolution,
+  }: {
+    host: string;
+    arnsName: string;
+    referenceResolution: ArnsResolution;
+  }): Promise<ArnsNameAssessment> {
+    const assessedAt = +(Date.now() / 1000).toFixed(0);
+    const expectedId = referenceResolution.resolvedId ?? null;
+
+    // Without a reference binding (which CID the name should resolve to) there is
+    // nothing to verify against — neutral rather than blaming the gateway.
+    if (expectedId === null) {
+      return {
+        assessedAt,
+        expectedStatusCode: referenceResolution.statusCode,
+        expectedId: null,
+        resolvedId: null,
+        expectedDataHash: referenceResolution.dataHashDigest ?? null,
+        resolvedDataHash: null,
+        protocol: 'ipfs',
+        outcome: 'neutral',
+        pass: false,
+        failureReason:
+          'neutral: reference resolution unavailable for IPFS name',
+      };
+    }
+
+    const timer = metrics.arnsResolutionHistogram.startTimer();
+    const { statusCode, resolvedId, bytes } = await getIpfsRawBlock({
+      url: `https://${arnsName}.${host}/?format=raw`,
+      got: this.gotClient,
+    });
+    timer();
+
+    const base = {
+      assessedAt,
+      expectedStatusCode: referenceResolution.statusCode,
+      resolvedStatusCode: statusCode,
+      expectedId,
+      resolvedId,
+      expectedDataHash: referenceResolution.dataHashDigest ?? null,
+      protocol: 'ipfs' as const,
+    };
+
+    if (bytes === null) {
+      // A supporting gateway failed to serve the verifiable block.
+      return {
+        ...base,
+        resolvedDataHash: null,
+        outcome: 'fail',
+        pass: false,
+        failureReason: `gateway did not serve a raw block (status ${statusCode})`,
+      };
+    }
+
+    const resolvedDataHash = crypto
+      .createHash('sha256')
+      .update(bytes)
+      .digest('base64url');
+    const verification = await verifyBytesAgainstCid(expectedId, bytes);
+
+    if (verification === 'unsupported') {
+      // The CID uses a multihash we can't verify (not sha2-256) — neutral.
+      return {
+        ...base,
+        resolvedDataHash,
+        outcome: 'neutral',
+        pass: false,
+        failureReason: `neutral: CID not trustlessly verifiable (${expectedId})`,
+      };
+    }
+
+    if (verification === 'pass') {
+      return { ...base, resolvedDataHash, outcome: 'pass', pass: true };
+    }
+
+    return {
+      ...base,
+      resolvedDataHash,
+      outcome: 'fail',
+      pass: false,
+      failureReason: `IPFS content verification failed: served bytes do not match CID ${expectedId}`,
+    };
+  }
+
   async assessArnsName({
     host,
     arnsName,
@@ -1926,6 +2106,17 @@ export class Observer {
         failureReason:
           'neutral: gateway does not advertise IPFS support (adoption ramp)',
       };
+    }
+
+    // Trustless IPFS verification (Phase 2): the resolvedId IS a content hash, so
+    // verify the served bytes against the CID directly instead of comparing a
+    // sampled digest to a reference gateway. Stronger than the Arweave path.
+    if (protocol === 'ipfs') {
+      return this.assessIpfsNameTrustlessly({
+        host,
+        arnsName,
+        referenceResolution,
+      });
     }
 
     const arnsResolutionTimer = metrics.arnsResolutionHistogram.startTimer();

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -279,16 +279,23 @@ export const MAX_IPFS_RAW_BLOCK_BYTES = 4 * 1024 * 1024; // 4 MiB
 export async function getIpfsRawBlock({
   url,
   got,
+  timeoutMs,
 }: {
   url: string;
   got: Got;
+  timeoutMs: number;
 }): Promise<{
   statusCode: number;
   resolvedId: string | null;
   bytes: Buffer | null;
 }> {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     const stream = got.stream.get(url, {
+      // An explicit request deadline sized for cold IPFS retrieval (the base
+      // client's socket-idle timeout is tuned for fast Arweave calls and would
+      // misclassify slow-but-valid content). Also bounds a slow-drip gateway so
+      // report generation can't hang.
+      timeout: { request: timeoutMs },
       headers: {
         'Accept-Encoding': 'identity',
         Accept: 'application/vnd.ipld.raw',
@@ -335,21 +342,20 @@ export async function getIpfsRawBlock({
       done({ statusCode, resolvedId, bytes: Buffer.concat(chunks) });
     });
 
+    // Any error — connection refused, timeout, TLS, or a mid-body read error
+    // after a 200 — resolves as "not served" (bytes: null) rather than rejecting.
+    // The caller scores an unserved block as NEUTRAL (content unavailability is
+    // not proof the gateway misbehaved), and never leaves a pending promise.
     stream.on('error', (error: RequestError) => {
       const rs = error.response?.statusCode;
-      if (rs !== undefined) {
-        done({
-          statusCode: rs,
-          resolvedId:
-            (error.response?.headers?.['x-arns-resolved-id'] as
-              | string
-              | undefined) ?? resolvedId,
-          bytes: null,
-        });
-      } else if (!settled) {
-        settled = true;
-        reject(error);
-      }
+      done({
+        statusCode: rs ?? statusCode,
+        resolvedId:
+          (error.response?.headers?.['x-arns-resolved-id'] as
+            | string
+            | undefined) ?? resolvedId,
+        bytes: null,
+      });
     });
   });
 }
@@ -2024,6 +2030,7 @@ export class Observer {
     const { statusCode, resolvedId, bytes } = await getIpfsRawBlock({
       url: `https://${arnsName}.${host}/?format=raw`,
       got: this.gotClient,
+      timeoutMs: config.IPFS_ASSESSMENT_TIMEOUT_MS,
     });
     timer();
 
@@ -2037,14 +2044,24 @@ export class Observer {
       protocol: 'ipfs' as const,
     };
 
+    // Scoring rule: FAIL only on a proven-wrong answer — the gateway agrees on
+    // the CID (its resolvedId matches the reference binding) yet serves bytes
+    // that do not hash to it. Everything else that isn't a clean PASS is NEUTRAL
+    // (excluded from the denominator): content unavailability (no live provider),
+    // timeouts, a CID we can't verify, or a binding disagreement that may just be
+    // a stale reference cache vs a mid-epoch repoint. This makes participating in
+    // IPFS never *riskier* than abstaining, and can't be griefed by availability.
+
     if (bytes === null) {
-      // A supporting gateway failed to serve the verifiable block.
+      // Not served: a non-IPFS gateway routes the CID to its Arweave path and
+      // 404s, or the content has no live provider network-wide, or the fetch
+      // timed out. None of these prove the gateway served wrong content.
       return {
         ...base,
         resolvedDataHash: null,
-        outcome: 'fail',
+        outcome: 'neutral',
         pass: false,
-        failureReason: `gateway did not serve a raw block (status ${statusCode})`,
+        failureReason: `neutral: gateway did not serve a raw block (status ${statusCode})`,
       };
     }
 
@@ -2053,6 +2070,10 @@ export class Observer {
       .update(bytes)
       .digest('base64url');
     const verification = await verifyBytesAgainstCid(expectedId, bytes);
+
+    if (verification === 'pass') {
+      return { ...base, resolvedDataHash, outcome: 'pass', pass: true };
+    }
 
     if (verification === 'unsupported') {
       // The CID uses a multihash we can't verify (not sha2-256) — neutral.
@@ -2065,10 +2086,20 @@ export class Observer {
       };
     }
 
-    if (verification === 'pass') {
-      return { ...base, resolvedDataHash, outcome: 'pass', pass: true };
+    // verification === 'fail'. If the gateway resolved the name to a DIFFERENT
+    // CID than the reference, the disagreement may be a stale reference cache
+    // (5-min TTL) racing a mid-epoch ArNS repoint — not proof of wrong bytes.
+    if (resolvedId !== null && resolvedId !== expectedId) {
+      return {
+        ...base,
+        resolvedDataHash,
+        outcome: 'neutral',
+        pass: false,
+        failureReason: `neutral: binding disagreement (gateway ${resolvedId} vs reference ${expectedId})`,
+      };
     }
 
+    // The gateway agrees on the CID but served bytes that don't hash to it.
     return {
       ...base,
       resolvedDataHash,
@@ -2082,12 +2113,10 @@ export class Observer {
     host,
     arnsName,
     entropy,
-    supportsIpfs = false,
   }: {
     host: string;
     arnsName: string;
     entropy: Buffer;
-    supportsIpfs?: boolean;
   }): Promise<ArnsNameAssessment> {
     // TODO instantiate cache in constructor
     // Currently not possible because we only have access to epochStartHeight in generateReport
@@ -2099,29 +2128,14 @@ export class Observer {
       await this.referenceGatewayResolutionCache.get(arnsName);
     const protocol = referenceResolution.protocol ?? 'arweave';
 
-    // Capability gate (IPFS adoption ramp): an IPFS-protocol name assessed
-    // against a gateway that does not yet advertise IPFS support is NEUTRAL, not
-    // a failure — excluded from the names denominator so it can't sink a gateway
-    // that simply hasn't enabled IPFS. Skip probing the gateway entirely.
-    if (protocol === 'ipfs' && supportsIpfs !== true) {
-      return {
-        assessedAt: +(Date.now() / 1000).toFixed(0),
-        expectedStatusCode: referenceResolution.statusCode,
-        expectedId: referenceResolution.resolvedId ?? null,
-        resolvedId: null,
-        expectedDataHash: referenceResolution.dataHashDigest ?? null,
-        resolvedDataHash: null,
-        protocol,
-        outcome: 'neutral',
-        pass: false,
-        failureReason:
-          'neutral: gateway does not advertise IPFS support (adoption ramp)',
-      };
-    }
-
     // Trustless IPFS verification (Phase 2): the resolvedId IS a content hash, so
     // verify the served bytes against the CID directly instead of comparing a
-    // sampled digest to a reference gateway. Stronger than the Arweave path.
+    // sampled digest to a reference gateway. We ALWAYS probe — capability is
+    // judged behaviorally, not on the gateway's self-reported /ar-io/info flag
+    // (which a malicious operator could flip to exempt itself). A gateway that
+    // doesn't serve the name (a non-IPFS gateway 404s its Arweave path) scores
+    // NEUTRAL; a gateway that serves wrong bytes scores FAIL. So a non-IPFS
+    // gateway is never failed, and a liar serving corrupt bytes can't hide.
     if (protocol === 'ipfs') {
       return this.assessIpfsNameTrustlessly({
         host,
@@ -2178,12 +2192,10 @@ export class Observer {
     host,
     names,
     entropy,
-    supportsIpfs = false,
   }: {
     host: string;
     names: string[];
     entropy: Buffer;
-    supportsIpfs?: boolean;
   }): Promise<ArnsNameAssessments> {
     return pMap(
       names,
@@ -2193,7 +2205,6 @@ export class Observer {
             host,
             arnsName: name,
             entropy,
-            supportsIpfs,
           });
         } catch (err) {
           const errorMessage =
@@ -2347,13 +2358,11 @@ export class Observer {
                 host: host.fqdn,
                 names: prescribedNames,
                 entropy,
-                supportsIpfs: ownershipAssessment.supportsIpfs,
               }),
               this.assessArnsNames({
                 host: host.fqdn,
                 names: chosenNames,
                 entropy,
-                supportsIpfs: ownershipAssessment.supportsIpfs,
               }),
             ]),
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -477,34 +477,24 @@ export async function assessIpfsNameTrustless({
     };
   }
 
-  // verification === 'fail': the bytes don't hash to the reference CID. Give the
-  // benefit of the doubt for a stale-cache / mid-epoch-repoint race ONLY when the
-  // gateway PROVES it is serving authentic content for the DIFFERENT CID it claims
-  // (bytes hash to the gateway's own resolvedId). A liar serving garbage with a
-  // bogus resolvedId fails this proof and is scored FAIL — the fail/neutral
-  // decision never depends on an unverified, attacker-controlled header.
-  if (
-    resolvedId !== null &&
-    resolvedId !== expectedId &&
-    isValidCid(resolvedId) &&
-    (await verifyBytesAgainstCid(resolvedId, bytes)) === 'pass'
-  ) {
-    return {
-      ...base,
-      resolvedDataHash,
-      outcome: 'neutral',
-      pass: false,
-      failureReason: `neutral: binding disagreement (gateway serves ${resolvedId} vs reference ${expectedId})`,
-    };
-  }
-
-  // Bytes match neither the reference CID nor the gateway's own claimed CID.
+  // verification === 'fail': the served bytes do not hash to the reference-bound
+  // CID. This is a proven-wrong answer -> FAIL, consistent with the Arweave path
+  // (which likewise fails a gateway whose resolvedId disagrees with the reference).
+  //
+  // We deliberately do NOT excuse this based on the gateway's self-reported
+  // resolvedId: a gateway controls both the bytes AND that header, and can mint a
+  // CID from its own garbage (cid = CID(sha256(bytes))) so that the bytes "verify"
+  // against it by construction — proving nothing about the name's true binding.
+  // The only trustworthy binding is the reference (expectedId). A genuine
+  // mid-epoch repoint that races the reference cache may cause a rare, single-name
+  // false FAIL; that is bounded by the >=80% names threshold, the 3-cycle majority
+  // vote, and self-corrects next epoch — the same trade-off the Arweave path makes.
   return {
     ...base,
     resolvedDataHash,
     outcome: 'fail',
     pass: false,
-    failureReason: `IPFS content verification failed: served bytes do not match CID ${expectedId}`,
+    failureReason: `IPFS content verification failed: served bytes do not match reference CID ${expectedId}`,
   };
 }
 
@@ -517,6 +507,19 @@ export function arnsNameOutcome(
   a: ArnsNameAssessment,
 ): 'pass' | 'fail' | 'neutral' {
   return a.outcome ?? (a.pass ? 'pass' : 'fail');
+}
+
+// Whether a name should be assessed via the trustless IPFS path. Requires the
+// (trusted) reference to BOTH report protocol 'ipfs' AND resolve to a valid CID.
+// This stops a poisoned/malformed reference from flipping an Arweave name onto the
+// neutral-capable IPFS path, where a colluding gateway's deserved FAIL would be
+// converted into an excluded NEUTRAL.
+export function isIpfsAssessable(r: ArnsResolution): boolean {
+  return (
+    (r.protocol ?? 'arweave') === 'ipfs' &&
+    r.resolvedId !== null &&
+    isValidCid(r.resolvedId)
+  );
 }
 
 export async function assessOwnership({
@@ -2168,7 +2171,7 @@ export class Observer {
     // doesn't serve the name (a non-IPFS gateway 404s its Arweave path) scores
     // NEUTRAL; a gateway that serves wrong bytes scores FAIL. So a non-IPFS
     // gateway is never failed, and a liar serving corrupt bytes can't hide.
-    if (protocol === 'ipfs') {
+    if (isIpfsAssessable(referenceResolution)) {
       return assessIpfsNameTrustless({
         host,
         arnsName,

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -31,7 +31,7 @@ import {
   anchorChunkMetadata,
 } from './lib/chunk-metadata-anchor.js';
 import { customHashPRNG } from './lib/prng.js';
-import { verifyBytesAgainstCid } from './lib/ipfs-cid.js';
+import { verifyBytesAgainstCid, isValidCid } from './lib/ipfs-cid.js';
 import {
   parseTxPath,
   safeBigIntToNumber,
@@ -291,11 +291,12 @@ export async function getIpfsRawBlock({
 }> {
   return new Promise((resolve) => {
     const stream = got.stream.get(url, {
-      // An explicit request deadline sized for cold IPFS retrieval (the base
-      // client's socket-idle timeout is tuned for fast Arweave calls and would
-      // misclassify slow-but-valid content). Also bounds a slow-drip gateway so
-      // report generation can't hang.
-      timeout: { request: timeoutMs },
+      // Explicit deadlines sized for cold IPFS retrieval. BOTH request and socket
+      // are overridden: the base client's short socket-idle timeout (tuned for
+      // fast Arweave calls) would otherwise fire first and abort slow-but-valid
+      // cold-DHT retrieval. `request` also bounds a slow-drip gateway so report
+      // generation can't hang.
+      timeout: { request: timeoutMs, socket: timeoutMs },
       headers: {
         'Accept-Encoding': 'identity',
         Accept: 'application/vnd.ipld.raw',
@@ -322,7 +323,17 @@ export async function getIpfsRawBlock({
       statusCode = resp.statusCode;
       resolvedId =
         (resp.headers['x-arns-resolved-id'] as string | undefined) ?? null;
-      if (statusCode !== 200) {
+      const contentType = (
+        (resp.headers['content-type'] as string | undefined) ?? ''
+      ).toLowerCase();
+      // Only a genuine trustless raw block is verifiable. A non-200, or a 200
+      // that is NOT application/vnd.ipld.raw (an HTML error page, or a gateway
+      // that ignored ?format=raw), is treated as not-served (bytes: null ->
+      // neutral) so it can never be scored as a proven-wrong block.
+      if (
+        statusCode !== 200 ||
+        !contentType.includes('application/vnd.ipld.raw')
+      ) {
         stream.destroy();
         done({ statusCode, resolvedId, bytes: null });
       }
@@ -339,7 +350,13 @@ export async function getIpfsRawBlock({
     });
 
     stream.on('end', () => {
-      done({ statusCode, resolvedId, bytes: Buffer.concat(chunks) });
+      // A 200 with an empty body is not a served block — treat as not-served
+      // (neutral), consistent with "availability is never a fail".
+      done({
+        statusCode,
+        resolvedId,
+        bytes: total > 0 ? Buffer.concat(chunks) : null,
+      });
     });
 
     // Any error — connection refused, timeout, TLS, or a mid-body read error
@@ -358,6 +375,137 @@ export async function getIpfsRawBlock({
       });
     });
   });
+}
+
+/**
+ * Trustlessly assess an IPFS-protocol ArNS name: fetch the gateway's raw block
+ * (`?format=raw`) and verify it against the CID the name resolves to (the
+ * reference binding). No reference-gateway byte trust; the CID is the proof.
+ * Shared by the one-shot Observer and the live ContinuousObserver/GatewayAssessor
+ * paths so their scoring can never diverge.
+ *
+ * Scoring: FAIL only on a PROVEN-WRONG answer — the gateway serves 200 bytes that
+ * hash to NEITHER the reference CID nor the CID the gateway itself claims. A clean
+ * hash-match against the reference CID is PASS. Everything else is NEUTRAL
+ * (excluded from the denominator): not-served / non-200 / timeout, a CID we can't
+ * verify, or a genuine binding disagreement the gateway PROVES (its bytes hash to
+ * the different CID it claims — a stale-cache vs mid-epoch-repoint race). So a
+ * gateway is never failed for availability, yet a liar serving garbage cannot
+ * dodge FAIL by echoing a bogus resolvedId.
+ */
+export async function assessIpfsNameTrustless({
+  host,
+  arnsName,
+  referenceResolution,
+  got,
+  timeoutMs,
+}: {
+  host: string;
+  arnsName: string;
+  referenceResolution: ArnsResolution;
+  got: Got;
+  timeoutMs: number;
+}): Promise<ArnsNameAssessment> {
+  const assessedAt = +(Date.now() / 1000).toFixed(0);
+  const expectedId = referenceResolution.resolvedId ?? null;
+  const expectedDataHash = referenceResolution.dataHashDigest ?? null;
+
+  if (expectedId === null) {
+    // No reference binding to verify against — neutral, not the gateway's fault.
+    return {
+      assessedAt,
+      expectedStatusCode: referenceResolution.statusCode,
+      expectedId: null,
+      resolvedId: null,
+      expectedDataHash,
+      resolvedDataHash: null,
+      protocol: 'ipfs',
+      outcome: 'neutral',
+      pass: false,
+      failureReason: 'neutral: reference resolution unavailable for IPFS name',
+    };
+  }
+
+  const timer = metrics.arnsResolutionHistogram.startTimer();
+  const { statusCode, resolvedId, bytes } = await getIpfsRawBlock({
+    url: `https://${arnsName}.${host}/?format=raw`,
+    got,
+    timeoutMs,
+  });
+  timer();
+
+  const base = {
+    assessedAt,
+    expectedStatusCode: referenceResolution.statusCode,
+    resolvedStatusCode: statusCode,
+    expectedId,
+    resolvedId,
+    expectedDataHash,
+    protocol: 'ipfs' as const,
+  };
+
+  if (bytes === null) {
+    // Not served (non-IPFS gateway 404s its Arweave path, no live provider, or a
+    // timeout). None of these prove the gateway served wrong content.
+    return {
+      ...base,
+      resolvedDataHash: null,
+      outcome: 'neutral',
+      pass: false,
+      failureReason: `neutral: gateway did not serve a raw block (status ${statusCode})`,
+    };
+  }
+
+  const resolvedDataHash = crypto
+    .createHash('sha256')
+    .update(bytes)
+    .digest('base64url');
+  const verification = await verifyBytesAgainstCid(expectedId, bytes);
+
+  if (verification === 'pass') {
+    return { ...base, resolvedDataHash, outcome: 'pass', pass: true };
+  }
+
+  if (verification === 'unsupported') {
+    // The reference CID uses a multihash we can't verify (not sha2-256) — neutral.
+    return {
+      ...base,
+      resolvedDataHash,
+      outcome: 'neutral',
+      pass: false,
+      failureReason: `neutral: CID not trustlessly verifiable (${expectedId})`,
+    };
+  }
+
+  // verification === 'fail': the bytes don't hash to the reference CID. Give the
+  // benefit of the doubt for a stale-cache / mid-epoch-repoint race ONLY when the
+  // gateway PROVES it is serving authentic content for the DIFFERENT CID it claims
+  // (bytes hash to the gateway's own resolvedId). A liar serving garbage with a
+  // bogus resolvedId fails this proof and is scored FAIL — the fail/neutral
+  // decision never depends on an unverified, attacker-controlled header.
+  if (
+    resolvedId !== null &&
+    resolvedId !== expectedId &&
+    isValidCid(resolvedId) &&
+    (await verifyBytesAgainstCid(resolvedId, bytes)) === 'pass'
+  ) {
+    return {
+      ...base,
+      resolvedDataHash,
+      outcome: 'neutral',
+      pass: false,
+      failureReason: `neutral: binding disagreement (gateway serves ${resolvedId} vs reference ${expectedId})`,
+    };
+  }
+
+  // Bytes match neither the reference CID nor the gateway's own claimed CID.
+  return {
+    ...base,
+    resolvedDataHash,
+    outcome: 'fail',
+    pass: false,
+    failureReason: `IPFS content verification failed: served bytes do not match CID ${expectedId}`,
+  };
 }
 
 // Tri-state outcome for an ArNS name assessment. NEUTRAL names (e.g. an
@@ -1993,122 +2141,6 @@ export class Observer {
     }
   }
 
-  // Trustlessly assess an IPFS-protocol ArNS name: fetch the gateway's raw block
-  // (`?format=raw`) and verify it against the CID the name resolves to (the
-  // reference binding). No reference-gateway byte trust; the CID is the proof.
-  private async assessIpfsNameTrustlessly({
-    host,
-    arnsName,
-    referenceResolution,
-  }: {
-    host: string;
-    arnsName: string;
-    referenceResolution: ArnsResolution;
-  }): Promise<ArnsNameAssessment> {
-    const assessedAt = +(Date.now() / 1000).toFixed(0);
-    const expectedId = referenceResolution.resolvedId ?? null;
-
-    // Without a reference binding (which CID the name should resolve to) there is
-    // nothing to verify against — neutral rather than blaming the gateway.
-    if (expectedId === null) {
-      return {
-        assessedAt,
-        expectedStatusCode: referenceResolution.statusCode,
-        expectedId: null,
-        resolvedId: null,
-        expectedDataHash: referenceResolution.dataHashDigest ?? null,
-        resolvedDataHash: null,
-        protocol: 'ipfs',
-        outcome: 'neutral',
-        pass: false,
-        failureReason:
-          'neutral: reference resolution unavailable for IPFS name',
-      };
-    }
-
-    const timer = metrics.arnsResolutionHistogram.startTimer();
-    const { statusCode, resolvedId, bytes } = await getIpfsRawBlock({
-      url: `https://${arnsName}.${host}/?format=raw`,
-      got: this.gotClient,
-      timeoutMs: config.IPFS_ASSESSMENT_TIMEOUT_MS,
-    });
-    timer();
-
-    const base = {
-      assessedAt,
-      expectedStatusCode: referenceResolution.statusCode,
-      resolvedStatusCode: statusCode,
-      expectedId,
-      resolvedId,
-      expectedDataHash: referenceResolution.dataHashDigest ?? null,
-      protocol: 'ipfs' as const,
-    };
-
-    // Scoring rule: FAIL only on a proven-wrong answer — the gateway agrees on
-    // the CID (its resolvedId matches the reference binding) yet serves bytes
-    // that do not hash to it. Everything else that isn't a clean PASS is NEUTRAL
-    // (excluded from the denominator): content unavailability (no live provider),
-    // timeouts, a CID we can't verify, or a binding disagreement that may just be
-    // a stale reference cache vs a mid-epoch repoint. This makes participating in
-    // IPFS never *riskier* than abstaining, and can't be griefed by availability.
-
-    if (bytes === null) {
-      // Not served: a non-IPFS gateway routes the CID to its Arweave path and
-      // 404s, or the content has no live provider network-wide, or the fetch
-      // timed out. None of these prove the gateway served wrong content.
-      return {
-        ...base,
-        resolvedDataHash: null,
-        outcome: 'neutral',
-        pass: false,
-        failureReason: `neutral: gateway did not serve a raw block (status ${statusCode})`,
-      };
-    }
-
-    const resolvedDataHash = crypto
-      .createHash('sha256')
-      .update(bytes)
-      .digest('base64url');
-    const verification = await verifyBytesAgainstCid(expectedId, bytes);
-
-    if (verification === 'pass') {
-      return { ...base, resolvedDataHash, outcome: 'pass', pass: true };
-    }
-
-    if (verification === 'unsupported') {
-      // The CID uses a multihash we can't verify (not sha2-256) — neutral.
-      return {
-        ...base,
-        resolvedDataHash,
-        outcome: 'neutral',
-        pass: false,
-        failureReason: `neutral: CID not trustlessly verifiable (${expectedId})`,
-      };
-    }
-
-    // verification === 'fail'. If the gateway resolved the name to a DIFFERENT
-    // CID than the reference, the disagreement may be a stale reference cache
-    // (5-min TTL) racing a mid-epoch ArNS repoint — not proof of wrong bytes.
-    if (resolvedId !== null && resolvedId !== expectedId) {
-      return {
-        ...base,
-        resolvedDataHash,
-        outcome: 'neutral',
-        pass: false,
-        failureReason: `neutral: binding disagreement (gateway ${resolvedId} vs reference ${expectedId})`,
-      };
-    }
-
-    // The gateway agrees on the CID but served bytes that don't hash to it.
-    return {
-      ...base,
-      resolvedDataHash,
-      outcome: 'fail',
-      pass: false,
-      failureReason: `IPFS content verification failed: served bytes do not match CID ${expectedId}`,
-    };
-  }
-
   async assessArnsName({
     host,
     arnsName,
@@ -2137,10 +2169,12 @@ export class Observer {
     // NEUTRAL; a gateway that serves wrong bytes scores FAIL. So a non-IPFS
     // gateway is never failed, and a liar serving corrupt bytes can't hide.
     if (protocol === 'ipfs') {
-      return this.assessIpfsNameTrustlessly({
+      return assessIpfsNameTrustless({
         host,
         arnsName,
         referenceResolution,
+        got: this.gotClient,
+        timeoutMs: config.IPFS_ASSESSMENT_TIMEOUT_MS,
       });
     }
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -509,17 +509,17 @@ export function arnsNameOutcome(
   return a.outcome ?? (a.pass ? 'pass' : 'fail');
 }
 
-// Whether a name should be assessed via the trustless IPFS path. Requires the
-// (trusted) reference to BOTH report protocol 'ipfs' AND resolve to a valid CID.
-// This stops a poisoned/malformed reference from flipping an Arweave name onto the
-// neutral-capable IPFS path, where a colluding gateway's deserved FAIL would be
-// converted into an excluded NEUTRAL.
+// Whether a name should be assessed via the trustless IPFS path. Derived from the
+// CONSENSUSED resolvedId: an ArNS IPFS name resolves to a CID, an Arweave name to
+// a 43-char tx id (not a valid CID). We deliberately do NOT route on the
+// x-arns-protocol header — it is not part of reference consensus (the resolver
+// groups only by resolvedId and copies protocol from one arbitrary gateway), and
+// an older pool gateway may omit it, which would wrongly flip a real IPFS name
+// onto the Arweave path and FAIL honest non-IPFS gateways during the ramp. The CID
+// form is the ground truth; it also blocks a poisoned reference from flipping an
+// Arweave name (whose non-CID id is not a valid CID) onto the neutral-capable path.
 export function isIpfsAssessable(r: ArnsResolution): boolean {
-  return (
-    (r.protocol ?? 'arweave') === 'ipfs' &&
-    r.resolvedId !== null &&
-    isValidCid(r.resolvedId)
-  );
+  return r.resolvedId !== null && isValidCid(r.resolvedId);
 }
 
 export async function assessOwnership({

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -58,7 +58,11 @@ import {
   ReferenceGatewaySource,
 } from './types.js';
 
-export const REPORT_FORMAT_VERSION = 2;
+// v3: adds `protocol` and a tri-state `outcome` (pass|fail|neutral) to ArNS name
+// assessments so IPFS-protocol names can be scored neutral (excluded from the
+// names denominator) on gateways that don't yet support IPFS. On-chain
+// submission is unchanged (still a per-gateway pass/fail bitmap).
+export const REPORT_FORMAT_VERSION = 3;
 
 const NAME_PASS_THRESHOLD = 0.8;
 
@@ -141,6 +145,8 @@ export async function getArnsResolution({
         ? null
         : (response.headers['content-length'] ?? null),
     dataHashDigest: dataHashDigest ?? null,
+    protocol:
+      (response.headers['x-arns-protocol'] as string | undefined) ?? null,
     timings: response.timings,
   });
 
@@ -273,12 +279,17 @@ export async function assessOwnership({
       resp?.release === undefined || resp?.release === null
         ? undefined
         : String(resp.release);
+    // Capability signal for the IPFS adoption ramp: the gateway self-reports
+    // whether it serves IPFS via /ar-io/info (ipfs.enabled). Read here because
+    // assessOwnership already fetches /ar-io/info — no extra request.
+    const supportsIpfs = resp?.ipfs?.enabled === true;
     if (resp?.wallet) {
       if (!expectedWallets.includes(resp.wallet)) {
         const result = {
           expectedWallets,
           observedWallet: resp.wallet,
           observedRelease,
+          supportsIpfs,
           failureReason: `Wallet mismatch: expected one of ${expectedWallets.join(
             ', ',
           )} but found ${resp.wallet}`,
@@ -294,6 +305,7 @@ export async function assessOwnership({
           expectedWallets,
           observedWallet: resp.wallet,
           observedRelease,
+          supportsIpfs,
           pass: true,
         };
         metrics.ownershipAssessmentsCounter.inc({
@@ -307,6 +319,7 @@ export async function assessOwnership({
       expectedWallets,
       observedWallet: null,
       observedRelease,
+      supportsIpfs,
       failureReason: `No wallet found`,
       pass: false,
     };
@@ -1878,10 +1891,12 @@ export class Observer {
     host,
     arnsName,
     entropy,
+    supportsIpfs = false,
   }: {
     host: string;
     arnsName: string;
     entropy: Buffer;
+    supportsIpfs?: boolean;
   }): Promise<ArnsNameAssessment> {
     // TODO instantiate cache in constructor
     // Currently not possible because we only have access to epochStartHeight in generateReport
@@ -1891,6 +1906,27 @@ export class Observer {
 
     const referenceResolution =
       await this.referenceGatewayResolutionCache.get(arnsName);
+    const protocol = referenceResolution.protocol ?? 'arweave';
+
+    // Capability gate (IPFS adoption ramp): an IPFS-protocol name assessed
+    // against a gateway that does not yet advertise IPFS support is NEUTRAL, not
+    // a failure — excluded from the names denominator so it can't sink a gateway
+    // that simply hasn't enabled IPFS. Skip probing the gateway entirely.
+    if (protocol === 'ipfs' && supportsIpfs !== true) {
+      return {
+        assessedAt: +(Date.now() / 1000).toFixed(0),
+        expectedStatusCode: referenceResolution.statusCode,
+        expectedId: referenceResolution.resolvedId ?? null,
+        resolvedId: null,
+        expectedDataHash: referenceResolution.dataHashDigest ?? null,
+        resolvedDataHash: null,
+        protocol,
+        outcome: 'neutral',
+        pass: false,
+        failureReason:
+          'neutral: gateway does not advertise IPFS support (adoption ramp)',
+      };
+    }
 
     const arnsResolutionTimer = metrics.arnsResolutionHistogram.startTimer();
     const gatewayResolution = await getArnsResolution({
@@ -1927,6 +1963,8 @@ export class Observer {
       resolvedId: gatewayResolution.resolvedId ?? null,
       expectedDataHash: referenceResolution.dataHashDigest ?? null,
       resolvedDataHash: gatewayResolution.dataHashDigest ?? null,
+      protocol,
+      outcome: pass ? 'pass' : 'fail',
       failureReason,
       pass,
       timings: gatewayResolution?.timings?.phases,
@@ -1938,10 +1976,12 @@ export class Observer {
     host,
     names,
     entropy,
+    supportsIpfs = false,
   }: {
     host: string;
     names: string[];
     entropy: Buffer;
+    supportsIpfs?: boolean;
   }): Promise<ArnsNameAssessments> {
     return pMap(
       names,
@@ -1951,6 +1991,7 @@ export class Observer {
             host,
             arnsName: name,
             entropy,
+            supportsIpfs,
           });
         } catch (err) {
           const errorMessage =
@@ -1966,6 +2007,7 @@ export class Observer {
             resolvedId: null,
             expectedDataHash: null,
             resolvedDataHash: null,
+            outcome: 'fail' as const,
             failureReason: errorMessage?.slice(0, 512),
             pass: false,
           };
@@ -2103,11 +2145,13 @@ export class Observer {
                 host: host.fqdn,
                 names: prescribedNames,
                 entropy,
+                supportsIpfs: ownershipAssessment.supportsIpfs,
               }),
               this.assessArnsNames({
                 host: host.fqdn,
                 names: chosenNames,
                 entropy,
+                supportsIpfs: ownershipAssessment.supportsIpfs,
               }),
             ]),
 
@@ -2214,15 +2258,28 @@ export class Observer {
           });
         }
 
-        const nameCount = new Set([...prescribedNames, ...chosenNames]).size;
-        const namePassCount = Object.values({
+        const nameAssessmentList = Object.values({
           ...prescribedAssessments,
           ...chosenAssessments,
-        }).reduce(
-          (count, assessment) => (assessment.pass ? count + 1 : count),
-          0,
-        );
-        const namesPass = namePassCount >= nameCount * NAME_PASS_THRESHOLD;
+        });
+        // Tri-state scoring. Neutral names (e.g. an IPFS-protocol name on a
+        // gateway that does not yet advertise IPFS support) are EXCLUDED from the
+        // pass/fail denominator during the adoption ramp — they can neither pass
+        // nor fail the gateway. `outcome` falls back to pass/fail for any
+        // assessment produced before this field existed.
+        const outcomeOf = (a: (typeof nameAssessmentList)[number]) =>
+          a.outcome ?? (a.pass ? 'pass' : 'fail');
+        const namePassCount = nameAssessmentList.filter(
+          (a) => outcomeOf(a) === 'pass',
+        ).length;
+        const nameGradedCount = nameAssessmentList.filter(
+          (a) => outcomeOf(a) !== 'neutral',
+        ).length;
+        // If every sampled name was neutral there is nothing to grade — don't
+        // fail the gateway on absence of evidence.
+        const namesPass =
+          nameGradedCount === 0 ||
+          namePassCount >= nameGradedCount * NAME_PASS_THRESHOLD;
 
         // Check if offset observation enforcement should affect pass status
         const offsetPass =

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -2580,26 +2580,26 @@ export class Observer {
     return report;
   }
 
-  private calculateFailureRate(report: ObserverReport): number {
-    let totalAssessments = 0;
-    let failedAssessments = 0;
+  // Tally graded (non-neutral) assessments across a report. Neutral names are
+  // excluded from BOTH counts so they can't inflate the failure rate.
+  private tallyGradedAssessments(report: ObserverReport): {
+    failed: number;
+    graded: number;
+  } {
+    let graded = 0;
+    let failed = 0;
 
     Object.values(report.gatewayAssessments).forEach((gatewayAssessment) => {
-      // Count ownership assessment
-      totalAssessments++;
+      graded++; // ownership always counts
       if (!gatewayAssessment.ownershipAssessment.pass) {
-        failedAssessments++;
+        failed++;
       }
 
-      // Count prescribed + chosen name assessments, EXCLUDING neutral names from
-      // both the numerator and the denominator — otherwise a neutral name would
-      // inflate the failure rate and could change which observation is selected
-      // for the on-chain report.
       const countName = (assessment: ArnsNameAssessment) => {
         const outcome = arnsNameOutcome(assessment);
         if (outcome === 'neutral') return;
-        totalAssessments++;
-        if (outcome === 'fail') failedAssessments++;
+        graded++;
+        if (outcome === 'fail') failed++;
       };
       Object.values(gatewayAssessment.arnsAssessments.prescribedNames).forEach(
         countName,
@@ -2609,7 +2609,12 @@ export class Observer {
       );
     });
 
-    return totalAssessments > 0 ? failedAssessments / totalAssessments : 0;
+    return { failed, graded };
+  }
+
+  private calculateFailureRate(report: ObserverReport): number {
+    const { failed, graded } = this.tallyGradedAssessments(report);
+    return graded > 0 ? failed / graded : 0;
   }
 
   async generateReport(): Promise<ObserverReport> {
@@ -2657,14 +2662,26 @@ export class Observer {
       observations.push(observation);
     }
 
-    // Calculate failure rates and select the observation with the lowest rate
+    // Select the observation with the lowest failure rate. Since neutral names
+    // are excluded from the rate's denominator, two observations can have
+    // different graded-name counts — so on a tie, prefer the observation that
+    // graded MORE names (more evidence). This stops a run where many names went
+    // neutral (a spuriously low or zero rate over few graded names) from being
+    // selected over a fuller, equally-clean run.
+    const scoreOf = (report: ObserverReport) => {
+      const { failed, graded } = this.tallyGradedAssessments(report);
+      return { rate: graded > 0 ? failed / graded : 0, graded };
+    };
     let bestObservation = observations[0];
-    let lowestFailureRate = this.calculateFailureRate(observations[0]);
+    let best = scoreOf(observations[0]);
 
     for (let i = 1; i < observations.length; i++) {
-      const failureRate = this.calculateFailureRate(observations[i]);
-      if (failureRate < lowestFailureRate) {
-        lowestFailureRate = failureRate;
+      const candidate = scoreOf(observations[i]);
+      if (
+        candidate.rate < best.rate ||
+        (candidate.rate === best.rate && candidate.graded > best.graded)
+      ) {
+        best = candidate;
         bestObservation = observations[i];
       }
     }

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -354,6 +354,17 @@ export async function getIpfsRawBlock({
   });
 }
 
+// Tri-state outcome for an ArNS name assessment. NEUTRAL names (e.g. an
+// IPFS-protocol name on a gateway that does not yet advertise IPFS support) are
+// excluded from every pass/fail denominator — namesPass, the ArNS metrics, and
+// the failure rate that selects which observation is reported. Falls back to
+// pass/fail for assessments produced before `outcome` existed.
+export function arnsNameOutcome(
+  a: ArnsNameAssessment,
+): 'pass' | 'fail' | 'neutral' {
+  return a.outcome ?? (a.pass ? 'pass' : 'fail');
+}
+
 export async function assessOwnership({
   host,
   expectedWallets,
@@ -2402,11 +2413,12 @@ export class Observer {
                 })(),
           ]);
 
-        // Track ArNS assessment metrics
+        // Track ArNS assessment metrics. Neutral names are reported under their
+        // own status so they never inflate the pass/fail counts.
         Object.values(prescribedAssessments).forEach((assessment) => {
           metrics.arnsAssessmentsCounter.inc({
             type: 'prescribed',
-            status: assessment.pass ? 'pass' : 'fail',
+            status: arnsNameOutcome(assessment),
             enforced: 'true',
           });
         });
@@ -2414,7 +2426,7 @@ export class Observer {
         Object.values(chosenAssessments).forEach((assessment) => {
           metrics.arnsAssessmentsCounter.inc({
             type: 'chosen',
-            status: assessment.pass ? 'pass' : 'fail',
+            status: arnsNameOutcome(assessment),
             enforced: 'true',
           });
         });
@@ -2458,13 +2470,11 @@ export class Observer {
         // pass/fail denominator during the adoption ramp — they can neither pass
         // nor fail the gateway. `outcome` falls back to pass/fail for any
         // assessment produced before this field existed.
-        const outcomeOf = (a: (typeof nameAssessmentList)[number]) =>
-          a.outcome ?? (a.pass ? 'pass' : 'fail');
         const namePassCount = nameAssessmentList.filter(
-          (a) => outcomeOf(a) === 'pass',
+          (a) => arnsNameOutcome(a) === 'pass',
         ).length;
         const nameGradedCount = nameAssessmentList.filter(
-          (a) => outcomeOf(a) !== 'neutral',
+          (a) => arnsNameOutcome(a) !== 'neutral',
         ).length;
         // If every sampled name was neutral there is nothing to grade — don't
         // fail the gateway on absence of evidence.
@@ -2535,24 +2545,21 @@ export class Observer {
         failedAssessments++;
       }
 
-      // Count prescribed name assessments
+      // Count prescribed + chosen name assessments, EXCLUDING neutral names from
+      // both the numerator and the denominator — otherwise a neutral name would
+      // inflate the failure rate and could change which observation is selected
+      // for the on-chain report.
+      const countName = (assessment: ArnsNameAssessment) => {
+        const outcome = arnsNameOutcome(assessment);
+        if (outcome === 'neutral') return;
+        totalAssessments++;
+        if (outcome === 'fail') failedAssessments++;
+      };
       Object.values(gatewayAssessment.arnsAssessments.prescribedNames).forEach(
-        (assessment) => {
-          totalAssessments++;
-          if (!assessment.pass) {
-            failedAssessments++;
-          }
-        },
+        countName,
       );
-
-      // Count chosen name assessments
       Object.values(gatewayAssessment.arnsAssessments.chosenNames).forEach(
-        (assessment) => {
-          totalAssessments++;
-          if (!assessment.pass) {
-            failedAssessments++;
-          }
-        },
+        countName,
       );
     });
 

--- a/src/reference/composite-reference-gateway.test.ts
+++ b/src/reference/composite-reference-gateway.test.ts
@@ -49,6 +49,7 @@ describe('CompositeReferenceGateway', function () {
     contentLength: '1000',
     contentType: 'application/octet-stream',
     dataHashDigest: 'hash123',
+    protocol: null,
     timings: null,
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,6 +103,9 @@ export interface ArnsResolution {
   contentLength: string | null;
   contentType: string | null;
   dataHashDigest: string | null;
+  // Target protocol from the x-arns-protocol header (e.g. 'arweave' | 'ipfs').
+  // Null when the gateway does not report it (treated as 'arweave').
+  protocol: string | null;
   timings: any | null;
 }
 
@@ -143,6 +146,9 @@ export interface OwnershipAssessment {
   observedRelease?: string;
   failureReason?: string;
   pass: boolean;
+  // Whether the gateway advertises IPFS support in /ar-io/info (ipfs.enabled).
+  // Used to capability-gate IPFS-protocol name assessments (adoption ramp).
+  supportsIpfs?: boolean;
 }
 
 export interface ArnsNameAssessment {
@@ -154,6 +160,10 @@ export interface ArnsNameAssessment {
   expectedDataHash: string | null;
   resolvedDataHash: string | null;
   pass: boolean;
+  // Resolved target protocol ('arweave' | 'ipfs'), and the tri-state outcome.
+  // 'neutral' names are excluded from the names pass/fail denominator.
+  protocol?: string;
+  outcome?: 'pass' | 'fail' | 'neutral';
   failureReason?: string;
   timings?: {
     wait?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5897,7 +5897,7 @@ multer@^1.4.5-lts.1:
     type-is "^1.6.4"
     xtend "^4.0.0"
 
-multiformats@^13:
+multiformats@^13.4.2:
   version "13.4.2"
   resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-13.4.2.tgz#309ee17d3946db9a6954cf6832aeb2b4b10dd0f3"
   integrity sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5897,6 +5897,11 @@ multer@^1.4.5-lts.1:
     type-is "^1.6.4"
     xtend "^4.0.0"
 
+multiformats@^13:
+  version "13.4.2"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-13.4.2.tgz#309ee17d3946db9a6954cf6832aeb2b4b10dd0f3"
+  integrity sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==
+
 multistream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/multistream/-/multistream-4.1.0.tgz#7bf00dfd119556fbc153cff3de4c6d477909f5a8"


### PR DESCRIPTION
Makes named IPFS a first-class, **trustlessly-verified** assessment dimension in the
observer, with **zero smart-contract changes** (the chain only ever receives the
per-gateway pass/fail bitmap). Companion to ar-io-node PR #793.

Implemented and then hardened through **five multi-agent adversarial-review passes**
(findings converged 11 → 11 → 4 → 2 → 0). This description reflects the **as-shipped**
design; a few things evolved from the original phased proposal — noted below.

## What it does

- **Where it runs:** a shared `assessIpfsNameTrustless()` in `observer.ts`, called by
  BOTH the one-shot `Observer` and the **live** `ContinuousObserver → GatewayAssessor`
  path — so the running service actually uses it and the two paths can't diverge.
- **Routing:** a name is assessed via the IPFS path iff its (reference-resolved)
  `resolvedId` is a valid CID (`isIpfsAssessable`). Not the `x-arns-protocol` header,
  which isn't part of reference consensus. The CID form is the ground truth and blocks
  a poisoned reference from flipping an Arweave name onto the neutral-capable path.
- **Trustless verification:** fetch the target gateway's `?format=raw` block and verify
  it against the CID's multihash. No reference-gateway byte trust.
- **Scoring (tri-state, `outcome`):**
  - **PASS** — served 200 `application/vnd.ipld.raw` bytes hash to the CID.
  - **FAIL** — served 200 bytes that do NOT hash to the CID (a *proven-wrong* answer).
    The fail/neutral decision never trusts the gateway's own `x-arns-resolved-id` (it
    controls both the bytes and that header). Consistent with the Arweave path.
  - **NEUTRAL** (excluded from every denominator — `namesPass`, metrics, the
    report-selection failure rate, and the `GatewayAssessor` pass rate) — not served /
    non-200 / timeout / non-raw content-type / empty body / unverifiable multihash.
    Capability is judged **behaviorally**; a non-IPFS gateway 404s → neutral. So a
    gateway is never failed for availability and can't be griefed.
- **Report:** `REPORT_FORMAT_VERSION` 2 → 3 (adds `protocol` + `outcome`); on-chain
  submission unchanged → no contract change.
- **Timeouts:** `IPFS_ASSESSMENT_TIMEOUT_MS` (35s) with the socket timeout overridden;
  `getIpfsRawBlock` never hangs.

## Recommended topology

Point the observer's reference (`REFERENCE_GATEWAY_HOSTS`) at its own co-located
gateway resolving ArNS **on-demand** (from chain) — see ar-io-node PR #836. Then the
name→CID binding is authoritative (chain-derived via your own gateway's resolver) and
decentralized, with no external-gateway or header trust. When deployed via the
ar-io-node compose this defaults to the node's `ARNS_ROOT_HOST`.

## Not in scope

Full-DAG/leaf verification for multi-block (UnixFS/dag-pb) CIDs — a `PASS` proves
possession of the DAG **root block** only; leaf/block sampling (the analog of the
Arweave chunk/offset proof) is a planned follow-up. Contract-level work (stratified
prescription, pinning incentives) is out of scope.

## Validation

Full suite green (382 tests incl. the first tests on the live `GatewayAssessor` path);
`lint:check` / `build` / immutable-install clean. Observer CI runs on merge, so these
were run locally to match.