### PR TITLE
feat(crank): derive poll + cleanup intervals from epoch duration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -300,6 +300,24 @@ function parsePositiveIntEnv(name: string, defaultValue: string): number {
   }
   return value;
 }
+// Like parsePositiveIntEnv, but returns undefined when the env var is unset so
+// callers can distinguish "operator set an explicit value" from "not set" and
+// fall back to a derived/adaptive default. Still validates when a value IS set.
+function parsePositiveIntEnvOrUndefined(name: string): number | undefined {
+  const raw = env.varOrUndefined(name);
+  if (raw === undefined) {
+    return undefined;
+  }
+  // Number() (not parseInt) so partially-numeric typos fail loudly: parseInt
+  // would silently accept '1.5'->1 and '15ms'->15, configuring e.g. a 1ms poll.
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(
+      `Invalid configuration: ${name}='${raw}' must be a positive integer.`,
+    );
+  }
+  return value;
+}
 function parseNonNegativeIntEnv(name: string, defaultValue: string): number {
   const raw = env.varOrDefault(name, defaultValue);
   // Reject anything that isn't strictly digits — Number.parseInt would silently
@@ -431,9 +449,10 @@ export const ARIO_ANT_PROGRAM_ID = env.varOrUndefined('ARIO_ANT_PROGRAM_ID');
 // Epoch cranking (opt-in — zero overhead when disabled)
 export const ENABLE_EPOCH_CRANKING =
   env.varOrDefault('ENABLE_EPOCH_CRANKING', 'false') === 'true';
-export const CRANK_POLL_INTERVAL_MS = parsePositiveIntEnv(
+// Optional: when unset, the cranker derives the poll cadence from the epoch
+// duration (see src/epoch/adaptive-intervals.ts). An explicit value always wins.
+export const CRANK_POLL_INTERVAL_MS = parsePositiveIntEnvOrUndefined(
   'CRANK_POLL_INTERVAL_MS',
-  '15000',
 );
 export const CRANK_BATCH_SIZE = parsePositiveIntEnv('CRANK_BATCH_SIZE', '15');
 export const CRANK_CLOSE_EPOCHS =
@@ -469,9 +488,10 @@ export const CLEANUP_FAILURE_THRESHOLD = parsePositiveIntEnv(
   'CLEANUP_FAILURE_THRESHOLD',
   '30',
 );
-export const CLEANUP_MIN_INTERVAL_MS = parsePositiveIntEnv(
+// Optional: when unset, the cranker derives the cleanup cadence from the epoch
+// duration (see src/epoch/adaptive-intervals.ts). An explicit value always wins.
+export const CLEANUP_MIN_INTERVAL_MS = parsePositiveIntEnvOrUndefined(
   'CLEANUP_MIN_INTERVAL_MS',
-  '300000',
 );
 export const ALT_RECLAIM_SCAN_LIMIT = parseNonNegativeIntEnv(
   'ALT_RECLAIM_SCAN_LIMIT',

--- a/src/epoch/adaptive-intervals.test.ts
+++ b/src/epoch/adaptive-intervals.test.ts
@@ -1,0 +1,77 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { expect } from 'chai';
+
+import { deriveCrankIntervals } from './adaptive-intervals.js';
+
+// Input unit is SECONDS (matches on-chain EpochSettings.epochDuration).
+const MIN_S = 60;
+const HOUR_S = 60 * MIN_S;
+// Output unit is MILLISECONDS.
+const SEC_MS = 1000;
+const MIN_MS = 60 * SEC_MS;
+
+describe('deriveCrankIntervals', () => {
+  it('reproduces the proven 24h production values (60s poll / 30min cleanup)', () => {
+    expect(deriveCrankIntervals(24 * HOUR_S)).to.deep.equal({
+      pollIntervalMs: 60 * SEC_MS,
+      cleanupMinIntervalMs: 30 * MIN_MS,
+    });
+  });
+
+  it('scales cleanup down but keeps the poll ceiling at 12h', () => {
+    expect(deriveCrankIntervals(12 * HOUR_S)).to.deep.equal({
+      pollIntervalMs: 60 * SEC_MS, // ceiling
+      cleanupMinIntervalMs: 15 * MIN_MS,
+    });
+  });
+
+  it('matches the previous fixed defaults at 1h (15s poll / 5min cleanup)', () => {
+    expect(deriveCrankIntervals(1 * HOUR_S)).to.deep.equal({
+      pollIntervalMs: 15 * SEC_MS,
+      cleanupMinIntervalMs: 5 * MIN_MS, // floor
+    });
+  });
+
+  it('floors both at short (10min) epochs — poll floor is <= the old 15s default (no regression)', () => {
+    const { pollIntervalMs, cleanupMinIntervalMs } = deriveCrankIntervals(
+      10 * MIN_S,
+    );
+    expect(pollIntervalMs).to.equal(10 * SEC_MS); // floor
+    expect(cleanupMinIntervalMs).to.equal(5 * MIN_MS); // floor
+    expect(pollIntervalMs).to.be.at.most(15 * SEC_MS);
+  });
+
+  it('clamps very long epochs to the ceilings', () => {
+    expect(deriveCrankIntervals(100 * HOUR_S)).to.deep.equal({
+      pollIntervalMs: 60 * SEC_MS,
+      cleanupMinIntervalMs: 30 * MIN_MS,
+    });
+  });
+
+  it('returns safe floors for unknown / invalid epoch durations', () => {
+    const floors = {
+      pollIntervalMs: 10 * SEC_MS,
+      cleanupMinIntervalMs: 5 * MIN_MS,
+    };
+    expect(deriveCrankIntervals(0)).to.deep.equal(floors);
+    expect(deriveCrankIntervals(-5)).to.deep.equal(floors);
+    expect(deriveCrankIntervals(Number.NaN)).to.deep.equal(floors);
+    expect(deriveCrankIntervals(Number.POSITIVE_INFINITY)).to.deep.equal(
+      floors,
+    );
+  });
+
+  it('never returns values outside the documented clamp bounds', () => {
+    for (const durS of [0, 1, MIN_S, HOUR_S, 24 * HOUR_S, 1000 * HOUR_S]) {
+      const { pollIntervalMs, cleanupMinIntervalMs } =
+        deriveCrankIntervals(durS);
+      expect(pollIntervalMs).to.be.within(10 * SEC_MS, 60 * SEC_MS);
+      expect(cleanupMinIntervalMs).to.be.within(5 * MIN_MS, 30 * MIN_MS);
+    }
+  });
+});

--- a/src/epoch/adaptive-intervals.ts
+++ b/src/epoch/adaptive-intervals.ts
@@ -1,0 +1,82 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Epoch-adaptive cranker intervals.
+ *
+ * The cranker's poll cadence and permissionless-cleanup cadence only need to be
+ * sized relative to the epoch duration. Fixed defaults (15s poll / 5min cleanup)
+ * are fine for short dev/localnet epochs but wastefully over-poll — and fire far
+ * too many credit-heavy `getProgramAccounts` cleanup scans — on 24h production
+ * epochs. Deriving both from the on-chain `epochDuration` lets one config
+ * self-tune from 24h mainnet down to minute-scale localnet.
+ *
+ * The clamps are chosen so the floors sit at/below today's defaults: short-epoch
+ * networks are unchanged-or-slightly-faster (no regression), and only long-epoch
+ * deployments change — strictly toward fewer RPC calls. An explicit
+ * `CRANK_POLL_INTERVAL_MS` / `CLEANUP_MIN_INTERVAL_MS` env always overrides these.
+ *
+ *   epoch    poll    cleanup
+ *   24h      60s     30min   (reproduces the proven hand-tuned production values)
+ *   12h      60s     15min
+ *    1h      15s      5min   (= the previous fixed defaults)
+ *   10min    10s      5min   (floors)
+ */
+
+const POLL_DIVISOR = 240;
+const POLL_FLOOR_MS = 10_000; // 10s — at/below the previous 15s default
+const POLL_CEILING_MS = 60_000; // 60s — the proven 24h value
+
+const CLEANUP_DIVISOR = 48;
+const CLEANUP_FLOOR_MS = 300_000; // 5min — the previous default
+const CLEANUP_CEILING_MS = 1_800_000; // 30min — the proven 24h value
+
+/**
+ * Static fallbacks for when the epoch duration can't be read at startup (e.g.
+ * RPC error, or epochs not yet enabled). These are the historically-safe fixed
+ * defaults, conservative for any epoch length.
+ */
+export const FALLBACK_POLL_INTERVAL_MS = 15_000;
+export const FALLBACK_CLEANUP_MIN_INTERVAL_MS = 300_000;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export interface CrankIntervals {
+  pollIntervalMs: number;
+  cleanupMinIntervalMs: number;
+}
+
+/**
+ * Derive poll + cleanup intervals (ms) from the epoch duration, clamped.
+ *
+ * `epochDurationSeconds` is the on-chain `EpochSettings.epochDuration` field,
+ * which is denominated in **seconds** (e.g. 86400 for a 24h epoch) — not ms.
+ * A non-positive or non-finite duration (unknown / epochs not initialized)
+ * yields the safe floors.
+ */
+export function deriveCrankIntervals(
+  epochDurationSeconds: number,
+): CrankIntervals {
+  const durMs =
+    Number.isFinite(epochDurationSeconds) && epochDurationSeconds > 0
+      ? epochDurationSeconds * 1000
+      : 0;
+  return {
+    pollIntervalMs: clamp(
+      Math.round(durMs / POLL_DIVISOR),
+      POLL_FLOOR_MS,
+      POLL_CEILING_MS,
+    ),
+    cleanupMinIntervalMs: clamp(
+      Math.round(durMs / CLEANUP_DIVISOR),
+      CLEANUP_FLOOR_MS,
+      CLEANUP_CEILING_MS,
+    ),
+  };
+}

--- a/src/system.ts
+++ b/src/system.ts
@@ -346,6 +346,11 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
     }
     const { EpochCranker } = await import('./epoch/epoch-cranker.js');
     const {
+      deriveCrankIntervals,
+      FALLBACK_POLL_INTERVAL_MS,
+      FALLBACK_CLEANUP_MIN_INTERVAL_MS,
+    } = await import('./epoch/adaptive-intervals.js');
+    const {
       getEpochSettingsPDA,
       getArnsRegistryPDA,
       deserializeEpochSettingsFull,
@@ -354,11 +359,55 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
     const [nameRegistryPda] = await getArnsRegistryPDA(
       config.ARIO_ARNS_PROGRAM_ID as any,
     );
+
+    // Hoisted so the same reader both derives the adaptive intervals up front
+    // and drives the cranker's per-cycle reads.
+    const getEpochSettings = async () => {
+      const [pda] = await getEpochSettingsPDA(
+        config.ARIO_GAR_PROGRAM_ID as any,
+      );
+
+      const account = await fetchEncodedAccount(solanaRpc as any, pda, {
+        commitment: 'confirmed',
+      });
+      if (!account.exists) throw new Error('EpochSettings not found');
+      const data = deserializeEpochSettingsFull(Buffer.from(account.data));
+      return {
+        currentEpochIndex: data.currentEpochIndex as number,
+        genesisTimestamp: data.genesisTimestamp as number,
+        epochDuration: data.epochDuration as number,
+        enabled: (data.enabled as boolean) ?? true,
+      };
+    };
+
+    // Size poll + cleanup cadence to the epoch duration unless the operator set
+    // explicit values. One read at startup; a restart re-derives if the network
+    // ever changes epoch length. Fall back to static defaults on a read error.
+    let derived = {
+      pollIntervalMs: FALLBACK_POLL_INTERVAL_MS,
+      cleanupMinIntervalMs: FALLBACK_CLEANUP_MIN_INTERVAL_MS,
+    };
+    let intervalSource = 'derived';
+    try {
+      const { epochDuration } = await getEpochSettings();
+      derived = deriveCrankIntervals(epochDuration);
+    } catch (err) {
+      intervalSource = 'fallback';
+      log.warn(
+        'Could not read epoch duration to derive cranker intervals; using static defaults',
+        { error: err instanceof Error ? err.message : String(err) },
+      );
+    }
+    const pollIntervalMs =
+      config.CRANK_POLL_INTERVAL_MS ?? derived.pollIntervalMs;
+    const cleanupMinIntervalMs =
+      config.CLEANUP_MIN_INTERVAL_MS ?? derived.cleanupMinIntervalMs;
+
     const cranker = new EpochCranker({
       contract: networkContract,
       rpc: solanaRpc,
       signer: solanaSigner,
-      pollIntervalMs: config.CRANK_POLL_INTERVAL_MS,
+      pollIntervalMs,
       batchSize: config.CRANK_BATCH_SIZE,
       closeEpochs: config.CRANK_CLOSE_EPOCHS,
       epochRetention: config.CRANK_EPOCH_RETENTION,
@@ -369,30 +418,23 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
       maxCleanupTxsPerCycle: config.MAX_CLEANUP_TXS_PER_CYCLE,
       cleanupFailureThreshold: config.CLEANUP_FAILURE_THRESHOLD,
       altReclaimScanLimit: config.ALT_RECLAIM_SCAN_LIMIT,
-      cleanupMinIntervalMs: config.CLEANUP_MIN_INTERVAL_MS,
+      cleanupMinIntervalMs,
       log,
       nameRegistryAccount: nameRegistryPda,
-      getEpochSettings: async () => {
-        const [pda] = await getEpochSettingsPDA(
-          config.ARIO_GAR_PROGRAM_ID as any,
-        );
-
-        const account = await fetchEncodedAccount(solanaRpc as any, pda, {
-          commitment: 'confirmed',
-        });
-        if (!account.exists) throw new Error('EpochSettings not found');
-        const data = deserializeEpochSettingsFull(Buffer.from(account.data));
-        return {
-          currentEpochIndex: data.currentEpochIndex as number,
-          genesisTimestamp: data.genesisTimestamp as number,
-          epochDuration: data.epochDuration as number,
-          enabled: (data.enabled as boolean) ?? true,
-        };
-      },
+      getEpochSettings,
     });
     cranker.start();
     log.verbose('Epoch cranking enabled', {
-      pollIntervalMs: config.CRANK_POLL_INTERVAL_MS,
+      pollIntervalMs,
+      pollIntervalSource:
+        config.CRANK_POLL_INTERVAL_MS !== undefined
+          ? 'override'
+          : intervalSource,
+      cleanupMinIntervalMs,
+      cleanupMinIntervalSource:
+        config.CLEANUP_MIN_INTERVAL_MS !== undefined
+          ? 'override'
+          : intervalSource,
       batchSize: config.CRANK_BATCH_SIZE,
       epochRetention: config.CRANK_EPOCH_RETENTION,
       enableCleanup: config.ENABLE_CLEANUP,


### PR DESCRIPTION
## Problem
The cranker's poll cadence (`CRANK_POLL_INTERVAL_MS`, default 15s) and permissionless-cleanup cadence (`CLEANUP_MIN_INTERVAL_MS`, default 5min) are sized for short dev/localnet epochs. On **24h** production epochs they over-poll and fire ~288 credit-heavy `getProgramAccounts` cleanup scans/day (mostly submitting 0 txs) — wasted RPC that can push operators over free-tier limits.

## Change
Derive both intervals from the on-chain `epochDuration`, clamped:

```
poll    = clamp(epochDuration / 240, 10s, 60s)
cleanup = clamp(epochDuration / 48,  5min, 30min)
```

| epoch | poll | cleanup | note |
|---|---|---|---|
| 24h | 60s | 30min | reproduces the proven hand-tuned production values |
| 12h | 60s | 15min | |
| 1h | 15s | 5min | = the previous fixed defaults |
| 10min | 10s | 5min | floors |

**No-regression property:** the floors sit at/below today's defaults, so short-epoch networks are unchanged-or-slightly-faster; only long-epoch deployments change, and strictly toward fewer RPC calls.

## Design
- New pure `deriveCrankIntervals` (`src/epoch/adaptive-intervals.ts`) + unit tests. Input is the on-chain `epochDuration` in **seconds**.
- `CRANK_POLL_INTERVAL_MS` / `CLEANUP_MIN_INTERVAL_MS` become **optional** (new `parsePositiveIntEnvOrUndefined`) — an explicit value always wins (backward compatible).
- `system.ts` derives once at startup from a single `getEpochSettings` read (falls back to static 15s/5min on a read error), applies `?? override`, and logs the effective values + whether `derived`/`override`. The cranker's timer/gate code is **untouched** (it still receives concrete numbers).

## Validated in staging
Deployed a local build to a 24h-epoch staging box with the explicit overrides **removed**: the observer logged `pollIntervalMs:60000, cleanupMinIntervalMs:1800000, source:derived` — i.e. the formula independently reproduces the hand-tuned values from the live epoch. Healthy, cranking, 0 firehose. (Staging also caught a units bug pre-merge: `epochDuration` is seconds, not ms — fixed.)

Tests: `362 passing` (7 new), `lint` + `tsc` clean.

Follow-up (separate PR): mirror this to the standalone `ar-io-cranker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATzdETW9PfP7Q9oQBAyREi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Polling and cleanup intervals now adapt automatically to the configured on-chain epoch duration.
  - Explicit interval settings continue to override adaptive values.
  - Safe fallback intervals are used when epoch information is unavailable or invalid.
  - Startup logs now show the effective intervals and their source.

- **Tests**
  - Added coverage for interval scaling, bounds, fallback behavior, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->