### PR TITLE
fix(observer): retry save_observations on transient send errors

### DIFF
--- a/src/store/solana-contract-report-sink.test.ts
+++ b/src/store/solana-contract-report-sink.test.ts
@@ -14,6 +14,10 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as winston from 'winston';
 import type { Address } from '@solana/kit';
+import {
+  SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED,
+  SolanaError,
+} from '@solana/errors';
 
 import type { SolanaARIOReadable, SolanaARIOWriteable } from '@ar.io/sdk';
 import { SolanaContractReportSink } from './solana-contract-report-sink.js';
@@ -341,6 +345,138 @@ describe('SolanaContractReportSink', () => {
         expect(e.message).to.match(/Transaction simulation failed/);
       }
       expect(threw).to.equal(true);
+    });
+  });
+
+  describe('transient send-error retry', () => {
+    const openStatus = {
+      prescribed: true,
+      observerIdx: 7,
+      alreadyObserved: false,
+      windowOpen: true,
+      endTimestampSec: Math.floor(Date.now() / 1000) + 100,
+    };
+
+    /** The exact failure seen on mainnet: blockhash expired by one block. */
+    const blockHeightExceeded = () =>
+      new SolanaError(SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED, {
+        currentBlockHeight: 417090557n,
+        lastValidBlockHeight: 417090556n,
+      });
+
+    function makeSink(opts: { saveStub: sinon.SinonStub; statuses?: any[] }) {
+      const statusStub = sinon.stub();
+      const statuses = opts.statuses ?? [openStatus, openStatus, openStatus];
+      statuses.forEach((st, i) =>
+        st instanceof Error
+          ? statusStub.onCall(i).rejects(st)
+          : statusStub.onCall(i).resolves(st),
+      );
+      statusStub.resolves(statuses[statuses.length - 1]);
+      return new SolanaContractReportSink({
+        log: makeLog(),
+        contract: { saveObservations: opts.saveStub } as any,
+        readable: { getEpochObservationStatus: statusStub } as any,
+        observerAddress: OBSERVER_PUBKEY,
+      });
+    }
+
+    it('retries a blockhash expiry and succeeds on the next attempt', async () => {
+      const saveStub = sinon.stub();
+      saveStub.onCall(0).rejects(blockHeightExceeded());
+      saveStub.onCall(1).resolves({ id: 'SIG_RETRIED' });
+      const sink = makeSink({ saveStub });
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(2);
+      expect(result.interactionTxIds).to.deep.equal(['SIG_RETRIED']);
+    });
+
+    it('retries when the transient error is nested in a cause chain', async () => {
+      const wrapped: any = new Error('sendAndConfirm failed');
+      wrapped.cause = blockHeightExceeded();
+      const saveStub = sinon.stub();
+      saveStub.onCall(0).rejects(wrapped);
+      saveStub.onCall(1).resolves({ id: 'SIG_NESTED' });
+      const sink = makeSink({ saveStub });
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(2);
+      expect(result.interactionTxIds).to.deep.equal(['SIG_NESTED']);
+    });
+
+    it('does NOT retry a deterministic program error', async () => {
+      const saveStub = sinon
+        .stub()
+        .rejects(new Error('Transaction simulation failed: NotPrescribed'));
+      const sink = makeSink({ saveStub });
+
+      let threw = false;
+      try {
+        await sink.saveReport(
+          makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+        );
+      } catch {
+        threw = true;
+      }
+      expect(threw).to.equal(true);
+      expect(saveStub.callCount).to.equal(1);
+    });
+
+    it('stops retrying when the first attempt actually landed', async () => {
+      const saveStub = sinon.stub().rejects(blockHeightExceeded());
+      const sink = makeSink({
+        saveStub,
+        statuses: [openStatus, { ...openStatus, alreadyObserved: true }],
+      });
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(1);
+      expect(result.interactionTxIds).to.equal(undefined);
+    });
+
+    it('stops retrying once the observation window has closed', async () => {
+      const saveStub = sinon.stub().rejects(blockHeightExceeded());
+      const sink = makeSink({
+        saveStub,
+        statuses: [openStatus, { ...openStatus, windowOpen: false }],
+      });
+
+      let threw = false;
+      try {
+        await sink.saveReport(
+          makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+        );
+      } catch {
+        threw = true;
+      }
+      expect(threw).to.equal(true);
+      expect(saveStub.callCount).to.equal(1);
+    });
+
+    it('gives up after the attempt cap and rethrows', async () => {
+      const saveStub = sinon.stub().rejects(blockHeightExceeded());
+      const sink = makeSink({ saveStub });
+
+      let threw = false;
+      try {
+        await sink.saveReport(
+          makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+        );
+      } catch {
+        threw = true;
+      }
+      expect(threw).to.equal(true);
+      expect(saveStub.callCount).to.equal(3);
     });
   });
 });

--- a/src/store/solana-contract-report-sink.ts
+++ b/src/store/solana-contract-report-sink.ts
@@ -24,11 +24,56 @@
  * needed from the observer side.
  */
 import type { Address } from '@solana/kit';
+import {
+  SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_NODE_UNHEALTHY,
+  SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR,
+  SOLANA_ERROR__TRANSACTION_ERROR__BLOCKHASH_NOT_FOUND,
+  isSolanaError,
+} from '@solana/errors';
 import type { SolanaARIOReadable, SolanaARIOWriteable } from '@ar.io/sdk';
 import type winston from 'winston';
 
 import type { ObserverReport, ReportInfo, ReportSink } from '../types.js';
 import { getFailedGatewaySummaryFromReport } from './failed-gateway-summary.js';
+
+/** Total `save_observations` attempts before giving up on an epoch. */
+const MAX_SUBMIT_ATTEMPTS = 3;
+/** Linear backoff base between attempts. */
+const RETRY_BACKOFF_MS = 1_000;
+
+/**
+ * Send failures that say "this transaction did not commit under that
+ * blockhash" — re-sending with a fresh one is the correct response. A
+ * deterministic program error (not prescribed, window closed, already
+ * observed) is NOT in this set: retrying those only burns fees.
+ *
+ * Retrying is safe even if a prior attempt did land after all, because the
+ * Observation PDA is `init`-constrained: a duplicate lands as an on-chain
+ * rejection rather than a second observation. The `alreadyObserved` re-check
+ * between attempts catches that case first and exits cleanly.
+ */
+const RETRYABLE_SOLANA_ERROR_CODES = [
+  SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED,
+  SOLANA_ERROR__TRANSACTION_ERROR__BLOCKHASH_NOT_FOUND,
+  SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_NODE_UNHEALTHY,
+] as const;
+
+/**
+ * True when `err` (or anything in its `cause` chain — kit nests the original
+ * failure under the confirmation error) is one of the transient send failures.
+ */
+export function isRetryableSendError(err: unknown, depth = 0): boolean {
+  if (err === null || err === undefined || depth > 10) return false;
+  for (const code of RETRYABLE_SOLANA_ERROR_CODES) {
+    if (isSolanaError(err, code)) return true;
+  }
+  return isRetryableSendError((err as { cause?: unknown }).cause, depth + 1);
+}
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export interface SolanaContractReportSinkConfig {
   log: winston.Logger;
@@ -151,20 +196,83 @@ export class SolanaContractReportSink implements ReportSink {
       reportTxId,
     });
 
-    let interactionTxId: string;
-    try {
-      const { id } = await this.contract.saveObservations({
-        reportTxId,
-        failedGateways,
-        epochIndex,
-      });
-      interactionTxId = id;
-    } catch (err: any) {
-      this.log.error('save_observations transaction failed', {
-        epochIndex,
-        message: err.message,
-      });
-      throw err;
+    // A blockhash is only valid ~60s from issue, so a slow RPC can expire the
+    // transaction before it lands — losing the epoch's observation AND its
+    // reward even though the report uploaded and the window was open. Retry the
+    // transient cases with a fresh blockhash (the SDK takes a new one per call).
+    let interactionTxId: string | undefined;
+    for (let attempt = 1; attempt <= MAX_SUBMIT_ATTEMPTS; attempt++) {
+      try {
+        const { id } = await this.contract.saveObservations({
+          reportTxId,
+          failedGateways,
+          epochIndex,
+        });
+        interactionTxId = id;
+        break;
+      } catch (err: any) {
+        const retryable = isRetryableSendError(err);
+        if (!retryable || attempt === MAX_SUBMIT_ATTEMPTS) {
+          this.log.error('save_observations transaction failed', {
+            epochIndex,
+            attempt,
+            retryable,
+            message: err.message,
+          });
+          throw err;
+        }
+
+        this.log.warn(
+          'save_observations hit a transient send error — retrying with a fresh blockhash',
+          {
+            epochIndex,
+            observer: this.observerAddress,
+            attempt,
+            maxAttempts: MAX_SUBMIT_ATTEMPTS,
+            message: err.message,
+          },
+        );
+
+        await delay(RETRY_BACKOFF_MS * attempt);
+
+        // Re-read epoch state before spending another transaction. Two cases
+        // matter: the previous attempt may have landed after we gave up on it
+        // (then we're done — the PDA exists and a retry would just be rejected),
+        // or the observation window may have closed while we backed off (then no
+        // retry can succeed). A failure to READ state is not itself a reason to
+        // abandon the retry, so that case falls through to the next attempt.
+        try {
+          const recheck = await this.readable.getEpochObservationStatus(
+            epochIndex,
+            this.observerAddress,
+          );
+          if (recheck.alreadyObserved) {
+            this.log.info(
+              'save_observations actually landed despite the send error — nothing to retry',
+              { epochIndex, observer: this.observerAddress, attempt },
+            );
+            return reportInfo;
+          }
+          if (!recheck.windowOpen) {
+            this.log.warn(
+              'Observation window closed while retrying — abandoning epoch',
+              { epochIndex, observer: this.observerAddress, attempt },
+            );
+            throw err;
+          }
+        } catch (recheckErr: any) {
+          if (recheckErr === err) throw err;
+          this.log.warn(
+            'Could not re-read epoch state between retries — retrying anyway',
+            { epochIndex, attempt, message: recheckErr.message },
+          );
+        }
+      }
+    }
+
+    /* c8 ignore next 3 -- the loop either sets an id, returns, or throws */
+    if (interactionTxId === undefined) {
+      throw new Error('save_observations produced no transaction id');
     }
 
     this.log.info('save_observations submitted', {


### PR DESCRIPTION
## Problem

`saveReport()` submitted `save_observations` once and rethrew on any error. A transient blockhash expiry therefore cost the observer that epoch's observation **and its reward** — even though the report had uploaded to Turbo and the observation window was still open.

Reported by an operator on mainnet epoch 512, expiring by exactly one block (`lastValidBlockHeight` 417090556 vs `currentBlockHeight` 417090557). Checking that observer on-chain: they were prescribed **once in six epochs**, and this was that epoch — so the single failure cost them their only opportunity in the window.

## Fix

Up to 3 attempts with linear backoff. The SDK takes a fresh blockhash per call, so each retry is a genuinely new lifetime — which is the direct remedy for an expiry.

**Transient-only.** Retries `BLOCK_HEIGHT_EXCEEDED`, `BLOCKHASH_NOT_FOUND`, transport errors, and node-unhealthy — walking the `cause` chain, since kit nests the original failure under the confirmation error. Deterministic program errors (not prescribed, window closed) still fail on the first attempt rather than burning fees.

**State re-checked between attempts**, so we never spend a transaction we already know can't succeed:
- `alreadyObserved` → an earlier attempt landed after we gave up on it; return cleanly instead of sending a duplicate.
- window closed → no retry can succeed; abandon the epoch.
- a failure to *read* that state is not itself a reason to abandon; falls through to the next attempt.

Retrying is safe regardless of the re-check: the Observation PDA is `init`-constrained, so a duplicate is rejected on-chain rather than double-counted.

## What was ruled out

Priority-fee underpricing was investigated and **ruled out** as the cause. `save_observations` does pay a floor-rate fee (~290–375 lamports), but two other observers landed epoch-512 submissions 17 and 60 minutes either side of this failure at that same rate, and all 16 of the epoch's submissions landed at floor rates across the day. No fee change is needed.

## Scope

This makes a transient failure survivable; it does not change network participation. Across epochs 508–512, 128 of 161 prescribed observers never submitted at all — operators not running a Solana-capable observer, which no retry logic touches.

## Tests

6 new cases: retry-then-succeed, nested `cause` chains, no-retry on deterministic errors, the landed-after-all exit, the window-closed exit, and the attempt cap.

Suite: 375 → 381 passing on this base, 0 failures. `tsc` shows the same 5 pre-existing errors in unrelated test files, none in the changed file. eslint/prettier clean.

> Note for reviewers: this repo has no PR CI — the only workflow triggers on push to `develop`/`main`. The results above are from a local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKeNoHyV6m1Z3sh81Jykkf
