### PR TITLE
fix(crank): raise prune_name_to_returned throughput above the expiry rate

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.1.0",
+    "@ar.io/sdk": "^4.1.2",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -488,6 +488,18 @@ export const CLEANUP_FAILURE_THRESHOLD = parsePositiveIntEnv(
   'CLEANUP_FAILURE_THRESHOLD',
   '30',
 );
+// `prune_name_to_returned` takes a single record, so it cannot batch into one
+// tx the way the other two prune steps do — its throughput is (txs per scan) x
+// (scan rate). It is also the only deadline-bound step: a lease not converted
+// while inside its auction window ages into the past-auction band and is closed
+// directly, losing the protocol that Dutch auction permanently. Left at one per
+// scan it capped at ~48 names/day on a 24h epoch, the same order as the rate
+// leases fall past grace — so a backlog could never drain. Default 10 keeps
+// ~10x headroom while staying well inside MAX_CLEANUP_TXS_PER_CYCLE.
+export const CLEANUP_TO_RETURNED_TXS_PER_CYCLE = parsePositiveIntEnv(
+  'CLEANUP_TO_RETURNED_TXS_PER_CYCLE',
+  '10',
+);
 // Optional: when unset, the cranker derives the cleanup cadence from the epoch
 // duration (see src/epoch/adaptive-intervals.ts). An explicit value always wins.
 export const CLEANUP_MIN_INTERVAL_MS = parsePositiveIntEnvOrUndefined(

--- a/src/epoch/epoch-cranker-arns-lifecycle.test.ts
+++ b/src/epoch/epoch-cranker-arns-lifecycle.test.ts
@@ -37,11 +37,15 @@ const noopLog: EpochCrankerConfig['log'] = {
  * `crankEpochStep` and tolerates every other SDK call the cleanup phases
  * may make (each returns an empty result).
  */
-function stubContract(capture: (opts: Record<string, unknown>) => void) {
+function stubContract(
+  capture: (opts: Record<string, unknown>) => void,
+  result: Record<string, unknown> | undefined = undefined,
+) {
+  const stepResult = result ?? { action: 'idle', reason: 'stubbed' };
   const base: Record<string, unknown> = {
     crankEpochStep: async (opts: Record<string, unknown>) => {
       capture(opts);
-      return { action: 'idle', reason: 'stubbed' };
+      return stepResult;
     },
   };
   return new Proxy(base, {
@@ -54,12 +58,13 @@ function stubContract(capture: (opts: Record<string, unknown>) => void) {
 
 async function crankOnce(
   overrides: Partial<EpochCrankerConfig>,
+  stepResult?: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   let captured: Record<string, unknown> | null = null;
   const cranker = new EpochCranker({
     contract: stubContract((o) => {
       captured = o;
-    }) as never,
+    }, stepResult) as never,
     rpc: {} as never,
     signer: { address: 'stub' } as never,
     pollIntervalMs: 1000,
@@ -89,6 +94,49 @@ describe('EpochCranker — ArNS lease lifecycle options', () => {
     expect(opts.enablePruneExpired).to.equal(true);
     // the pre-existing returned-name step must keep working
     expect(opts.enablePrune).to.equal(true);
+  });
+
+  it('forwards cleanupToReturnedTxsPerCycle as pruneToReturnedTxsPerCycle', async () => {
+    // Sets throughput for the only deadline-bound step. `prune_name_to_returned`
+    // takes a single record and cannot batch into one tx, so txs-per-scan is
+    // the whole lever: at one per scan a 24h-epoch cranker caps at ~48
+    // names/day, the same order as leases fall past grace, and the backlog
+    // never drains. A silently-dropped option here reintroduces exactly that.
+    const opts = await crankOnce({
+      enableCleanup: true,
+      cleanupToReturnedTxsPerCycle: 7,
+    });
+    expect(opts.pruneToReturnedTxsPerCycle).to.equal(7);
+  });
+
+  it('surfaces partialFailureReason from the SDK result into the log line', async () => {
+    // A partial drain must be distinguishable from a budget-bounded one.
+    const lines: Array<{ msg: string; meta: Record<string, unknown> }> = [];
+    await crankOnce(
+      {
+        enableCleanup: true,
+        log: {
+          ...noopLog,
+          info: (msg: string, meta?: Record<string, unknown>) => {
+            lines.push({ msg, meta: meta ?? {} });
+          },
+        } as EpochCrankerConfig['log'],
+      },
+      {
+        action: 'prune_name_to_returned',
+        txId: 'tx-1',
+        progress: { index: 2, total: 9 },
+        partialFailureReason: 'blockhash expired',
+      },
+    );
+    const line = lines.find((l) => l.msg.includes('prune_name_to_returned'));
+    expect(line, 'no prune log line emitted').to.not.equal(undefined);
+    expect(line?.meta.partialFailureReason).to.equal('blockhash expired');
+  });
+
+  it('leaves pruneToReturnedTxsPerCycle undefined when unconfigured, so the SDK default applies', async () => {
+    const opts = await crankOnce({ enableCleanup: true });
+    expect(opts.pruneToReturnedTxsPerCycle).to.equal(undefined);
   });
 
   it('forwards cleanupBatchSize as the expired-name batch size', async () => {

--- a/src/epoch/epoch-cranker.ts
+++ b/src/epoch/epoch-cranker.ts
@@ -56,6 +56,13 @@ export interface EpochCrankerConfig {
    */
   maxCleanupTxsPerCycle?: number;
   /**
+   * `prune_name_to_returned` txs to submit per scan. Unlike the other two prune
+   * steps this instruction takes a single record and cannot batch into one tx,
+   * so this is what sets its throughput. Default: 10.
+   * Env: CLEANUP_TO_RETURNED_TXS_PER_CYCLE.
+   */
+  cleanupToReturnedTxsPerCycle?: number;
+  /**
    * Threshold for `prune_gateway` (failed_consecutive >= N). Mirrors
    * `EpochSettings.max_consecutive_failures` (default 30).
    */
@@ -216,6 +223,14 @@ export class EpochCranker {
         // tie it to the same cleanup config the runCleanup phases use.
         enablePrune: this.config.enableCleanup !== false,
         pruneBatchSize: this.config.cleanupBatchSize,
+        // Scan cadence stays tied to the cleanup interval on purpose. It is
+        // derived from the epoch duration specifically to cut credit-heavy
+        // getProgramAccounts scans on long epochs (adaptive-intervals.ts), and
+        // decoupling it would multiply them ~30x. The throughput problem that
+        // cadence used to cause is solved by pruneToReturnedTxsPerCycle below,
+        // which makes the deadline-bound step drain proportionally to the
+        // backlog rather than to the scan rate. Worst-case conversion latency
+        // is then one scan interval (30 min) against a 14-day auction window.
         pruneScanIntervalMs: this.config.cleanupMinIntervalMs,
         // The other two thirds of the ArNS lease lifecycle. Previously the
         // cranker only drained ReturnedName PDAs — a queue nothing ever filled,
@@ -223,6 +238,7 @@ export class EpochCranker {
         // called it. Expired leases therefore accumulated on-chain and stayed
         // resolvable-but-unbuyable indefinitely. Same cleanup gate as above.
         enablePruneToReturned: this.config.enableCleanup !== false,
+        pruneToReturnedTxsPerCycle: this.config.cleanupToReturnedTxsPerCycle,
         enablePruneExpired: this.config.enableCleanup !== false,
         pruneExpiredBatchSize: this.config.cleanupBatchSize,
       });
@@ -234,6 +250,13 @@ export class EpochCranker {
           epochIndex: result.epochIndex,
           tx: result.txId,
           progress: result.progress,
+          // Present when a batched step stopped early on a failed submission.
+          // Without it a partial drain is indistinguishable from a full one:
+          // the operator sees only a smaller progress.index and cannot tell
+          // whether the per-cycle budget or a real error bounded the work.
+          ...(result.partialFailureReason !== undefined
+            ? { partialFailureReason: result.partialFailureReason }
+            : {}),
         });
       }
     } catch (err) {

--- a/src/system.ts
+++ b/src/system.ts
@@ -416,6 +416,7 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
       enableCleanup: config.ENABLE_CLEANUP,
       cleanupBatchSize: config.CLEANUP_BATCH_SIZE,
       maxCleanupTxsPerCycle: config.MAX_CLEANUP_TXS_PER_CYCLE,
+      cleanupToReturnedTxsPerCycle: config.CLEANUP_TO_RETURNED_TXS_PER_CYCLE,
       cleanupFailureThreshold: config.CLEANUP_FAILURE_THRESHOLD,
       altReclaimScanLimit: config.ALT_RECLAIM_SCAN_LIMIT,
       cleanupMinIntervalMs,

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.0.tgz#a8fa42c6bb99339480371a2dcfcea71e930f42cd"
-  integrity sha512-eW4OjjNDZhOHYqRVHM3hq7iGFlp+mYYAHYv4LPI9/q6paM490uoPB+TBOVteGIi+HYvGPUNlAONfy4QYfOiWfg==
+"@ar.io/sdk@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.2.tgz#421cf300112e6698b53d000eaad45237437e7d53"
+  integrity sha512-4AyS67lkKa62L6BAWrNbXx3S1GG/AKWeMNZCGkqpkwwKldLGLyq3ZQrylku2bcSJKqRKL/SmYS76OPqIC6o3aQ==
   dependencies:
     "@ar.io/solana-contracts" "1.1.0"
     "@noble/hashes" "^1.8.0"


### PR DESCRIPTION
Depends on ar-io/ar-io-sdk#703 — merge that and bump `@ar.io/sdk` here before this takes effect. The option is optional, so an older SDK ignores it and behaviour is unchanged; this PR is safe to merge first, it just does nothing until the bump.

## Problem

`prune_name_to_returned` is the only **deadline-bound** step in the ArNS lease lifecycle: a lease not converted while still inside its auction window ages into the past-auction band and is closed directly, losing the protocol that Dutch auction permanently. It also takes a single record per instruction, so unlike the other two prune steps it cannot batch into one tx — its throughput is `txs per scan × scan rate`.

The SDK drained exactly one per scan, and this cranker feeds it `cleanupMinIntervalMs`, which `adaptive-intervals` derives from the epoch duration and clamps to a **30 min ceiling**. On a 24h epoch that capped conversion at **~48 names/day** — the same order as the rate leases fall past their grace period.

Observed on mainnet: a **121-name backlog** that had been *growing* (155 → 174), with names ageing out of their auction window at roughly the rate they were converted.

## Change

Forward `pruneToReturnedTxsPerCycle` via new env **`CLEANUP_TO_RETURNED_TXS_PER_CYCLE`** (default 10), so throughput scales with the backlog instead of the scan rate — ~10× headroom over the observed expiry rate.

Also log `partialFailureReason` when a batched step stops early, so a partial drain is distinguishable from a budget-bounded one. Without it the operator sees only a smaller `progress.index` with no explanation. This is not hypothetical: during staging validation a real RPC 429 produced exactly that case.

## Deliberately NOT decoupling the scan interval

`adaptive-intervals` exists to cut credit-heavy `getProgramAccounts` scans on long epochs. Giving this step its own 60s cadence would multiply those ~30× to solve a problem the per-scan budget already solves. Worst-case conversion latency stays one scan interval (30 min) against a **14-day** auction window.

## Testing

- 369 tests, 0 failures (3 new).
- Wire-format assertions in `epoch-cranker-arns-lifecycle.test.ts` — these matter here because `runCycle` casts the contract to `any`, so a dropped or misspelled option name compiles clean and silently does nothing.
- **Validated end-to-end on AR.IO Staging V2 (devnet)** with a purpose-built image carrying this change plus the SDK fix: drained **141 → 83 pruneable records in ~15 min**, with `progress.index` tracking `CLEANUP_TO_RETURNED_TXS_PER_CYCLE` exactly (tested at 5, then 8). On-chain `PruneNameToReturned` confirmed, +0.000357 SOL rent reclaimed per prune.

## Aside worth a follow-up

`const ario = contract as any` in `epoch-cranker.ts` means the whole `crankEpochStep` call site is unchecked — I confirmed by inserting a bogus option and getting no compile error. With the patched SDK types and the cast lifted, `runCycle` type-checks cleanly, so the cast may now be removable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration to control the number of returned-name cleanup transactions processed per cycle, defaulting to 10.
  * Cleanup settings are now applied automatically during epoch processing.

* **Bug Fixes**
  * Epoch progress logs now report why processing stopped after a partial batch failure.
  * Unconfigured cleanup limits are omitted from processing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->