### PR TITLE
fix(crank): classify LeaveWindowNotExpired (6079) as not_ready

### DIFF
--- a/src/epoch/errors.test.ts
+++ b/src/epoch/errors.test.ts
@@ -152,6 +152,12 @@ describe('cranker error classification', () => {
         new Error('AnchorError ... Error Number: 6038'),
         // WeightsNotTallied
         new Error('AnchorError ... Error Number: 6046'),
+        // LeaveWindowNotExpired (finalize_gone on a not-yet-expired gateway)
+        new Error('AnchorError ... Error Number: 6079'),
+        // ...same, hex form (0x17bf = 6079) as seen in simulation failures
+        new Error(
+          'Transaction simulation failed: custom program error: 0x17bf',
+        ),
       ];
       for (const e of examples) {
         expect(classifyError(e)).to.equal('not_ready');

--- a/src/epoch/errors.ts
+++ b/src/epoch/errors.ts
@@ -61,6 +61,13 @@ const NOT_READY_ERRORS = new Set<number>([
   6048,
   // EpochNotCloseable (variant 51)
   6051,
+  // LeaveWindowNotExpired (variant 79) — a Leaving gateway whose leave window
+  // hasn't elapsed yet can't be finalize_gone'd. `getGoneGateways()` returns
+  // every Leaving gateway (not just expired ones), so the cleanup pass attempts
+  // them and they revert with this until their window passes — a wait-and-retry
+  // condition, NOT a real error (must not spam error logs or trip unhealthy via
+  // consecutiveRealErrors).
+  6079,
 ]);
 
 /**


### PR DESCRIPTION
Mirrors ar-io-cranker PR #14. The observer-embedded cranker shares this cleanup code.

## Problem
`getGoneGateways()` returns **every** `Leaving` gateway (not just those whose leave window has elapsed), so the Phase-3 `finalize_gone` cleanup attempts them all; the not-yet-expired ones revert with `6079 LeaveWindowNotExpired`. `6079` was unmapped in `errors.ts` → classified `real`, which:
- spams `[crank:finalize_gone] Error` at error level — one per gone-but-unexpired gateway, every cleanup cycle (68 in a single pass observed on staging), and
- increments `consecutiveRealErrors`, which trips the cranker health server to unhealthy at ≥10 consecutive.

## Fix
Map `6079 LeaveWindowNotExpired` → `not_ready` (a wait-and-retry precondition): resets `consecutiveRealErrors`, logs at `debug`. Extends `errors.test.ts` with the 6079 decimal + hex (0x17bf) forms.

Fully eliminating the wasted `finalize_gone` simulations is a follow-up needing `getGoneGateways()` to expose the leave-window end (SDK change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATzdETW9PfP7Q9oQBAyREi