### PR TITLE
Bump @ar.io/sdk to 4.1.0 stable — 4-account close_observation (mainnet rent refund)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.1.0-alpha.7",
+    "@ar.io/sdk": "^4.1.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,12 +23,12 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.1.0-alpha.7":
-  version "4.1.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.0-alpha.7.tgz#6d76fdb35964054e9a8aa92c4e4410d774075f94"
-  integrity sha512-zhpuip7oM064jxXYntWT7feomT3GXN9tosCYrGexihWXASFrrmt1Fl/LPiGwRotqkBpVz20DHa/Vi5LvdVtMww==
+"@ar.io/sdk@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.0.tgz#a8fa42c6bb99339480371a2dcfcea71e930f42cd"
+  integrity sha512-eW4OjjNDZhOHYqRVHM3hq7iGFlp+mYYAHYv4LPI9/q6paM490uoPB+TBOVteGIi+HYvGPUNlAONfy4QYfOiWfg==
   dependencies:
-    "@ar.io/solana-contracts" "1.0.1"
+    "@ar.io/solana-contracts" "1.1.0"
     "@noble/hashes" "^1.8.0"
     "@solana-program/address-lookup-table" "^0.11.0"
     "@solana-program/compute-budget" "^0.15.0"
@@ -40,10 +40,10 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/solana-contracts@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.1.tgz#1a16958d54540222b77def81d5d39e7402b8b69c"
-  integrity sha512-zD7OepkzzWb1SIHRDxSo3y+dzRh9gu+43eI2DBJLtQ+7EkT3Py8v9kHQ40UcRC8CReHHTO74RDty6Hwx5JYVGA==
+"@ar.io/solana-contracts@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.1.0.tgz#900784dad9b0867ae76678dc177d346692f5e61f"
+  integrity sha512-qX8ttp5GoZYMMNNgVzGMdBmaym3g1XL3Y7GyApbbXo4e4SSgt3DXMKl6PCISij5snhkec21LAhHxzHuLyoOe8w==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
Moves the embedded epoch cranker from @ar.io/sdk ^4.1.0-alpha.7 to the stable ^4.1.0 (@latest), now that mainnet == develop (gar #116 + ant #118 deployed). 4.1.0 builds close_observation with the 4-account [epoch, observation, observer, caller] form so reclaimed rent refunds the observer.

- Dep bump only; tsc clean (develop already handles the lease-lifecycle crank actions).
- close_observation verified as 4-account.

Deploy alongside the standalone cranker to close the mainnet observer rent gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AR.IO SDK to the stable 4.1.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->