### PR TITLE
Observer holding-probe: local-only IPFS assessment (serving→holding ramp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Relevant configuration:
 | Variable | Default | Description |
 | --- | --- | --- |
 | `IPFS_ASSESSMENT_TIMEOUT_MS` | `35000` | Request/response deadline for the `?format=raw` fetch. Set `>=` the gateway's IPFS retrieval budget so slow-but-valid cold-IPFS content isn't misclassified. |
+| `IPFS_ASSESSMENT_LOCAL_ONLY` | `false` | Holding-probe ramp. When `true`, the `?format=raw` probe sends `X-Ar-Io-Local-Only: true`, so a PASS proves the gateway **holds** the content locally (a proxy 404s → NEUTRAL, never FAIL). This is the serving→holding lever — it rewards holding without penalising a not-yet-holding gateway. Requires the gateway fleet to support local-only serve (ar-io-node IPFS peer-fetch). Flipping it on is a governance/ramp decision; ships dark. |
 | `REFERENCE_GATEWAY_HOSTS` | `turbo-gateway.com,ar-io.net` | Gateways used to resolve the name→CID binding. **Recommended:** point this at your **own** co-located gateway configured to resolve ArNS **on-demand** (from chain) — then the binding is authoritative (chain-derived) and local rather than trusting external gateways. When deployed via the ar-io-node compose this defaults to the node's `ARNS_ROOT_HOST`. |
 
 Multi-block (UnixFS/dag-pb) CIDs are verified at the **DAG root block** today; full

--- a/src/assessment/gateway-assessor.ts
+++ b/src/assessment/gateway-assessor.ts
@@ -176,6 +176,7 @@ export class GatewayAssessor {
         referenceResolution,
         got: this.gotClient,
         timeoutMs: config.IPFS_ASSESSMENT_TIMEOUT_MS,
+        localOnly: config.IPFS_ASSESSMENT_LOCAL_ONLY,
       });
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -236,6 +236,17 @@ export const IPFS_ASSESSMENT_TIMEOUT_MS = +env.varOrDefault(
   '35000',
 );
 
+// Holding-probe ramp: when true, the trustless IPFS raw-block probe sends
+// `X-Ar-Io-Local-Only: true`, so a PASS proves the gateway HOLDS the content
+// locally (not merely proxies it from public IPFS — a proxy 404s in local-only
+// mode and scores NEUTRAL, never FAIL). This is the serving->holding lever: it
+// rewards holding without ever penalising a not-yet-holding gateway. Ships dark
+// (default false = today's "serves correctly" behavior). Flipping it on is a
+// governance/ramp decision and requires the gateway fleet to support local-only
+// serve (ar-io-node IPFS peer-fetch layer). Default: false
+export const IPFS_ASSESSMENT_LOCAL_ONLY =
+  env.varOrDefault('IPFS_ASSESSMENT_LOCAL_ONLY', 'false') === 'true';
+
 if (REFERENCE_GATEWAY_CONSENSUS_SIZE < 1) {
   throw new Error(
     `Invalid configuration: REFERENCE_GATEWAY_CONSENSUS_SIZE (${REFERENCE_GATEWAY_CONSENSUS_SIZE}) must be at least 1.`,

--- a/src/observer.test.ts
+++ b/src/observer.test.ts
@@ -27,6 +27,7 @@ import * as rawCodec from 'multiformats/codecs/raw';
 import { customHashPRNG } from './lib/prng.js';
 import * as metrics from './metrics.js';
 import {
+  assessIpfsNameTrustless,
   assessOwnership,
   generateRandomRanges,
   getArnsResolution,
@@ -718,6 +719,105 @@ describe('Observer', function () {
         });
 
         expect(result.bytes).to.equal(null);
+      });
+
+      // ---- Holding-probe ramp (X-Ar-Io-Local-Only) ----
+      const rawUrl = `https://${arnsName}.${host}/?format=raw`;
+
+      it('getIpfsRawBlock sends X-Ar-Io-Local-Only:true when localOnly is set', async function () {
+        // matchHeader means the interceptor only matches if the header is sent;
+        // a returned block therefore proves the probe carried the header.
+        nock(`https://${arnsName}.${host}`)
+          .matchHeader('x-ar-io-local-only', 'true')
+          .get('/?format=raw')
+          .reply(200, Buffer.from('held locally'), {
+            'content-type': 'application/vnd.ipld.raw',
+          });
+
+        const result = await getIpfsRawBlock({
+          url: rawUrl,
+          got,
+          timeoutMs: 5000,
+          localOnly: true,
+        });
+        expect(result.statusCode).to.equal(200);
+        expect(result.bytes).to.not.equal(null);
+      });
+
+      it('getIpfsRawBlock omits the local-only header by default', async function () {
+        nock(`https://${arnsName}.${host}`)
+          .matchHeader('x-ar-io-local-only', (v) => v === undefined)
+          .get('/?format=raw')
+          .reply(200, Buffer.from('served'), {
+            'content-type': 'application/vnd.ipld.raw',
+          });
+
+        const result = await getIpfsRawBlock({ url: rawUrl, got, timeoutMs: 5000 });
+        expect(result.bytes).to.not.equal(null);
+      });
+
+      it('assessIpfsNameTrustless(localOnly): a non-holding gateway is NEUTRAL, not FAIL', async function () {
+        const cid = await rawCidFor(Buffer.from('named content'));
+        // A proxy holds nothing locally -> 404s the local-only probe.
+        nock(`https://${arnsName}.${host}`)
+          .matchHeader('x-ar-io-local-only', 'true')
+          .get('/?format=raw')
+          .reply(404);
+
+        const result = await assessIpfsNameTrustless({
+          host,
+          arnsName,
+          referenceResolution: {
+            statusCode: 200,
+            resolvedId: cid,
+            ttlSeconds: null,
+            contentLength: null,
+            contentType: null,
+            dataHashDigest: null,
+            protocol: 'ipfs',
+            timings: null,
+          },
+          got,
+          timeoutMs: 5000,
+          localOnly: true,
+        });
+
+        expect(result.outcome).to.equal('neutral');
+        expect(result.pass).to.equal(false);
+        expect(result.failureReason).to.match(/hold/i);
+      });
+
+      it('assessIpfsNameTrustless(localOnly): a holding gateway that serves the verifying block PASSES', async function () {
+        const bytes = Buffer.from('the held block');
+        const cid = await rawCidFor(bytes);
+        nock(`https://${arnsName}.${host}`)
+          .matchHeader('x-ar-io-local-only', 'true')
+          .get('/?format=raw')
+          .reply(200, bytes, {
+            'content-type': 'application/vnd.ipld.raw',
+            'x-arns-resolved-id': cid,
+          });
+
+        const result = await assessIpfsNameTrustless({
+          host,
+          arnsName,
+          referenceResolution: {
+            statusCode: 200,
+            resolvedId: cid,
+            ttlSeconds: null,
+            contentLength: null,
+            contentType: null,
+            dataHashDigest: null,
+            protocol: 'ipfs',
+            timings: null,
+          },
+          got,
+          timeoutMs: 5000,
+          localOnly: true,
+        });
+
+        expect(result.outcome).to.equal('pass');
+        expect(result.pass).to.equal(true);
       });
     });
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -280,10 +280,15 @@ export async function getIpfsRawBlock({
   url,
   got,
   timeoutMs,
+  localOnly = false,
 }: {
   url: string;
   got: Got;
   timeoutMs: number;
+  // Holding probe: send `X-Ar-Io-Local-Only: true` so the gateway serves ONLY
+  // from its local blockstore. A proxying gateway 404s (bytes:null -> neutral);
+  // a holding gateway serves the verifiable block. See IPFS_ASSESSMENT_LOCAL_ONLY.
+  localOnly?: boolean;
 }): Promise<{
   statusCode: number;
   resolvedId: string | null;
@@ -300,6 +305,9 @@ export async function getIpfsRawBlock({
       headers: {
         'Accept-Encoding': 'identity',
         Accept: 'application/vnd.ipld.raw',
+        // Holding probe: serve only from the gateway's local blockstore. A proxy
+        // 404s here (-> neutral); a holder serves the verifiable block (-> pass).
+        ...(localOnly ? { 'X-Ar-Io-Local-Only': 'true' } : {}),
       },
     });
 
@@ -399,12 +407,17 @@ export async function assessIpfsNameTrustless({
   referenceResolution,
   got,
   timeoutMs,
+  localOnly = false,
 }: {
   host: string;
   arnsName: string;
   referenceResolution: ArnsResolution;
   got: Got;
   timeoutMs: number;
+  // When true, probe local-only so a PASS proves HOLDING, not just serving. A
+  // not-holding gateway 404s -> neutral (never failed). See
+  // IPFS_ASSESSMENT_LOCAL_ONLY.
+  localOnly?: boolean;
 }): Promise<ArnsNameAssessment> {
   const assessedAt = +(Date.now() / 1000).toFixed(0);
   const expectedId = referenceResolution.resolvedId ?? null;
@@ -431,6 +444,7 @@ export async function assessIpfsNameTrustless({
     url: `https://${arnsName}.${host}/?format=raw`,
     got,
     timeoutMs,
+    localOnly,
   });
   timer();
 
@@ -452,7 +466,9 @@ export async function assessIpfsNameTrustless({
       resolvedDataHash: null,
       outcome: 'neutral',
       pass: false,
-      failureReason: `neutral: gateway did not serve a raw block (status ${statusCode})`,
+      failureReason: localOnly
+        ? `neutral: gateway does not hold the content locally (local-only probe, status ${statusCode})`
+        : `neutral: gateway did not serve a raw block (status ${statusCode})`,
     };
   }
 
@@ -2178,6 +2194,7 @@ export class Observer {
         referenceResolution,
         got: this.gotClient,
         timeoutMs: config.IPFS_ASSESSMENT_TIMEOUT_MS,
+        localOnly: config.IPFS_ASSESSMENT_LOCAL_ONLY,
       });
     }
 


### PR DESCRIPTION
## Observer holding-probe rider (§7)

The trustless IPFS assessment (PR #112) proves a gateway serves the **correct** bytes for an IPFS-target ArNS name — but not that it **holds** them. A gateway proxying from public IPFS passes identically to one that pins (Open-Question #3 in the spec: "trustless verification proves correctness, not who persists"). This adds the trustless **holding** measurement.

When `IPFS_ASSESSMENT_LOCAL_ONLY=true`, the existing `?format=raw` probe sends `X-Ar-Io-Local-Only: true`, so the gateway must serve from its **local blockstore**. The ramp falls out of the existing tri-state scoring — **no scoring change**:

| Gateway | Probe result | Outcome |
|---|---|---|
| Holds it | 200 + verifying bytes | **PASS** (now proves *holding*) |
| Proxies it (no local copy) | 404 in local-only mode → `bytes:null` | **NEUTRAL** (never FAIL) |
| Serves wrong bytes | proven-wrong | **FAIL** (unchanged) |

So enabling it **rewards holding without ever penalising a not-yet-holding gateway** — a proxy is excluded from the denominator, not failed. Flipping the flag on is the serving→holding governance lever (spec §8-Q1) and requires the gateway fleet to support local-only serve (the ar-io-node IPFS peer-fetch layer, now live). **Ships dark** (default `false` = today's "serves correctly" behavior).

- Threaded through **both** assessment paths (`Observer` + `ContinuousObserver`/`GatewayAssessor`) so scoring can't diverge.
- Neutral `failureReason` distinguishes "does not hold" from "did not serve" under local-only.
- Unit tests: header sent when enabled / omitted by default; hold→PASS, proxy→NEUTRAL. 386 passing, typecheck + lint clean.

Depends on the gateway primitive `X-Ar-Io-Local-Only` (ar-io-node PR #839), which is deployed and validated in prod on ar-io.nexus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPmZYvBxMyHWxrTL85xFr7
