### PR TITLE
chore(deps): bump @ar.io/sdk ^4.1.2 -> ^4.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.1.2",
+    "@ar.io/sdk": "^4.1.4",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.2.tgz#421cf300112e6698b53d000eaad45237437e7d53"
-  integrity sha512-4AyS67lkKa62L6BAWrNbXx3S1GG/AKWeMNZCGkqpkwwKldLGLyq3ZQrylku2bcSJKqRKL/SmYS76OPqIC6o3aQ==
+"@ar.io/sdk@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.4.tgz#8ff7941d51fadac21cc57271aa08adf97ef289f1"
+  integrity sha512-5Nm6SP+KePW74jFn8qA68iio8/dvYzR5OxFC3euLjTzJ5YKsrl2G44qVbo9powU/XFarKmxYJhgMYZDSU7MGxw==
   dependencies:
     "@ar.io/solana-contracts" "1.1.0"
     "@noble/hashes" "^1.8.0"


### PR DESCRIPTION
Completes the release chain for the lost-observation fixes.

## What this picks up

`@ar.io/sdk@4.1.4` (published to `latest`) carries **ar-io/ar-io-sdk#708** — the lifetime blockhash is now taken *after* the compute-unit simulation, so a signed transaction starts with the full ~60s validity window instead of one already partly spent by the simulation round trip.

A caret range on `^4.1.2` excludes prereleases, so the observer could not pick this up from `4.1.4-alpha.1`; stable 4.1.4 is the first release that reaches it.

## Scoping

This is the **hardening** half. The fix that actually recovers a lost observation shipped in #125 (failed sink no longer recorded as success + bounded retry) and is already on `develop`.

Blast radius of the rest of 4.1.4 is nil here — the observer uses neither `getTokenSupply` (changed to report the live SPL mint supply, #706) nor `paginate`/`sortBy` (#707). Verified by grep before bumping.

## Verification

- `@ar.io/sdk` resolves to **4.1.4**, and the blockhash fix is confirmed present in the built `lib/esm/solana/send.js`
- **396 passing / 0 failing**
- `tsc --noEmit -p tsconfig.prod.json` clean
- `eslint src` clean
- The retry, `failedSinks` propagation, and backoff-window tests from #125 all still pass against the new SDK

## ⚠️ Note for anyone re-running the install

This repo is **Yarn 1**, but a bare `yarn` resolves to **Berry 3.8.7** in this directory. Berry rewrites `yarn.lock` into the `__metadata: version 6` format — a ~10,000-line diff — and drops a stray `.yarnrc.yml`. That would break the build.

Use `corepack yarn@1.22.22 install`. The correct diff for this bump is **4 lines** in `yarn.lock`, which is what's here.

Worth considering a `packageManager` field to pin this, since the trap is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKeNoHyV6m1Z3sh81Jykkf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Arweave SDK dependency to version 4.1.4 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->