### PR TITLE
feat(crank): enable the full ArNS lease lifecycle in the epoch cranker

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.0.3",
+    "@ar.io/sdk": "^4.1.0-alpha.7",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/src/epoch/epoch-cranker-arns-lifecycle.test.ts
+++ b/src/epoch/epoch-cranker-arns-lifecycle.test.ts
@@ -1,0 +1,114 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { expect } from 'chai';
+
+import { EpochCranker, type EpochCrankerConfig } from './epoch-cranker.js';
+
+/**
+ * Tests for the ArNS lease-lifecycle options the cranker forwards to
+ * `crankEpochStep`.
+ *
+ * These exist because `runCycle` casts the contract to `any`
+ * (`const ario = contract as any`) before calling `crankEpochStep`. That
+ * silences TypeScript at the call site entirely — a misspelled option name
+ * compiles clean and then silently does nothing at runtime, which is exactly
+ * the failure mode that let expired ArNS leases pile up unnoticed in the first
+ * place (`prune_returned_names` ran forever against a queue that
+ * `prune_name_to_returned` was never called to fill).
+ *
+ * So assert the wire format directly: the exact option names, and that the
+ * `enableCleanup` kill switch still reaches all three prune steps.
+ */
+
+const noopLog: EpochCrankerConfig['log'] = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  verbose: () => undefined,
+};
+
+/**
+ * Contract stub that captures the options object handed to
+ * `crankEpochStep` and tolerates every other SDK call the cleanup phases
+ * may make (each returns an empty result).
+ */
+function stubContract(capture: (opts: Record<string, unknown>) => void) {
+  const base: Record<string, unknown> = {
+    crankEpochStep: async (opts: Record<string, unknown>) => {
+      capture(opts);
+      return { action: 'idle', reason: 'stubbed' };
+    },
+  };
+  return new Proxy(base, {
+    get(target, prop: string) {
+      if (prop in target) return target[prop];
+      return async () => [];
+    },
+  });
+}
+
+async function crankOnce(
+  overrides: Partial<EpochCrankerConfig>,
+): Promise<Record<string, unknown>> {
+  let captured: Record<string, unknown> | null = null;
+  const cranker = new EpochCranker({
+    contract: stubContract((o) => {
+      captured = o;
+    }) as never,
+    rpc: {} as never,
+    signer: { address: 'stub' } as never,
+    pollIntervalMs: 1000,
+    batchSize: 18,
+    closeEpochs: false,
+    cleanupMinIntervalMs: 0,
+    log: noopLog,
+    getEpochSettings: async () => ({
+      currentEpochIndex: 1,
+      genesisTimestamp: 1000,
+      epochDuration: 100,
+      enabled: true,
+    }),
+    ...overrides,
+  });
+  // runCycle holds the crankEpochStep call; calling it directly skips tick()'s
+  // random jitter sleep and the periodic balance check.
+  await (cranker as never as { runCycle: () => Promise<void> }).runCycle();
+  expect(captured, 'crankEpochStep was never called').to.not.equal(null);
+  return captured as unknown as Record<string, unknown>;
+}
+
+describe('EpochCranker — ArNS lease lifecycle options', () => {
+  it('enables all three prune steps by default', async () => {
+    const opts = await crankOnce({ enableCleanup: true });
+    expect(opts.enablePruneToReturned).to.equal(true);
+    expect(opts.enablePruneExpired).to.equal(true);
+    // the pre-existing returned-name step must keep working
+    expect(opts.enablePrune).to.equal(true);
+  });
+
+  it('forwards cleanupBatchSize as the expired-name batch size', async () => {
+    const opts = await crankOnce({
+      enableCleanup: true,
+      cleanupBatchSize: 20,
+    });
+    expect(opts.pruneExpiredBatchSize).to.equal(20);
+  });
+
+  it('enableCleanup:false disables every prune step, not just the old one', async () => {
+    const opts = await crankOnce({ enableCleanup: false });
+    expect(opts.enablePruneToReturned).to.equal(false);
+    expect(opts.enablePruneExpired).to.equal(false);
+    expect(opts.enablePrune).to.equal(false);
+  });
+
+  it('treats an unset enableCleanup as enabled (matches existing behaviour)', async () => {
+    const opts = await crankOnce({});
+    expect(opts.enablePruneToReturned).to.equal(true);
+    expect(opts.enablePruneExpired).to.equal(true);
+  });
+});

--- a/src/epoch/epoch-cranker.ts
+++ b/src/epoch/epoch-cranker.ts
@@ -217,6 +217,14 @@ export class EpochCranker {
         enablePrune: this.config.enableCleanup !== false,
         pruneBatchSize: this.config.cleanupBatchSize,
         pruneScanIntervalMs: this.config.cleanupMinIntervalMs,
+        // The other two thirds of the ArNS lease lifecycle. Previously the
+        // cranker only drained ReturnedName PDAs — a queue nothing ever filled,
+        // because `prune_name_to_returned` is what creates them and no actor
+        // called it. Expired leases therefore accumulated on-chain and stayed
+        // resolvable-but-unbuyable indefinitely. Same cleanup gate as above.
+        enablePruneToReturned: this.config.enableCleanup !== false,
+        enablePruneExpired: this.config.enableCleanup !== false,
+        pruneExpiredBatchSize: this.config.cleanupBatchSize,
       });
       action = result.action;
       if (result.action === 'idle') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.3.tgz#1c852322ad71458600f540ab4082b0c9c7704e41"
-  integrity sha512-r4QIm9UWE4OxT3pMBK4ZI3tM1VeVRIQt3llw7pd9hw7sYscreDF+apIteeYRHNGFnDmA2pvElH6qTTpWuM3EBg==
+"@ar.io/sdk@^4.1.0-alpha.7":
+  version "4.1.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.0-alpha.7.tgz#6d76fdb35964054e9a8aa92c4e4410d774075f94"
+  integrity sha512-zhpuip7oM064jxXYntWT7feomT3GXN9tosCYrGexihWXASFrrmt1Fl/LPiGwRotqkBpVz20DHa/Vi5LvdVtMww==
   dependencies:
     "@ar.io/solana-contracts" "1.0.1"
     "@noble/hashes" "^1.8.0"
@@ -6979,7 +6979,16 @@ strict-event-emitter@^0.5.1:
   resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
   integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7011,7 +7020,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7535,7 +7551,16 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Companion to **ar-io/ar-io-sdk#699**. Merge that first — this needs an `@ar.io/sdk` release exposing the new options.

## Problem

The cranker only passed `enablePrune`, which drives `prune_returned_names` — the step that cleans up `ReturnedName` PDAs *after* their auction ends. Nothing ever created those PDAs: `prune_name_to_returned` is what converts an expired lease into an auction, and no actor called it.

So the cranker was draining a queue that was never filled. Expired ArNS leases accumulated on-chain indefinitely — still resolving through gateways, and impossible for anyone to re-buy. On mainnet that left **601 of 2,469 leases past their end timestamp** (343 of them past grace + auction, oldest 78 days) and **zero `ReturnedName` PDAs ever created**.

No other actor has an incentive to fill the gap: `prune_to_returned` always sets `initiator = config`, so `buy_returned_name` pays 100% to the protocol and 0% to the caller. The contracts' `WORKFLOWS.md` already assigns `prune state | ario-gar, ario-arns` to the Cranker.

## Change

8 lines: forward `enablePruneToReturned` and `enablePruneExpired` (gated on the same `enableCleanup` config as the existing prune step), and pass `cleanupBatchSize` through as `pruneExpiredBatchSize`.

## Regression test

`runCycle` casts the contract to `any` before calling `crankEpochStep`:

```ts
const ario = contract as any;
```

That silences TypeScript at the call site completely. I verified this — adding a fabricated option named `thisOptionDoesNotExistAnywhere` compiles clean against both the patched and the released SDK. A misspelled option name would therefore compile, ship, and silently do nothing: the same class of silent no-op that let this bug sit unnoticed.

So the new test asserts the wire format directly rather than relying on types — exact option names, and that `enableCleanup: false` still reaches all three prune steps.

## Testing

- Observer suite: **366 passing, 0 failing**, including the 4 new tests.
- Prod build (`tsconfig.prod.json`) clean against both the patched SDK and released `@ar.io/sdk@4.0.3`.
- Runtime-verified against the patched SDK: with `enableCleanup: true` the cranker passes `enablePruneToReturned: true`, `enablePruneExpired: true`, `pruneExpiredBatchSize: <cleanupBatchSize>`; with `enableCleanup: false` all three prune flags are `false`.

Because of the `as any` cast this compiles against any SDK version, so it won't break CI ahead of the SDK release — but it is a no-op until that release lands.

## Not yet exercised

This has not been run through a live crank loop. The SDK-side instructions are independently verified (mainnet: 343 records closed across 14 transactions, 0 failures, verified by an independent `getProgramAccounts` sweep; `prune_name_to_returned` simulates clean), but the patched cranker driving them end to end is still pending a testnet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjByJECE5DcTSjNLAUMcBc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Epoch processing now automatically cleans up returned names and expired leases when cleanup is enabled.
  - Cleanup operations support configurable batch sizes.
  - Cleanup remains enabled by default and can be disabled through existing configuration.
  - Cleanup settings are consistently applied during each epoch-processing cycle.

- **Tests**
  - Added coverage for default cleanup behavior, custom batch sizes, disabled cleanup, and unset cleanup settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->