### PR TITLE
fix(config): trim entries in comma-separated host and name lists

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,66 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect } from 'chai';
+
+import { parseCommaSeparatedList } from './config.js';
+
+describe('parseCommaSeparatedList', () => {
+  it('parses a plain comma-separated list', () => {
+    expect(parseCommaSeparatedList('a.com,b.com')).to.deep.equal([
+      'a.com',
+      'b.com',
+    ]);
+  });
+
+  it('trims spaces after commas', () => {
+    // The regression this exists for: an untrimmed split yields ' b.com',
+    // which matches no gateway and silently shrinks the observation set.
+    expect(parseCommaSeparatedList('a.com, b.com')).to.deep.equal([
+      'a.com',
+      'b.com',
+    ]);
+  });
+
+  it('trims surrounding whitespace of every entry', () => {
+    expect(parseCommaSeparatedList('  a.com ,\tb.com , c.com  ')).to.deep.equal(
+      ['a.com', 'b.com', 'c.com'],
+    );
+  });
+
+  it('drops empty entries from stray or trailing commas', () => {
+    expect(parseCommaSeparatedList('a.com,,b.com,')).to.deep.equal([
+      'a.com',
+      'b.com',
+    ]);
+  });
+
+  it('returns an empty list for an empty or whitespace-only value', () => {
+    // The unset case: config passes '' when neither env nor CLI arg is set,
+    // and an empty list means "no restriction".
+    expect(parseCommaSeparatedList('')).to.deep.equal([]);
+    expect(parseCommaSeparatedList('   ')).to.deep.equal([]);
+    expect(parseCommaSeparatedList(',')).to.deep.equal([]);
+  });
+
+  it('preserves a single entry unchanged', () => {
+    expect(parseCommaSeparatedList('only.example')).to.deep.equal([
+      'only.example',
+    ]);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,15 +91,29 @@ export const REFERENCE_GATEWAY_HOSTS: string[] = (() => {
   return DEFAULT_REFERENCE_GATEWAYS;
 })();
 
-export const OBSERVED_GATEWAY_HOSTS = env
-  .varOrDefault('OBSERVED_GATEWAY_HOSTS', args.observedGatewayHosts ?? '')
-  .split(',')
-  .filter((h) => h.length > 0);
+/**
+ * Split a comma-separated env var into trimmed, non-empty entries.
+ *
+ * Trimming is the point: `a.com, b.com` is the natural way to write a list,
+ * but an untrimmed split yields `' b.com'`, which matches no gateway or name.
+ * That fails silently — the entry is simply never found — so it narrows the
+ * observation set rather than erroring. `REFERENCE_GATEWAY_HOSTS` already
+ * trims; this shares that behavior with the other list-valued settings.
+ */
+export function parseCommaSeparatedList(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
 
-export const ARNS_NAMES = env
-  .varOrDefault('ARNS_NAMES', args.arnsNames ?? '')
-  .split(',')
-  .filter((h) => h.length > 0);
+export const OBSERVED_GATEWAY_HOSTS = parseCommaSeparatedList(
+  env.varOrDefault('OBSERVED_GATEWAY_HOSTS', args.observedGatewayHosts ?? ''),
+);
+
+export const ARNS_NAMES = parseCommaSeparatedList(
+  env.varOrDefault('ARNS_NAMES', args.arnsNames ?? ''),
+);
 
 // Whitepaper v3.0.0 §10.3: "eight (8) 'chosen names' selected
 // independently by each observer". The default lived at `1` since the


### PR DESCRIPTION
`OBSERVED_GATEWAY_HOSTS` and `ARNS_NAMES` split on `,` without trimming, so the natural way to write a list breaks them:

```
'a.com, b.com'  ->  ['a.com', ' b.com']
```

The `' b.com'` entry matches no gateway, so it fails **silently** — the host is simply never found and the observation set narrows, with no error explaining why. `ARNS_NAMES` has the same shape.

`REFERENCE_GATEWAY_HOSTS`, defined directly above these two, already does `.map((h) => h.trim())`. This aligns the other two with that existing behavior rather than introducing a new convention.

## Change

Extracted `parseCommaSeparatedList` and used it for both. The extraction is what makes this testable — `config.ts` parses at module load, so the exported values can otherwise only be exercised by reimporting the module under mutated `process.env`, which no test in this repo does today.

## No behavior change for well-formed input

- Already-trimmed lists parse identically.
- An unset var still yields `[]` — `config` passes `''` when neither the env var nor the CLI arg is set, and an empty list means "no restriction".

Verified against the built `dist`:

```
'host-a, host-b' -> ["host-a","host-b"]
'n1, n2 ,n3'     -> ["n1","n2","n3"]
unset            -> []
```

## Testing

375 tests passing (6 new), lint and build clean. The new cases cover the reported input (`host-a, host-b`), interior/tab whitespace, stray and trailing commas, empty and whitespace-only values, and the single-entry case.

Found by CodeRabbit on ar-io/ar-io-node#857, which forwards `OBSERVED_GATEWAY_HOSTS` into the observer container for the first time — so this footgun was previously unreachable via compose and is about to become reachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing comma-separated configuration values with whitespace normalization and empty-entry removal.
  * Updated gateway host and ARN name settings to use the improved parsing behavior.

* **Tests**
  * Added coverage for comma-separated values, whitespace trimming, empty inputs, and single entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->