### PR TITLE
chore(deps): bump @ar.io/sdk ^4.1.4 -> ^4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.1.4",
+    "@ar.io/sdk": "^4.2.0",
     "@ar.io/solana-contracts": "^1.1.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.1.4":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.4.tgz#8ff7941d51fadac21cc57271aa08adf97ef289f1"
-  integrity sha512-5Nm6SP+KePW74jFn8qA68iio8/dvYzR5OxFC3euLjTzJ5YKsrl2G44qVbo9powU/XFarKmxYJhgMYZDSU7MGxw==
+"@ar.io/sdk@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.2.0.tgz#7282cfefae0cc76e2b99b6f1fcbfd056a5c423f2"
+  integrity sha512-kbMVGytA2jNJf11Ka6FPJcTi4DPucYNQCPc+F02ZHZ0XAstGoXm3KwwT4dV95m32OHbBVl/F9xlLnMbE9ovhLg==
   dependencies:
     "@ar.io/solana-contracts" "1.1.0"
     "@noble/hashes" "^1.8.0"


### PR DESCRIPTION
Picks up [ar-io/ar-io-sdk#717](https://github.com/ar-io/ar-io-sdk/pull/717), released as **4.2.0**.

## What it fixes

`saveObservations` derived `gateway_count` from a **live** registry read, but the chain validates it against the epoch's frozen `Epoch.active_gateway_count`. One gateway joining mid-epoch desynced the two and rejected **every observer's** submission with `InvalidObservation` (6041) for the rest of the epoch.

Mainnet **epoch 523** closed with `observations_submitted = 0` across all 50 prescribed observers — not a local misconfiguration, a protocol-wide outage. It was recovered by submitting manually with the corrected count.

## No observer code change needed

`SolanaContractReportSink` calls `saveObservations({ reportTxId, failedGateways, epochIndex })` with no `gatewayCount` — which is precisely the path 4.2.0 fixes. It now resolves the epoch snapshot, and refuses to submit when a `finalize_gone` swap-remove has reordered registry slots (a positional bitmap would otherwise misattribute results, which lands silently rather than reverting).

## Verification

Against **live mainnet**, using the published 4.2.0 resolved into this package's `node_modules`:

```
SDK 4.2.0 | active epoch: 524
  epoch 523: snapshot=644 live=645 -> new SDK sends 644  (old SDK sent 645)
  epoch 524: snapshot=645 live=645 -> new SDK sends 645  (old SDK sent 645)
```

Epoch 523 is the regression case and now resolves correctly. Epoch 524 has had no mid-epoch churn yet, so both agree — it is not currently at risk, but would be if a gateway joins before this epoch's report is submitted.

Suite: **400 passing, 0 failing**, lint clean, `tsconfig.prod.json` typecheck clean, full typecheck unchanged from `develop` (5 pre-existing errors in unrelated test files).

4.2.0 pins `@ar.io/solana-contracts` at `1.1.0`, satisfying the `^1.1.0` range this package already declares for the GAR error constants added in #127.

## Why it matters soon

248 gateways sit in `leaving` with no delegated stake, and the first becomes `finalize_gone`-eligible on **2026-09-10**. Once those drain, the registry count moves most epochs and this stops being a rare race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kexn8mPZfVRHiWCW2k4kU3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Arweave SDK dependency to the latest 4.2 release.
  * Includes the SDK’s latest improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->