### PR TITLE
fix(store): retry save_observations on transient errors and stop hiding sink failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,9 +154,30 @@ Flow:
 - After the parent epoch is fully distributed, the cranker's
   `close_observation` loop reclaims the Observation PDA's rent.
 
+**Transient-failure retry.** A blockhash lives ~150 slots (~60s). If
+the transaction does not land inside that window, `sendAndConfirm`
+rejects a valid instruction. The sink retries up to
+`maxSubmitAttempts` (default 3) with the backoff in `retryBackoffMs`
+(default 1s, 3s). `src/store/solana-tx-errors.ts` classifies the
+error: only transient send/confirm failures retry, and a program
+revert throws on the first attempt. Between attempts the sink re-reads
+`getEpochObservationStatus` — it stops if the observation landed after
+all, or if the window closed while retrying. An `already in use`
+revert from the `init`-constrained Observation PDA counts as a
+completed submission, not a failure.
+
+**Sink-failure propagation.** `PipelineReportSink` logs a sink error
+and continues to the next sink, so its result can carry a `reportTxId`
+from Turbo while the contract sink failed. It now names the failures in
+`ReportInfo.failedSinks`. `ContinuousObserver` treats a non-empty
+`failedSinks` as "not submitted" and retries next cycle; without that
+check a failed `save_observations` was logged as `Report submitted` and
+the epoch reward was lost.
+
 Unit tests: `src/store/solana-contract-report-sink.test.ts` covers the
 happy path + all three skip gates + missing-reportTxId guard + error
-propagation (9 tests).
+propagation + the retry loop (16 tests).
+`src/store/solana-tx-errors.test.ts` covers the classifiers (10 tests).
 
 ## Compression Settings
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,10 +36,21 @@ if (args.saveReport) {
     console.error(
       `Persistence incomplete — these sinks failed: ${persisted.failedSinks.join(', ')}`,
     );
+    console.error(
+      'Skipping submission: refusing to land an on-chain observation without a ' +
+        'complete local record. Mirrors ContinuousObserver, which treats a failed ' +
+        'persistence sink as "not submitted".',
+    );
+    // `process.exitCode` records the failure but does NOT halt execution, so
+    // the submission below must be gated explicitly or a one-shot run would
+    // submit on-chain despite the incomplete persistence.
     process.exitCode = 1;
   }
 
-  if (submissionReportSink !== undefined) {
+  if (
+    submissionReportSink !== undefined &&
+    persisted.failedSinks === undefined
+  ) {
     let proceed = true;
     if (submissionGate !== undefined) {
       try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,12 @@ if (args.saveReport) {
   // gated on prescription so the one-shot CLI doesn't burn Turbo
   // credits + RPC for a report with no on-chain pathway.
   const persisted = await persistenceReportSink.saveReport({ report });
+  if (persisted.failedSinks !== undefined) {
+    console.error(
+      `Persistence incomplete — these sinks failed: ${persisted.failedSinks.join(', ')}`,
+    );
+    process.exitCode = 1;
+  }
 
   if (submissionReportSink !== undefined) {
     let proceed = true;
@@ -52,7 +58,15 @@ if (args.saveReport) {
       }
     }
     if (proceed) {
-      await submissionReportSink.saveReport(persisted);
+      const submitted = await submissionReportSink.saveReport(persisted);
+      // The pipeline logs sink errors and continues, so a non-zero exit
+      // is the only way a one-shot run signals a partial submission.
+      if (submitted.failedSinks !== undefined) {
+        console.error(
+          `Submission incomplete — these sinks failed: ${submitted.failedSinks.join(', ')}`,
+        );
+        process.exitCode = 1;
+      }
     }
   }
 }

--- a/src/continuous/continuous-observer.test.ts
+++ b/src/continuous/continuous-observer.test.ts
@@ -1242,6 +1242,51 @@ describe('ContinuousObserver Integration', function () {
       expect(submission.saveReport.called).to.be.false;
     });
 
+    it('submission sink failed → returns false even though Turbo produced a txid', async function () {
+      // The epoch 512 miss: TurboReportSink uploaded, then
+      // SolanaContractReportSink threw. PipelineReportSink logs that and
+      // continues, so the result still carries a reportTxId. Reading
+      // only the txid marks the epoch done and drops the reward.
+      const persistence = persistenceSinkStub();
+      const submission = {
+        saveReport: sinon.stub().callsFake(async (info: any) => ({
+          ...info,
+          reportTxId: 'arweave-mock-tx',
+          failedSinks: ['SolanaContractReportSink'],
+        })),
+      };
+      const observer = newObserver({
+        persistenceSink: persistence,
+        submissionSink: submission,
+        submissionGate: sinon.stub().resolves({ proceed: true }),
+      });
+
+      const submitted = await (observer as any).finalizeAndSubmitReport();
+
+      expect(submitted).to.equal(false);
+      expect(submission.saveReport.calledOnce).to.be.true;
+    });
+
+    it('persistence sink failed → returns false before submission runs', async function () {
+      const persistence = {
+        saveReport: sinon.stub().callsFake(async (info: any) => ({
+          ...info,
+          failedSinks: ['FsReportStore'],
+        })),
+      };
+      const submission = submissionSinkStub();
+      const observer = newObserver({
+        persistenceSink: persistence,
+        submissionSink: submission,
+        submissionGate: sinon.stub().resolves({ proceed: true }),
+      });
+
+      const submitted = await (observer as any).finalizeAndSubmitReport();
+
+      expect(submitted).to.equal(false);
+      expect(submission.saveReport.called).to.be.false;
+    });
+
     it('no submission pipeline wired → persistence runs, returns true (terminal)', async function () {
       // Dev / dry-run setup with no Turbo + no contract submission.
       const persistence = persistenceSinkStub();

--- a/src/continuous/continuous-observer.ts
+++ b/src/continuous/continuous-observer.ts
@@ -681,6 +681,9 @@ export class ContinuousObserver {
    *   - false:  Submission pipeline ran but no `reportTxId` came back
    *             (a downstream gate dropped it — e.g. failure-rate
    *             threshold). Retry next cycle.
+   *   - false:  A sink inside either pipeline threw. The pipeline logs
+   *             and continues, so this is read from `failedSinks`.
+   *             Retry next cycle.
    *   - false:  Submission pipeline threw. Retry next cycle.
    *   - false:  Gate threw (RPC indeterminate). Retry next cycle.
    */
@@ -707,6 +710,18 @@ export class ContinuousObserver {
       this.log.error('Persistence pipeline failed; will retry next cycle', {
         epochIndex: report.epochIndex,
         error: error.message,
+      });
+      return false;
+    }
+
+    // PipelineReportSink swallows per-sink errors so one bad sink can't
+    // block the rest. It reports them in `failedSinks`, which must be
+    // checked — otherwise a failed FsReportStore looks like success and
+    // a restart finds no local state to restore.
+    if (persisted.failedSinks !== undefined) {
+      this.log.error('Persistence sink failed; will retry next cycle', {
+        epochIndex: report.epochIndex,
+        failedSinks: persisted.failedSinks,
       });
       return false;
     }
@@ -748,6 +763,18 @@ export class ContinuousObserver {
     // ----- Submission pipeline runs -----
     try {
       const result = await this.submissionSink.saveReport(persisted);
+      // A Turbo upload followed by a failed `save_observations` returns
+      // a `reportTxId` and no on-chain record. Checking only the txid
+      // reads that as success and burns the rest of the epoch. Retry
+      // instead — the observation window usually has hours left.
+      if (result.failedSinks !== undefined) {
+        this.log.error('Submission sink failed; will retry next cycle', {
+          epochIndex: report.epochIndex,
+          failedSinks: result.failedSinks,
+          reportTxId: result.reportTxId,
+        });
+        return false;
+      }
       if (result.reportTxId === undefined) {
         // The submission pipeline dropped the report (e.g. the 80%
         // failure-rate safety inside PipelineReportSink, or a Turbo

--- a/src/store/pipeline-report-sink.test.ts
+++ b/src/store/pipeline-report-sink.test.ts
@@ -365,7 +365,6 @@ describe('PipelineReportSink', function () {
       expect((mockSink3.saveReport as sinon.SinonStub).calledOnce).to.be.true;
 
       // Verify error was logged
-      expect((logStub.error as sinon.SinonStub).calledOnce).to.be.true;
       const errorCall = (logStub.error as sinon.SinonStub).firstCall;
       expect(errorCall.args[0]).to.equal(
         'Error saving report using failingSink',
@@ -374,6 +373,39 @@ describe('PipelineReportSink', function () {
       // Verify final result includes successful processing flags
       expect(result).to.have.property('sink1Processed', true);
       expect(result).to.have.property('sink3Processed', true);
+
+      // The caller must be able to see that the run was partial.
+      expect(result.failedSinks).to.deep.equal(['failingSink']);
+    });
+
+    it('names every failed sink and leaves the field unset on a clean run', async function () {
+      const failingSinkA: ReportSink = {
+        saveReport: sinon.stub().rejects(new Error('A failed')),
+      };
+      const failingSinkB: ReportSink = {
+        saveReport: sinon.stub().rejects(new Error('B failed')),
+      };
+
+      pipelineReportSink = new PipelineReportSink({
+        log: logStub,
+        sinks: [
+          { name: 'sinkA', sink: failingSinkA },
+          { name: 'sink1', sink: mockSink1 },
+          { name: 'sinkB', sink: failingSinkB },
+        ],
+      });
+
+      const report = createMockReport(10, 2);
+      const failed = await pipelineReportSink.saveReport({ report });
+      expect(failed.failedSinks).to.deep.equal(['sinkA', 'sinkB']);
+
+      // A later clean run must not inherit the previous run's failures.
+      const cleanPipeline = new PipelineReportSink({
+        log: logStub,
+        sinks: [{ name: 'sink1', sink: mockSink1 }],
+      });
+      const clean = await cleanPipeline.saveReport(failed);
+      expect(clean.failedSinks).to.equal(undefined);
     });
 
     it('should handle empty sinks array', async function () {

--- a/src/store/pipeline-report-sink.ts
+++ b/src/store/pipeline-report-sink.ts
@@ -96,6 +96,12 @@ export class PipelineReportSink implements ReportSink {
 
     log.verbose('Saving report...');
     let lastReportInfo = reportInfo;
+    // One sink failure must not stop the sinks behind it — a failed
+    // Arweave upload should still let the on-chain sink run. The names
+    // are collected so the caller can see that the run was partial:
+    // a `reportTxId` from an early sink is not proof that the later
+    // sinks succeeded.
+    const failedSinks: string[] = [];
     for (const { name, sink } of this.sinks) {
       try {
         log.verbose(`Saving report using ${name}...`);
@@ -107,11 +113,28 @@ export class PipelineReportSink implements ReportSink {
           report: undefined,
         });
       } catch (error: any) {
+        failedSinks.push(name);
         log.error(`Error saving report using ${name}`, {
           message: error.message,
           stack: error.stack,
         });
       }
+    }
+
+    // Report this run's failures only. An inherited value from an
+    // upstream pipeline (persistence feeding submission) is dropped so
+    // each caller reads the result of the pipeline it invoked.
+    if (failedSinks.length > 0) {
+      log.error('Report pipeline finished with sink failures', {
+        failedSinks,
+        reportTxId: lastReportInfo.reportTxId,
+      });
+      return { ...lastReportInfo, failedSinks };
+    }
+    if (lastReportInfo.failedSinks !== undefined) {
+      const cleared: ReportInfo = { ...lastReportInfo };
+      delete cleared.failedSinks;
+      return cleared;
     }
 
     return lastReportInfo;

--- a/src/store/solana-contract-report-sink.test.ts
+++ b/src/store/solana-contract-report-sink.test.ts
@@ -119,6 +119,68 @@ function makeWriteable(opts: { txId?: string; throws?: Error }): {
   };
 }
 
+type ObservationStatus = Awaited<
+  ReturnType<SolanaARIOReadable['getEpochObservationStatus']>
+>;
+
+/** The pre-flight status of a prescribed observer with work to do. */
+function openStatus(overrides: Partial<ObservationStatus> = {}) {
+  return {
+    prescribed: true,
+    observerIdx: 40,
+    alreadyObserved: false,
+    windowOpen: true,
+    endTimestampSec: Math.floor(Date.now() / 1000) + 3600,
+    ...overrides,
+  } as ObservationStatus;
+}
+
+/**
+ * A readable whose successive calls return successive statuses. The
+ * retry loop re-reads epoch state between attempts, so the first entry
+ * serves the pre-flight gate and later entries serve the retries.
+ */
+function makeSequencedReadable(
+  statuses: (ObservationStatus | Error)[],
+): SolanaARIOReadable {
+  const stub = sinon.stub();
+  statuses.forEach((status, i) => {
+    if (status instanceof Error) {
+      stub.onCall(i).rejects(status);
+    } else {
+      stub.onCall(i).resolves(status);
+    }
+  });
+  stub.resolves(statuses[statuses.length - 1]);
+  return { getEpochObservationStatus: stub } as any;
+}
+
+/** The @solana/kit error seen when a blockhash expires before commit. */
+function blockhashExpiredError(): Error {
+  const err: any = new Error(
+    'The network has progressed past the last block for which this transaction could have been committed.',
+  );
+  err.name = 'SolanaError';
+  err.context = { __code: 1 };
+  return err;
+}
+
+/** A writeable whose saveObservations follows a scripted sequence. */
+function makeSequencedWriteable(outcomes: (string | Error)[]): {
+  contract: SolanaARIOWriteable;
+  saveStub: sinon.SinonStub;
+} {
+  const saveStub = sinon.stub();
+  outcomes.forEach((outcome, i) => {
+    if (outcome instanceof Error) {
+      saveStub.onCall(i).rejects(outcome);
+    } else {
+      saveStub.onCall(i).resolves({ id: outcome });
+    }
+  });
+  return { contract: { saveObservations: saveStub } as any, saveStub };
+}
+
 // ---------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------
@@ -341,6 +403,157 @@ describe('SolanaContractReportSink', () => {
         expect(e.message).to.match(/Transaction simulation failed/);
       }
       expect(threw).to.equal(true);
+    });
+  });
+
+  describe('transient submission retry', () => {
+    /** Build a sink with retries and no backoff, for fast tests. */
+    function makeRetrySink(
+      readable: SolanaARIOReadable,
+      contract: SolanaARIOWriteable,
+      maxSubmitAttempts = 3,
+    ) {
+      return new SolanaContractReportSink({
+        log: makeLog(),
+        contract,
+        readable,
+        observerAddress: OBSERVER_PUBKEY,
+        maxSubmitAttempts,
+        retryBackoffMs: [0, 0],
+      });
+    }
+
+    it('retries a blockhash expiry and reports the signature that lands', async () => {
+      const readable = makeSequencedReadable([openStatus(), openStatus()]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        'SIG_SECOND_TRY',
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(2);
+      expect(result.interactionTxIds).to.deep.equal(['SIG_SECOND_TRY']);
+    });
+
+    it('gives up after the attempt limit and rethrows', async () => {
+      const readable = makeSequencedReadable([openStatus()]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        blockhashExpiredError(),
+        blockhashExpiredError(),
+      ]);
+      const sink = makeRetrySink(readable, contract, 3);
+
+      let threw = false;
+      try {
+        await sink.saveReport(
+          makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+        );
+      } catch (e: any) {
+        threw = true;
+        expect(e.message).to.match(/network has progressed past/);
+      }
+      expect(threw).to.equal(true);
+      expect(saveStub.callCount).to.equal(3);
+    });
+
+    it('does not retry a program revert', async () => {
+      const readable = makeSequencedReadable([openStatus()]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        new Error(
+          'Transaction simulation failed: custom program error: 0x1771',
+        ),
+        'SIG_NEVER_REACHED',
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      let threw = false;
+      try {
+        await sink.saveReport(
+          makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+        );
+      } catch {
+        threw = true;
+      }
+      expect(threw).to.equal(true);
+      expect(saveStub.callCount).to.equal(1);
+    });
+
+    it('stops when the re-read shows the observation already landed', async () => {
+      const readable = makeSequencedReadable([
+        openStatus(),
+        openStatus({ alreadyObserved: true }),
+      ]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        'SIG_DOUBLE_SUBMIT',
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      // No second submission, and no throw: the work is done on chain.
+      expect(saveStub.callCount).to.equal(1);
+      expect(result.interactionTxIds).to.equal(undefined);
+    });
+
+    it('stops when the window closes while retrying', async () => {
+      const readable = makeSequencedReadable([
+        openStatus(),
+        openStatus({ windowOpen: false }),
+      ]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        'SIG_TOO_LATE',
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(1);
+      expect(result.interactionTxIds).to.equal(undefined);
+    });
+
+    it('retries anyway when the pre-retry re-read fails', async () => {
+      const readable = makeSequencedReadable([
+        openStatus(),
+        new Error('RPC 503'),
+      ]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        'SIG_AFTER_BLIND_RETRY',
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(2);
+      expect(result.interactionTxIds).to.deep.equal(['SIG_AFTER_BLIND_RETRY']);
+    });
+
+    it('treats an already-in-use revert as a completed submission', async () => {
+      const readable = makeSequencedReadable([openStatus()]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        new Error('Allocate: account Address { address: 7fxz } already in use'),
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(1);
+      expect(result.interactionTxIds).to.equal(undefined);
     });
   });
 });

--- a/src/store/solana-contract-report-sink.test.ts
+++ b/src/store/solana-contract-report-sink.test.ts
@@ -522,6 +522,44 @@ describe('SolanaContractReportSink', () => {
       expect(result.interactionTxIds).to.equal(undefined);
     });
 
+    it('stops when the window closes DURING the retry backoff', async () => {
+      // Regression guard for the re-read ordering. The pre-flight read happens
+      // immediately and sees an open window; the window then closes 25ms later,
+      // inside the 50ms backoff. Only a re-read placed AFTER the delay observes
+      // that. Checking before the pause would carry a stale "open" verdict into
+      // attempt 2 and submit past epoch.end_timestamp for a terminal revert.
+      const closesAtMs = Date.now() + 25;
+      const statusStub = sinon
+        .stub()
+        .callsFake(async () =>
+          Date.now() >= closesAtMs
+            ? openStatus({ windowOpen: false })
+            : openStatus(),
+        );
+      const readable = {
+        getEpochObservationStatus: statusStub,
+      } as any as SolanaARIOReadable;
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        'SIG_TOO_LATE',
+      ]);
+      const sink = new SolanaContractReportSink({
+        log: makeLog(),
+        contract,
+        readable,
+        observerAddress: OBSERVER_PUBKEY,
+        maxSubmitAttempts: 3,
+        retryBackoffMs: [50],
+      });
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(1);
+      expect(result.interactionTxIds).to.equal(undefined);
+    });
+
     it('retries anyway when the pre-retry re-read fails', async () => {
       const readable = makeSequencedReadable([
         openStatus(),

--- a/src/store/solana-contract-report-sink.ts
+++ b/src/store/solana-contract-report-sink.ts
@@ -227,15 +227,19 @@ export class SolanaContractReportSink implements ReportSink {
           },
         );
 
-        if ((await this.shouldRetry(epochIndex, attempt)) === false) {
-          return reportInfo;
-        }
-
         await delay(
           this.retryBackoffMs[
             Math.min(attempt - 1, this.retryBackoffMs.length - 1)
           ],
         );
+
+        // Re-read AFTER the backoff, not before: the observation window can
+        // close during the 1s/3s pause, and submitting past
+        // `epoch.end_timestamp` is a terminal revert. Checking first would
+        // clear a stale "open" verdict and spend the next attempt anyway.
+        if ((await this.shouldRetry(epochIndex, attempt)) === false) {
+          return reportInfo;
+        }
       }
     }
 

--- a/src/store/solana-contract-report-sink.ts
+++ b/src/store/solana-contract-report-sink.ts
@@ -29,6 +29,16 @@ import type winston from 'winston';
 
 import type { ObserverReport, ReportInfo, ReportSink } from '../types.js';
 import { getFailedGatewaySummaryFromReport } from './failed-gateway-summary.js';
+import {
+  isAlreadySubmittedError,
+  isTransientSubmitError,
+} from './solana-tx-errors.js';
+
+/** Total attempts for one `save_observations` submission. */
+const DEFAULT_MAX_SUBMIT_ATTEMPTS = 3;
+
+/** Pause before attempt 2, then before attempt 3. */
+const DEFAULT_RETRY_BACKOFF_MS = [1_000, 3_000];
 
 export interface SolanaContractReportSinkConfig {
   log: winston.Logger;
@@ -45,6 +55,11 @@ export interface SolanaContractReportSinkConfig {
    *  read from `contract` so this sink can be constructed without
    *  reaching into the SDK's `signer` internals. */
   observerAddress: Address;
+  /** Total submission attempts, including the first. Defaults to 3. */
+  maxSubmitAttempts?: number;
+  /** Pause before each retry, in milliseconds. The last entry repeats
+   *  if attempts outnumber entries. Tests pass `[0, 0]`. */
+  retryBackoffMs?: number[];
 }
 
 export class SolanaContractReportSink implements ReportSink {
@@ -52,12 +67,22 @@ export class SolanaContractReportSink implements ReportSink {
   private readonly contract: SolanaARIOWriteable;
   private readonly readable: SolanaARIOReadable;
   private readonly observerAddress: Address;
+  private readonly maxSubmitAttempts: number;
+  private readonly retryBackoffMs: number[];
 
   constructor(cfg: SolanaContractReportSinkConfig) {
     this.log = cfg.log.child({ class: this.constructor.name });
     this.contract = cfg.contract;
     this.readable = cfg.readable;
     this.observerAddress = cfg.observerAddress;
+    this.maxSubmitAttempts = Math.max(
+      1,
+      cfg.maxSubmitAttempts ?? DEFAULT_MAX_SUBMIT_ATTEMPTS,
+    );
+    this.retryBackoffMs =
+      cfg.retryBackoffMs !== undefined && cfg.retryBackoffMs.length > 0
+        ? cfg.retryBackoffMs
+        : DEFAULT_RETRY_BACKOFF_MS;
   }
 
   async saveReport(reportInfo: ReportInfo): Promise<{
@@ -151,20 +176,75 @@ export class SolanaContractReportSink implements ReportSink {
       reportTxId,
     });
 
-    let interactionTxId: string;
-    try {
-      const { id } = await this.contract.saveObservations({
-        reportTxId,
-        failedGateways,
-        epochIndex,
-      });
-      interactionTxId = id;
-    } catch (err: any) {
-      this.log.error('save_observations transaction failed', {
-        epochIndex,
-        message: err.message,
-      });
-      throw err;
+    // A blockhash lives ~150 slots (~60s). If the transaction does not
+    // land inside that window, `sendAndConfirm` rejects even though the
+    // instruction is valid — the observed epoch 512 failure. Re-signing
+    // over a fresh blockhash recovers it, so retry a bounded number of
+    // times before giving the error back to the pipeline.
+    let interactionTxId: string | undefined;
+
+    for (let attempt = 1; attempt <= this.maxSubmitAttempts; attempt++) {
+      try {
+        const { id } = await this.contract.saveObservations({
+          reportTxId,
+          failedGateways,
+          epochIndex,
+        });
+        interactionTxId = id;
+        break;
+      } catch (err: any) {
+        // A confirmation timeout does not prove the transaction died.
+        // If it landed, the retry hits the `init` constraint on the
+        // Observation PDA and reverts. That revert means the work is
+        // done — report success rather than failing the epoch.
+        if (isAlreadySubmittedError(err)) {
+          this.log.warn(
+            'save_observations reverted as already submitted — treating as done',
+            { epochIndex, attempt, message: err.message },
+          );
+          return reportInfo;
+        }
+
+        const transient = isTransientSubmitError(err);
+        if (!transient || attempt >= this.maxSubmitAttempts) {
+          this.log.error('save_observations transaction failed', {
+            epochIndex,
+            attempt,
+            maxAttempts: this.maxSubmitAttempts,
+            transient,
+            message: err.message,
+          });
+          throw err;
+        }
+
+        this.log.warn(
+          'save_observations failed transiently — retrying with a fresh blockhash',
+          {
+            epochIndex,
+            attempt,
+            maxAttempts: this.maxSubmitAttempts,
+            message: err.message,
+          },
+        );
+
+        if ((await this.shouldRetry(epochIndex, attempt)) === false) {
+          return reportInfo;
+        }
+
+        await delay(
+          this.retryBackoffMs[
+            Math.min(attempt - 1, this.retryBackoffMs.length - 1)
+          ],
+        );
+      }
+    }
+
+    if (interactionTxId === undefined) {
+      // Unreachable: the loop either breaks with a signature, returns,
+      // or throws. Kept so a future edit can't produce a silent success.
+      throw new Error(
+        `save_observations produced no signature for epoch ${epochIndex}`,
+      );
     }
 
     this.log.info('save_observations submitted', {
@@ -181,4 +261,57 @@ export class SolanaContractReportSink implements ReportSink {
       interactionTxIds: [interactionTxId],
     };
   }
+
+  /**
+   * Re-read epoch state between submission attempts. This is the
+   * idempotency guard for the retry loop: the gates at the top of
+   * `saveReport` ran before the first attempt and can be stale by now.
+   *
+   * Returns `false` when the caller must stop — either the observation
+   * landed after all, or the window closed while we retried. Returns
+   * `true` when another attempt is worthwhile. An RPC failure here is
+   * indeterminate, so it returns `true`: the `init` constraint on the
+   * Observation PDA still blocks a double write.
+   */
+  private async shouldRetry(
+    epochIndex: number,
+    attempt: number,
+  ): Promise<boolean> {
+    let status: Awaited<
+      ReturnType<SolanaARIOReadable['getEpochObservationStatus']>
+    >;
+    try {
+      status = await this.readable.getEpochObservationStatus(
+        epochIndex,
+        this.observerAddress,
+      );
+    } catch (err: any) {
+      this.log.warn(
+        'Epoch re-read before retry failed — retrying submission anyway',
+        { epochIndex, attempt, message: err.message },
+      );
+      return true;
+    }
+
+    if (status.alreadyObserved) {
+      this.log.info(
+        'Observation landed despite the confirmation error — no retry needed',
+        { epochIndex, attempt, observer: this.observerAddress },
+      );
+      return false;
+    }
+    if (!status.windowOpen) {
+      this.log.warn('Observation window closed while retrying — giving up', {
+        epochIndex,
+        attempt,
+        endTimestampSec: status.endTimestampSec,
+      });
+      return false;
+    }
+    return true;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/store/solana-tx-errors.test.ts
+++ b/src/store/solana-tx-errors.test.ts
@@ -1,0 +1,107 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { expect } from 'chai';
+
+import {
+  isAlreadySubmittedError,
+  isTransientSubmitError,
+} from './solana-tx-errors.js';
+
+/**
+ * The exact error shape observed for epoch 512: a @solana/kit
+ * SolanaError with `context.__code` 1 (SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED).
+ */
+function blockHeightExceededError(): Error {
+  const err: any = new Error(
+    'The network has progressed past the last block for which this transaction could have been committed.',
+  );
+  err.name = 'SolanaError';
+  err.context = {
+    __code: 1,
+    currentBlockHeight: 417090557n,
+    lastValidBlockHeight: 417090556n,
+  };
+  return err;
+}
+
+describe('solana-tx-errors', () => {
+  describe('isTransientSubmitError', () => {
+    it('matches the observed blockhash-expiry error', () => {
+      expect(isTransientSubmitError(blockHeightExceededError())).to.equal(true);
+    });
+
+    it('matches on context.__code alone when the message is reworded', () => {
+      const err: any = new Error('confirmation gave up');
+      err.context = { __code: 1 };
+      expect(isTransientSubmitError(err)).to.equal(true);
+    });
+
+    it('matches an error nested under `cause`', () => {
+      // The SDK wraps the kit error before it reaches the sink.
+      const err: any = new Error('sendAndConfirm failed');
+      err.cause = blockHeightExceededError();
+      expect(isTransientSubmitError(err)).to.equal(true);
+    });
+
+    it('matches RPC transport blips', () => {
+      expect(isTransientSubmitError(new Error('socket hang up'))).to.equal(
+        true,
+      );
+      expect(isTransientSubmitError(new Error('fetch failed'))).to.equal(true);
+    });
+
+    it('does not match a program revert', () => {
+      const err: any = new Error(
+        'Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1771',
+      );
+      err.context = { __code: 4615000 };
+      expect(isTransientSubmitError(err)).to.equal(false);
+    });
+
+    it('does not match insufficient funds', () => {
+      expect(
+        isTransientSubmitError(
+          new Error(
+            'Attempt to debit an account but found no record of a prior credit',
+          ),
+        ),
+      ).to.equal(false);
+    });
+
+    it('tolerates null and non-error input', () => {
+      expect(isTransientSubmitError(undefined)).to.equal(false);
+      expect(isTransientSubmitError(null)).to.equal(false);
+      expect(isTransientSubmitError('socket hang up')).to.equal(true);
+    });
+  });
+
+  describe('isAlreadySubmittedError', () => {
+    it('matches the init-constraint allocation failure', () => {
+      expect(
+        isAlreadySubmittedError(
+          new Error(
+            'Allocate: account Address { address: 7fxz..., base: None } already in use',
+          ),
+        ),
+      ).to.equal(true);
+    });
+
+    it('matches a duplicate signature', () => {
+      expect(
+        isAlreadySubmittedError(
+          new Error('This transaction has already been processed'),
+        ),
+      ).to.equal(true);
+    });
+
+    it('does not match a blockhash expiry', () => {
+      expect(isAlreadySubmittedError(blockHeightExceededError())).to.equal(
+        false,
+      );
+    });
+  });
+});

--- a/src/store/solana-tx-errors.ts
+++ b/src/store/solana-tx-errors.ts
@@ -1,0 +1,128 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * Classify errors thrown while a Solana transaction is sent and
+ * confirmed. Two questions matter to a submission retry loop:
+ *
+ *   1. Is the failure transient? A blockhash that expires before the
+ *      transaction lands says nothing about the instruction. The same
+ *      instruction, re-signed over a fresh blockhash, usually lands.
+ *   2. Did the transaction already land? A confirmation timeout does
+ *      not prove the transaction is dead. It can be committed while
+ *      the client stops watching. A retry then hits the `init`
+ *      constraint on the Observation PDA and reverts. That revert is a
+ *      success signal, not a failure.
+ *
+ * Errors from @solana/kit carry a numeric `context.__code` and nest a
+ * root cause under `cause`. Both are inspected. String matching is the
+ * fallback because the RPC layer, the SDK, and the program each wrap
+ * errors differently.
+ */
+
+/** Substrings that mark a retryable send/confirm failure. */
+const TRANSIENT_PATTERNS = [
+  // Blockhash expiry — the confirmed cause of the epoch 512 miss.
+  'network has progressed past the last block',
+  'block height exceeded',
+  'blockheightexceeded',
+  'blockhash not found',
+  'blockhash expired',
+  // Confirmation gave up before the cluster answered.
+  'transactionexpiredtimeout',
+  'was not confirmed',
+  'timed out awaiting confirmation',
+  'confirmation timeout',
+  // RPC transport blips. The transaction may or may not have been
+  // forwarded; the pre-retry state re-read settles that.
+  'socket hang up',
+  'fetch failed',
+  'econnreset',
+  'etimedout',
+  'econnrefused',
+  'service unavailable',
+  'gateway timeout',
+  'too many requests',
+];
+
+/** Substrings that mark "this observation is already on-chain". */
+const ALREADY_SUBMITTED_PATTERNS = [
+  // The Observation PDA is `init`-constrained. A second submission for
+  // the same (epochIndex, observer) fails to allocate.
+  'already in use',
+  // The identical signed transaction was already committed.
+  'already been processed',
+];
+
+/**
+ * `SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED` from @solana/errors. Matched
+ * numerically as well as by message so a reworded error still counts.
+ */
+const SOLANA_ERROR_BLOCK_HEIGHT_EXCEEDED = 1;
+
+/** Flatten an error and its `cause` chain into lowercased text. */
+function errorText(err: unknown): string {
+  const parts: string[] = [];
+  let current: any = err;
+  for (
+    let depth = 0;
+    current !== null && current !== undefined && depth < 5;
+    depth++
+  ) {
+    if (typeof current === 'string') {
+      parts.push(current);
+      break;
+    }
+    if (typeof current.message === 'string') {
+      parts.push(current.message);
+    }
+    if (typeof current.name === 'string') {
+      parts.push(current.name);
+    }
+    current = current.cause;
+  }
+  return parts.join(' ').toLowerCase();
+}
+
+/** Collect `context.__code` from an error and its `cause` chain. */
+function errorCodes(err: unknown): number[] {
+  const codes: number[] = [];
+  let current: any = err;
+  for (
+    let depth = 0;
+    current !== null && current !== undefined && depth < 5;
+    depth++
+  ) {
+    const code = current.context?.__code;
+    if (typeof code === 'number') {
+      codes.push(code);
+    }
+    current = current.cause;
+  }
+  return codes;
+}
+
+/**
+ * True when the failure is a send/confirm timing problem rather than a
+ * rejected instruction. Callers should re-read on-chain state before
+ * acting on this — see {@link isAlreadySubmittedError}.
+ */
+export function isTransientSubmitError(err: unknown): boolean {
+  if (errorCodes(err).includes(SOLANA_ERROR_BLOCK_HEIGHT_EXCEEDED)) {
+    return true;
+  }
+  const text = errorText(err);
+  return TRANSIENT_PATTERNS.some((pattern) => text.includes(pattern));
+}
+
+/**
+ * True when the error says the observation is already recorded on
+ * chain. The caller should treat this as a completed submission.
+ */
+export function isAlreadySubmittedError(err: unknown): boolean {
+  const text = errorText(err);
+  return ALREADY_SUBMITTED_PATTERNS.some((pattern) => text.includes(pattern));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -219,6 +219,17 @@ export interface ReportInfo {
   report: ObserverReport;
   reportTxId?: string;
   interactionTxIds?: string[];
+  /**
+   * Names of the sinks that threw during the last {@link ReportSink}
+   * run. `PipelineReportSink` logs a sink failure and continues to the
+   * next sink, so the returned `ReportInfo` can carry a `reportTxId`
+   * from an earlier sink while a later one failed. Without this field a
+   * caller cannot tell that partial state apart from full success.
+   *
+   * Each pipeline run replaces the field with its own result. An empty
+   * list is reported as `undefined`.
+   */
+  failedSinks?: string[];
 }
 
 export interface ReportSink {


### PR DESCRIPTION
## Problem

An observer reported a lost epoch observation reward. The report uploaded to Turbo, the observation window was still open for hours, but `save_observations` never landed on chain and nothing tried again.

Two defects combined.

**1. A failed sink was reported as success.** `PipelineReportSink` logs a sink error and continues to the next sink, so it does not throw. The `ReportInfo` it returns therefore carries a `reportTxId` from `TurboReportSink` even when `SolanaContractReportSink` failed. `ContinuousObserver` checked only that txid, logged `Report submitted`, and set `reportSubmitted` for the rest of the epoch. The retry path existed but could not be reached.

**2. A transient Solana error was fatal.** A blockhash is valid for ~150 slots (~60s). When the transaction does not land inside that window, `sendAndConfirm` rejects with `SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED` even though the instruction is valid. In the reported case the diagnostic `simulateTransaction` returned `err: null` and the RPC offered a replacement blockhash — the instruction was good and the Observation PDA did not yet exist. The sink gave up on the first error.

## Changes

### Sink-failure propagation

- `ReportInfo` gains `failedSinks?: string[]`.
- `PipelineReportSink` collects the name of every sink that threw. Each run reports its own failures, so a submission pipeline does not inherit a persistence result.
- `ContinuousObserver` treats a non-empty `failedSinks` as "not submitted" and retries next cycle, in both the persistence and the submission phase.
- `cli.ts` prints the failed sinks and exits non-zero. A one-shot run has no next cycle.

### Transient submission retry

- New `src/store/solana-tx-errors.ts`. `isTransientSubmitError` matches `context.__code === 1` (`SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED`) plus message patterns for blockhash expiry, confirmation timeouts, and RPC transport blips. It walks the `cause` chain, since the SDK wraps the kit error. `isAlreadySubmittedError` matches the `init`-constraint allocation failure and a duplicate signature.
- `SolanaContractReportSink` retries up to `maxSubmitAttempts` (default 3) with a 1s/3s backoff. Both are injectable for tests.
- A program revert still throws on the first attempt. No wasted fees on an instruction the contract rejects.

### Why the retry is safe

The pre-flight gates at the top of `saveReport` are stale by the time an attempt fails, so the loop re-reads `getEpochObservationStatus` between attempts. It stops when the observation landed after all, and when the window closed while retrying. A confirmation timeout does not prove the transaction is dead — if it landed, the retry hits the `init` constraint on the Observation PDA, and that revert is counted as a completed submission rather than a failure.

## Tests

395 passing, 0 failing. 17 new tests:

- `solana-tx-errors.test.ts` (10) — classifier coverage, including a nested `cause`, a program revert, and non-error input.
- `solana-contract-report-sink.test.ts` (+7) — retry then succeed, exhaust the attempt limit, skip the retry on a revert, stop on a mid-retry `alreadyObserved`, stop on a closed window, retry when the re-read itself fails, and treat `already in use` as done.
- `pipeline-report-sink.test.ts` / `continuous-observer.test.ts` — `failedSinks` is populated, is not inherited across runs, and blocks `reportSubmitted` in both phases.

`yarn lint:check` and `tsc --noEmit -p tsconfig.prod.json` are clean.

## Review notes

- **The SDK re-signs per attempt — verified against `@ar.io/sdk` 4.1.2.** `saveObservations` calls `sendTransaction` (`solana/io-writeable.js:816`), which calls `sendAndConfirm` (`:303-313`). `sendAndConfirm` fetches the blockhash (`solana/send.js:266`), sets the message lifetime from it (`:271`), and signs (`:328`) — all inside the call, nothing cached. Each retry gets a live blockhash and a fresh signature.
- Two incidental costs per retry: the instruction is rebuilt, so `getRegistryGatewayAddresses()` re-reads the registry to rebuild the bitmap; and `autoComputeUnitLimit` re-simulates before signing. RPC calls, not SOL — the fee is charged only if the transaction lands.
- Because the signature differs per attempt, a duplicate can only revert as `already in use` (the `init` constraint), never `already been processed`. Both are in the classifier.
- A persistently failing sink now retries every 30s until the window closes. `TurboReportSink` dedupes over GraphQL, so most retries skip the upload, but a retry inside the indexing lag can upload again. A submission-attempt counter in `ObservationState` would cap this if we want a hard stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retries for temporary transaction failures, with configurable attempts and backoff.
  * Added handling for already-submitted observations and changing observation status during retries.
  * Report processing now identifies failed destinations while continuing other submissions.

* **Bug Fixes**
  * Failed persistence or submission no longer appears successful when a transaction ID is returned.
  * CLI commands now skip dependent submissions and exit with an error when persistence or submission fails.
  * Improved transaction error classification and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->