### PR TITLE
release: promote develop → main (observation epoch-snapshot fix, @ar.io/sdk 4.2.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,9 +154,30 @@ Flow:
 - After the parent epoch is fully distributed, the cranker's
   `close_observation` loop reclaims the Observation PDA's rent.
 
+**Transient-failure retry.** A blockhash lives ~150 slots (~60s). If
+the transaction does not land inside that window, `sendAndConfirm`
+rejects a valid instruction. The sink retries up to
+`maxSubmitAttempts` (default 3) with the backoff in `retryBackoffMs`
+(default 1s, 3s). `src/store/solana-tx-errors.ts` classifies the
+error: only transient send/confirm failures retry, and a program
+revert throws on the first attempt. Between attempts the sink re-reads
+`getEpochObservationStatus` — it stops if the observation landed after
+all, or if the window closed while retrying. An `already in use`
+revert from the `init`-constrained Observation PDA counts as a
+completed submission, not a failure.
+
+**Sink-failure propagation.** `PipelineReportSink` logs a sink error
+and continues to the next sink, so its result can carry a `reportTxId`
+from Turbo while the contract sink failed. It now names the failures in
+`ReportInfo.failedSinks`. `ContinuousObserver` treats a non-empty
+`failedSinks` as "not submitted" and retries next cycle; without that
+check a failed `save_observations` was logged as `Report submitted` and
+the epoch reward was lost.
+
 Unit tests: `src/store/solana-contract-report-sink.test.ts` covers the
 happy path + all three skip gates + missing-reportTxId guard + error
-propagation (9 tests).
+propagation + the retry loop (16 tests).
+`src/store/solana-tx-errors.test.ts` covers the classifiers (10 tests).
 
 ## Compression Settings
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@ar.io/sdk": "^4.1.4",
+    "@ar.io/solana-contracts": "^1.1.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.1.4",
+    "@ar.io/sdk": "^4.2.0",
     "@ar.io/solana-contracts": "^1.1.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.1.0",
+    "@ar.io/sdk": "^4.1.2",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.1.2",
+    "@ar.io/sdk": "^4.1.4",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,10 +36,21 @@ if (args.saveReport) {
     console.error(
       `Persistence incomplete — these sinks failed: ${persisted.failedSinks.join(', ')}`,
     );
+    console.error(
+      'Skipping submission: refusing to land an on-chain observation without a ' +
+        'complete local record. Mirrors ContinuousObserver, which treats a failed ' +
+        'persistence sink as "not submitted".',
+    );
+    // `process.exitCode` records the failure but does NOT halt execution, so
+    // the submission below must be gated explicitly or a one-shot run would
+    // submit on-chain despite the incomplete persistence.
     process.exitCode = 1;
   }
 
-  if (submissionReportSink !== undefined) {
+  if (
+    submissionReportSink !== undefined &&
+    persisted.failedSinks === undefined
+  ) {
     let proceed = true;
     if (submissionGate !== undefined) {
       try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,12 @@ if (args.saveReport) {
   // gated on prescription so the one-shot CLI doesn't burn Turbo
   // credits + RPC for a report with no on-chain pathway.
   const persisted = await persistenceReportSink.saveReport({ report });
+  if (persisted.failedSinks !== undefined) {
+    console.error(
+      `Persistence incomplete — these sinks failed: ${persisted.failedSinks.join(', ')}`,
+    );
+    process.exitCode = 1;
+  }
 
   if (submissionReportSink !== undefined) {
     let proceed = true;
@@ -52,7 +58,15 @@ if (args.saveReport) {
       }
     }
     if (proceed) {
-      await submissionReportSink.saveReport(persisted);
+      const submitted = await submissionReportSink.saveReport(persisted);
+      // The pipeline logs sink errors and continues, so a non-zero exit
+      // is the only way a one-shot run signals a partial submission.
+      if (submitted.failedSinks !== undefined) {
+        console.error(
+          `Submission incomplete — these sinks failed: ${submitted.failedSinks.join(', ')}`,
+        );
+        process.exitCode = 1;
+      }
     }
   }
 }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,66 @@
+/**
+ * AR.IO Observer
+ * Copyright (C) 2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect } from 'chai';
+
+import { parseCommaSeparatedList } from './config.js';
+
+describe('parseCommaSeparatedList', () => {
+  it('parses a plain comma-separated list', () => {
+    expect(parseCommaSeparatedList('a.com,b.com')).to.deep.equal([
+      'a.com',
+      'b.com',
+    ]);
+  });
+
+  it('trims spaces after commas', () => {
+    // The regression this exists for: an untrimmed split yields ' b.com',
+    // which matches no gateway and silently shrinks the observation set.
+    expect(parseCommaSeparatedList('a.com, b.com')).to.deep.equal([
+      'a.com',
+      'b.com',
+    ]);
+  });
+
+  it('trims surrounding whitespace of every entry', () => {
+    expect(parseCommaSeparatedList('  a.com ,\tb.com , c.com  ')).to.deep.equal(
+      ['a.com', 'b.com', 'c.com'],
+    );
+  });
+
+  it('drops empty entries from stray or trailing commas', () => {
+    expect(parseCommaSeparatedList('a.com,,b.com,')).to.deep.equal([
+      'a.com',
+      'b.com',
+    ]);
+  });
+
+  it('returns an empty list for an empty or whitespace-only value', () => {
+    // The unset case: config passes '' when neither env nor CLI arg is set,
+    // and an empty list means "no restriction".
+    expect(parseCommaSeparatedList('')).to.deep.equal([]);
+    expect(parseCommaSeparatedList('   ')).to.deep.equal([]);
+    expect(parseCommaSeparatedList(',')).to.deep.equal([]);
+  });
+
+  it('preserves a single entry unchanged', () => {
+    expect(parseCommaSeparatedList('only.example')).to.deep.equal([
+      'only.example',
+    ]);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -488,6 +488,18 @@ export const CLEANUP_FAILURE_THRESHOLD = parsePositiveIntEnv(
   'CLEANUP_FAILURE_THRESHOLD',
   '30',
 );
+// `prune_name_to_returned` takes a single record, so it cannot batch into one
+// tx the way the other two prune steps do — its throughput is (txs per scan) x
+// (scan rate). It is also the only deadline-bound step: a lease not converted
+// while inside its auction window ages into the past-auction band and is closed
+// directly, losing the protocol that Dutch auction permanently. Left at one per
+// scan it capped at ~48 names/day on a 24h epoch, the same order as the rate
+// leases fall past grace — so a backlog could never drain. Default 10 keeps
+// ~10x headroom while staying well inside MAX_CLEANUP_TXS_PER_CYCLE.
+export const CLEANUP_TO_RETURNED_TXS_PER_CYCLE = parsePositiveIntEnv(
+  'CLEANUP_TO_RETURNED_TXS_PER_CYCLE',
+  '10',
+);
 // Optional: when unset, the cranker derives the cleanup cadence from the epoch
 // duration (see src/epoch/adaptive-intervals.ts). An explicit value always wins.
 export const CLEANUP_MIN_INTERVAL_MS = parsePositiveIntEnvOrUndefined(

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,15 +91,29 @@ export const REFERENCE_GATEWAY_HOSTS: string[] = (() => {
   return DEFAULT_REFERENCE_GATEWAYS;
 })();
 
-export const OBSERVED_GATEWAY_HOSTS = env
-  .varOrDefault('OBSERVED_GATEWAY_HOSTS', args.observedGatewayHosts ?? '')
-  .split(',')
-  .filter((h) => h.length > 0);
+/**
+ * Split a comma-separated env var into trimmed, non-empty entries.
+ *
+ * Trimming is the point: `a.com, b.com` is the natural way to write a list,
+ * but an untrimmed split yields `' b.com'`, which matches no gateway or name.
+ * That fails silently — the entry is simply never found — so it narrows the
+ * observation set rather than erroring. `REFERENCE_GATEWAY_HOSTS` already
+ * trims; this shares that behavior with the other list-valued settings.
+ */
+export function parseCommaSeparatedList(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
 
-export const ARNS_NAMES = env
-  .varOrDefault('ARNS_NAMES', args.arnsNames ?? '')
-  .split(',')
-  .filter((h) => h.length > 0);
+export const OBSERVED_GATEWAY_HOSTS = parseCommaSeparatedList(
+  env.varOrDefault('OBSERVED_GATEWAY_HOSTS', args.observedGatewayHosts ?? ''),
+);
+
+export const ARNS_NAMES = parseCommaSeparatedList(
+  env.varOrDefault('ARNS_NAMES', args.arnsNames ?? ''),
+);
 
 // Whitepaper v3.0.0 §10.3: "eight (8) 'chosen names' selected
 // independently by each observer". The default lived at `1` since the

--- a/src/continuous/continuous-observer.test.ts
+++ b/src/continuous/continuous-observer.test.ts
@@ -1242,6 +1242,51 @@ describe('ContinuousObserver Integration', function () {
       expect(submission.saveReport.called).to.be.false;
     });
 
+    it('submission sink failed → returns false even though Turbo produced a txid', async function () {
+      // The epoch 512 miss: TurboReportSink uploaded, then
+      // SolanaContractReportSink threw. PipelineReportSink logs that and
+      // continues, so the result still carries a reportTxId. Reading
+      // only the txid marks the epoch done and drops the reward.
+      const persistence = persistenceSinkStub();
+      const submission = {
+        saveReport: sinon.stub().callsFake(async (info: any) => ({
+          ...info,
+          reportTxId: 'arweave-mock-tx',
+          failedSinks: ['SolanaContractReportSink'],
+        })),
+      };
+      const observer = newObserver({
+        persistenceSink: persistence,
+        submissionSink: submission,
+        submissionGate: sinon.stub().resolves({ proceed: true }),
+      });
+
+      const submitted = await (observer as any).finalizeAndSubmitReport();
+
+      expect(submitted).to.equal(false);
+      expect(submission.saveReport.calledOnce).to.be.true;
+    });
+
+    it('persistence sink failed → returns false before submission runs', async function () {
+      const persistence = {
+        saveReport: sinon.stub().callsFake(async (info: any) => ({
+          ...info,
+          failedSinks: ['FsReportStore'],
+        })),
+      };
+      const submission = submissionSinkStub();
+      const observer = newObserver({
+        persistenceSink: persistence,
+        submissionSink: submission,
+        submissionGate: sinon.stub().resolves({ proceed: true }),
+      });
+
+      const submitted = await (observer as any).finalizeAndSubmitReport();
+
+      expect(submitted).to.equal(false);
+      expect(submission.saveReport.called).to.be.false;
+    });
+
     it('no submission pipeline wired → persistence runs, returns true (terminal)', async function () {
       // Dev / dry-run setup with no Turbo + no contract submission.
       const persistence = persistenceSinkStub();

--- a/src/continuous/continuous-observer.ts
+++ b/src/continuous/continuous-observer.ts
@@ -681,6 +681,9 @@ export class ContinuousObserver {
    *   - false:  Submission pipeline ran but no `reportTxId` came back
    *             (a downstream gate dropped it — e.g. failure-rate
    *             threshold). Retry next cycle.
+   *   - false:  A sink inside either pipeline threw. The pipeline logs
+   *             and continues, so this is read from `failedSinks`.
+   *             Retry next cycle.
    *   - false:  Submission pipeline threw. Retry next cycle.
    *   - false:  Gate threw (RPC indeterminate). Retry next cycle.
    */
@@ -707,6 +710,18 @@ export class ContinuousObserver {
       this.log.error('Persistence pipeline failed; will retry next cycle', {
         epochIndex: report.epochIndex,
         error: error.message,
+      });
+      return false;
+    }
+
+    // PipelineReportSink swallows per-sink errors so one bad sink can't
+    // block the rest. It reports them in `failedSinks`, which must be
+    // checked — otherwise a failed FsReportStore looks like success and
+    // a restart finds no local state to restore.
+    if (persisted.failedSinks !== undefined) {
+      this.log.error('Persistence sink failed; will retry next cycle', {
+        epochIndex: report.epochIndex,
+        failedSinks: persisted.failedSinks,
       });
       return false;
     }
@@ -748,6 +763,18 @@ export class ContinuousObserver {
     // ----- Submission pipeline runs -----
     try {
       const result = await this.submissionSink.saveReport(persisted);
+      // A Turbo upload followed by a failed `save_observations` returns
+      // a `reportTxId` and no on-chain record. Checking only the txid
+      // reads that as success and burns the rest of the epoch. Retry
+      // instead — the observation window usually has hours left.
+      if (result.failedSinks !== undefined) {
+        this.log.error('Submission sink failed; will retry next cycle', {
+          epochIndex: report.epochIndex,
+          failedSinks: result.failedSinks,
+          reportTxId: result.reportTxId,
+        });
+        return false;
+      }
       if (result.reportTxId === undefined) {
         // The submission pipeline dropped the report (e.g. the 80%
         // failure-rate safety inside PipelineReportSink, or a Turbo

--- a/src/epoch/epoch-cranker-arns-lifecycle.test.ts
+++ b/src/epoch/epoch-cranker-arns-lifecycle.test.ts
@@ -37,11 +37,15 @@ const noopLog: EpochCrankerConfig['log'] = {
  * `crankEpochStep` and tolerates every other SDK call the cleanup phases
  * may make (each returns an empty result).
  */
-function stubContract(capture: (opts: Record<string, unknown>) => void) {
+function stubContract(
+  capture: (opts: Record<string, unknown>) => void,
+  result: Record<string, unknown> | undefined = undefined,
+) {
+  const stepResult = result ?? { action: 'idle', reason: 'stubbed' };
   const base: Record<string, unknown> = {
     crankEpochStep: async (opts: Record<string, unknown>) => {
       capture(opts);
-      return { action: 'idle', reason: 'stubbed' };
+      return stepResult;
     },
   };
   return new Proxy(base, {
@@ -54,12 +58,13 @@ function stubContract(capture: (opts: Record<string, unknown>) => void) {
 
 async function crankOnce(
   overrides: Partial<EpochCrankerConfig>,
+  stepResult?: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   let captured: Record<string, unknown> | null = null;
   const cranker = new EpochCranker({
     contract: stubContract((o) => {
       captured = o;
-    }) as never,
+    }, stepResult) as never,
     rpc: {} as never,
     signer: { address: 'stub' } as never,
     pollIntervalMs: 1000,
@@ -89,6 +94,49 @@ describe('EpochCranker — ArNS lease lifecycle options', () => {
     expect(opts.enablePruneExpired).to.equal(true);
     // the pre-existing returned-name step must keep working
     expect(opts.enablePrune).to.equal(true);
+  });
+
+  it('forwards cleanupToReturnedTxsPerCycle as pruneToReturnedTxsPerCycle', async () => {
+    // Sets throughput for the only deadline-bound step. `prune_name_to_returned`
+    // takes a single record and cannot batch into one tx, so txs-per-scan is
+    // the whole lever: at one per scan a 24h-epoch cranker caps at ~48
+    // names/day, the same order as leases fall past grace, and the backlog
+    // never drains. A silently-dropped option here reintroduces exactly that.
+    const opts = await crankOnce({
+      enableCleanup: true,
+      cleanupToReturnedTxsPerCycle: 7,
+    });
+    expect(opts.pruneToReturnedTxsPerCycle).to.equal(7);
+  });
+
+  it('surfaces partialFailureReason from the SDK result into the log line', async () => {
+    // A partial drain must be distinguishable from a budget-bounded one.
+    const lines: Array<{ msg: string; meta: Record<string, unknown> }> = [];
+    await crankOnce(
+      {
+        enableCleanup: true,
+        log: {
+          ...noopLog,
+          info: (msg: string, meta?: Record<string, unknown>) => {
+            lines.push({ msg, meta: meta ?? {} });
+          },
+        } as EpochCrankerConfig['log'],
+      },
+      {
+        action: 'prune_name_to_returned',
+        txId: 'tx-1',
+        progress: { index: 2, total: 9 },
+        partialFailureReason: 'blockhash expired',
+      },
+    );
+    const line = lines.find((l) => l.msg.includes('prune_name_to_returned'));
+    expect(line, 'no prune log line emitted').to.not.equal(undefined);
+    expect(line?.meta.partialFailureReason).to.equal('blockhash expired');
+  });
+
+  it('leaves pruneToReturnedTxsPerCycle undefined when unconfigured, so the SDK default applies', async () => {
+    const opts = await crankOnce({ enableCleanup: true });
+    expect(opts.pruneToReturnedTxsPerCycle).to.equal(undefined);
   });
 
   it('forwards cleanupBatchSize as the expired-name batch size', async () => {

--- a/src/epoch/epoch-cranker.ts
+++ b/src/epoch/epoch-cranker.ts
@@ -56,6 +56,13 @@ export interface EpochCrankerConfig {
    */
   maxCleanupTxsPerCycle?: number;
   /**
+   * `prune_name_to_returned` txs to submit per scan. Unlike the other two prune
+   * steps this instruction takes a single record and cannot batch into one tx,
+   * so this is what sets its throughput. Default: 10.
+   * Env: CLEANUP_TO_RETURNED_TXS_PER_CYCLE.
+   */
+  cleanupToReturnedTxsPerCycle?: number;
+  /**
    * Threshold for `prune_gateway` (failed_consecutive >= N). Mirrors
    * `EpochSettings.max_consecutive_failures` (default 30).
    */
@@ -216,6 +223,14 @@ export class EpochCranker {
         // tie it to the same cleanup config the runCleanup phases use.
         enablePrune: this.config.enableCleanup !== false,
         pruneBatchSize: this.config.cleanupBatchSize,
+        // Scan cadence stays tied to the cleanup interval on purpose. It is
+        // derived from the epoch duration specifically to cut credit-heavy
+        // getProgramAccounts scans on long epochs (adaptive-intervals.ts), and
+        // decoupling it would multiply them ~30x. The throughput problem that
+        // cadence used to cause is solved by pruneToReturnedTxsPerCycle below,
+        // which makes the deadline-bound step drain proportionally to the
+        // backlog rather than to the scan rate. Worst-case conversion latency
+        // is then one scan interval (30 min) against a 14-day auction window.
         pruneScanIntervalMs: this.config.cleanupMinIntervalMs,
         // The other two thirds of the ArNS lease lifecycle. Previously the
         // cranker only drained ReturnedName PDAs — a queue nothing ever filled,
@@ -223,6 +238,7 @@ export class EpochCranker {
         // called it. Expired leases therefore accumulated on-chain and stayed
         // resolvable-but-unbuyable indefinitely. Same cleanup gate as above.
         enablePruneToReturned: this.config.enableCleanup !== false,
+        pruneToReturnedTxsPerCycle: this.config.cleanupToReturnedTxsPerCycle,
         enablePruneExpired: this.config.enableCleanup !== false,
         pruneExpiredBatchSize: this.config.cleanupBatchSize,
       });
@@ -234,6 +250,13 @@ export class EpochCranker {
           epochIndex: result.epochIndex,
           tx: result.txId,
           progress: result.progress,
+          // Present when a batched step stopped early on a failed submission.
+          // Without it a partial drain is indistinguishable from a full one:
+          // the operator sees only a smaller progress.index and cannot tell
+          // whether the per-cycle budget or a real error bounded the work.
+          ...(result.partialFailureReason !== undefined
+            ? { partialFailureReason: result.partialFailureReason }
+            : {}),
         });
       }
     } catch (err) {

--- a/src/epoch/errors.test.ts
+++ b/src/epoch/errors.test.ts
@@ -6,6 +6,20 @@
  */
 import { expect } from 'chai';
 
+import {
+  ARIO_GAR_ERROR__DISTRIBUTION_INCOMPLETE,
+  ARIO_GAR_ERROR__EPOCH_ALREADY_EXISTS,
+  ARIO_GAR_ERROR__EPOCH_IN_PROGRESS,
+  ARIO_GAR_ERROR__INVALID_GATEWAY_ACCOUNT,
+  ARIO_GAR_ERROR__INVALID_OBSERVATION,
+  ARIO_GAR_ERROR__LEAVE_WINDOW_NOT_EXPIRED,
+  ARIO_GAR_ERROR__NOT_PRESCRIBED_OBSERVER,
+  ARIO_GAR_ERROR__PRESCRIPTIONS_ALREADY_DONE,
+  ARIO_GAR_ERROR__REWARDS_ALREADY_DISTRIBUTED,
+  ARIO_GAR_ERROR__WEIGHTS_ALREADY_TALLIED,
+  ARIO_GAR_ERROR__WEIGHTS_NOT_TALLIED,
+} from '@ar.io/solana-contracts/gar';
+
 import { classifyError, parseAnchorErrorCode } from './errors.js';
 
 describe('cranker error classification', () => {
@@ -82,16 +96,17 @@ describe('cranker error classification', () => {
 
   describe('classifyError', () => {
     it('categorises GAR program errors marked as already-done as "already_done"', () => {
+      // Codes come from the generated IDL constants rather than literals:
+      // these four were previously written out by hand and every one of
+      // them was wrong by +2 (6037/6041/6045/6049 are actually
+      // NotPrescribedObserver / InvalidObservation / NoNamesAvailable /
+      // InvalidGatewayAccount — all real failures).
       const examples = [
-        // RewardsAlreadyDistributed
-        new Error('AnchorError ... Error Number: 6037'),
-        // EpochAlreadyExists
-        new Error('AnchorError ... Error Number: 6041'),
-        // WeightsAlreadyTallied
-        new Error('AnchorError ... Error Number: 6045'),
-        // PrescriptionsAlreadyDone
-        new Error('AnchorError ... Error Number: 6049'),
-      ];
+        ARIO_GAR_ERROR__REWARDS_ALREADY_DISTRIBUTED,
+        ARIO_GAR_ERROR__EPOCH_ALREADY_EXISTS,
+        ARIO_GAR_ERROR__WEIGHTS_ALREADY_TALLIED,
+        ARIO_GAR_ERROR__PRESCRIPTIONS_ALREADY_DONE,
+      ].map((code) => new Error(`AnchorError ... Error Number: ${code}`));
       for (const e of examples) {
         expect(classifyError(e)).to.equal('already_done');
       }
@@ -146,14 +161,13 @@ describe('cranker error classification', () => {
 
     it('categorises not-yet-ready GAR errors as "not_ready"', () => {
       const examples = [
-        // EpochInProgress
-        new Error('AnchorError ... Error Number: 6034'),
-        // DistributionIncomplete
-        new Error('AnchorError ... Error Number: 6038'),
-        // WeightsNotTallied
-        new Error('AnchorError ... Error Number: 6046'),
-        // LeaveWindowNotExpired (finalize_gone on a not-yet-expired gateway)
-        new Error('AnchorError ... Error Number: 6079'),
+        ...[
+          ARIO_GAR_ERROR__EPOCH_IN_PROGRESS,
+          ARIO_GAR_ERROR__DISTRIBUTION_INCOMPLETE,
+          ARIO_GAR_ERROR__WEIGHTS_NOT_TALLIED,
+          // finalize_gone on a gateway whose leave window hasn't elapsed
+          ARIO_GAR_ERROR__LEAVE_WINDOW_NOT_EXPIRED,
+        ].map((code) => new Error(`AnchorError ... Error Number: ${code}`)),
         // ...same, hex form (0x17bf = 6079) as seen in simulation failures
         new Error(
           'Transaction simulation failed: custom program error: 0x17bf',
@@ -211,6 +225,42 @@ describe('cranker error classification', () => {
       expect(
         classifyError(new Error('completely unexpected program error')),
       ).to.equal('real');
+    });
+  });
+
+  describe('GAR error codes match the deployed program (drift guard)', () => {
+    // These codes were hand-maintained and drifted +2 once already, because
+    // `EpochsAlreadyEnabled` (6032) and `EpochCounterAlreadyAdvanced` (6033)
+    // were inserted into the middle of the GarError enum. The drift made
+    // `classifyError` swallow real failures as "already done" — which is
+    // exactly how mainnet epoch 523 lost every observation without the
+    // cranker treating it as an error. Pin the values so a future insertion
+    // fails here rather than silently in production.
+    const anchorError = (code: number) =>
+      new Error(`AnchorError thrown. Error Number: ${code}.`);
+
+    it('classifies InvalidObservation as a real error, not already_done', () => {
+      expect(ARIO_GAR_ERROR__INVALID_OBSERVATION).to.equal(6041);
+      expect(classifyError(anchorError(6041))).to.equal('real');
+    });
+
+    it('classifies InvalidGatewayAccount as a real error, not already_done', () => {
+      expect(ARIO_GAR_ERROR__INVALID_GATEWAY_ACCOUNT).to.equal(6049);
+      expect(classifyError(anchorError(6049))).to.equal('real');
+    });
+
+    it('classifies NotPrescribedObserver as a real error', () => {
+      expect(ARIO_GAR_ERROR__NOT_PRESCRIBED_OBSERVER).to.equal(6037);
+      expect(classifyError(anchorError(6037))).to.equal('real');
+    });
+
+    it('classifies the genuine already-done races as already_done', () => {
+      expect(ARIO_GAR_ERROR__EPOCH_ALREADY_EXISTS).to.equal(6043);
+      expect(ARIO_GAR_ERROR__WEIGHTS_ALREADY_TALLIED).to.equal(6047);
+      expect(ARIO_GAR_ERROR__PRESCRIPTIONS_ALREADY_DONE).to.equal(6051);
+      for (const code of [6043, 6047, 6051]) {
+        expect(classifyError(anchorError(code))).to.equal('already_done');
+      }
     });
   });
 });

--- a/src/epoch/errors.ts
+++ b/src/epoch/errors.ts
@@ -7,15 +7,36 @@
  * - "not_ready": Preconditions not met yet. Wait and retry.
  * - "real": Unexpected failure. Needs investigation.
  *
- * IMPORTANT: Anchor assigns error codes as 6000 + variant-index in the
- * enum declared at `contracts/programs/ario-gar/src/error.rs`. Keep this
- * table in sync when new variants are added or reordered.
+ * Codes come from `@ar.io/solana-contracts`, which is generated from the
+ * deployed `ario-gar` IDL. They are deliberately NOT written out by hand:
+ * Anchor assigns each code as 6000 + the variant's index in
+ * `ario-gar/src/error.rs`, so inserting a variant anywhere shifts every
+ * code below it. That happened — `EpochsAlreadyEnabled` and
+ * `EpochCounterAlreadyAdvanced` were added at indexes 32/33 — and the
+ * previous hand-maintained table silently became a +2 shift for everything
+ * from 6032 up. Because the table decides whether a failure is ignorable,
+ * the drift both swallowed real errors as "already done"
+ * (6041 `InvalidObservation`, 6049 `InvalidGatewayAccount`) and reported
+ * benign races as real ones (`WeightsAlreadyTallied` was left unclassified).
+ * Importing the generated constants makes that class of bug impossible.
  */
+import {
+  ARIO_GAR_ERROR__DISTRIBUTION_INCOMPLETE,
+  ARIO_GAR_ERROR__EPOCHS_NOT_ENABLED,
+  ARIO_GAR_ERROR__EPOCH_ALREADY_EXISTS,
+  ARIO_GAR_ERROR__EPOCH_IN_PROGRESS,
+  ARIO_GAR_ERROR__EPOCH_NOT_CLOSEABLE,
+  ARIO_GAR_ERROR__EPOCH_NOT_STARTED,
+  ARIO_GAR_ERROR__LEAVE_WINDOW_NOT_EXPIRED,
+  ARIO_GAR_ERROR__PRESCRIPTIONS_ALREADY_DONE,
+  ARIO_GAR_ERROR__PRESCRIPTIONS_NOT_DONE,
+  ARIO_GAR_ERROR__REWARDS_ALREADY_DISTRIBUTED,
+  ARIO_GAR_ERROR__WEIGHTS_ALREADY_TALLIED,
+  ARIO_GAR_ERROR__WEIGHTS_NOT_TALLIED,
+} from '@ar.io/solana-contracts/gar';
 
 export type ErrorCategory = 'already_done' | 'not_ready' | 'real';
 
-// GarError variant indexes (verified against ario-gar/src/error.rs).
-// Anchor codes = 6000 + index.
 const ALREADY_DONE_ERRORS = new Set<number>([
   // AlreadyInitialized (Anchor built-in) — epoch account already exists
   0,
@@ -35,39 +56,29 @@ const ALREADY_DONE_ERRORS = new Set<number>([
   //          path where the account exists but has zero data could
   //          surface this. Semantically equivalent to "nothing to
   //          close."
-  3007, 3012,
-  // RewardsAlreadyDistributed (variant 37)
-  6037,
-  // EpochAlreadyExists (variant 41)
-  6041,
-  // WeightsAlreadyTallied (variant 45)
-  6045,
-  // PrescriptionsAlreadyDone (variant 49)
-  6049,
+  3007,
+  3012,
+  ARIO_GAR_ERROR__REWARDS_ALREADY_DISTRIBUTED,
+  ARIO_GAR_ERROR__EPOCH_ALREADY_EXISTS,
+  ARIO_GAR_ERROR__WEIGHTS_ALREADY_TALLIED,
+  ARIO_GAR_ERROR__PRESCRIPTIONS_ALREADY_DONE,
 ]);
 
 const NOT_READY_ERRORS = new Set<number>([
-  // EpochsNotEnabled (variant 31)
-  6031,
-  // EpochNotStarted (variant 32)
-  6032,
-  // EpochInProgress (variant 34)
-  6034,
-  // DistributionIncomplete (variant 38)
-  6038,
-  // WeightsNotTallied (variant 46)
-  6046,
-  // PrescriptionsNotDone (variant 48)
-  6048,
-  // EpochNotCloseable (variant 51)
-  6051,
-  // LeaveWindowNotExpired (variant 79) — a Leaving gateway whose leave window
+  ARIO_GAR_ERROR__EPOCHS_NOT_ENABLED,
+  ARIO_GAR_ERROR__EPOCH_NOT_STARTED,
+  ARIO_GAR_ERROR__EPOCH_IN_PROGRESS,
+  ARIO_GAR_ERROR__DISTRIBUTION_INCOMPLETE,
+  ARIO_GAR_ERROR__WEIGHTS_NOT_TALLIED,
+  ARIO_GAR_ERROR__PRESCRIPTIONS_NOT_DONE,
+  ARIO_GAR_ERROR__EPOCH_NOT_CLOSEABLE,
+  // LeaveWindowNotExpired — a Leaving gateway whose leave window
   // hasn't elapsed yet can't be finalize_gone'd. `getGoneGateways()` returns
   // every Leaving gateway (not just expired ones), so the cleanup pass attempts
   // them and they revert with this until their window passes — a wait-and-retry
   // condition, NOT a real error (must not spam error logs or trip unhealthy via
   // consecutiveRealErrors).
-  6079,
+  ARIO_GAR_ERROR__LEAVE_WINDOW_NOT_EXPIRED,
 ]);
 
 /**

--- a/src/store/pipeline-report-sink.test.ts
+++ b/src/store/pipeline-report-sink.test.ts
@@ -365,7 +365,6 @@ describe('PipelineReportSink', function () {
       expect((mockSink3.saveReport as sinon.SinonStub).calledOnce).to.be.true;
 
       // Verify error was logged
-      expect((logStub.error as sinon.SinonStub).calledOnce).to.be.true;
       const errorCall = (logStub.error as sinon.SinonStub).firstCall;
       expect(errorCall.args[0]).to.equal(
         'Error saving report using failingSink',
@@ -374,6 +373,39 @@ describe('PipelineReportSink', function () {
       // Verify final result includes successful processing flags
       expect(result).to.have.property('sink1Processed', true);
       expect(result).to.have.property('sink3Processed', true);
+
+      // The caller must be able to see that the run was partial.
+      expect(result.failedSinks).to.deep.equal(['failingSink']);
+    });
+
+    it('names every failed sink and leaves the field unset on a clean run', async function () {
+      const failingSinkA: ReportSink = {
+        saveReport: sinon.stub().rejects(new Error('A failed')),
+      };
+      const failingSinkB: ReportSink = {
+        saveReport: sinon.stub().rejects(new Error('B failed')),
+      };
+
+      pipelineReportSink = new PipelineReportSink({
+        log: logStub,
+        sinks: [
+          { name: 'sinkA', sink: failingSinkA },
+          { name: 'sink1', sink: mockSink1 },
+          { name: 'sinkB', sink: failingSinkB },
+        ],
+      });
+
+      const report = createMockReport(10, 2);
+      const failed = await pipelineReportSink.saveReport({ report });
+      expect(failed.failedSinks).to.deep.equal(['sinkA', 'sinkB']);
+
+      // A later clean run must not inherit the previous run's failures.
+      const cleanPipeline = new PipelineReportSink({
+        log: logStub,
+        sinks: [{ name: 'sink1', sink: mockSink1 }],
+      });
+      const clean = await cleanPipeline.saveReport(failed);
+      expect(clean.failedSinks).to.equal(undefined);
     });
 
     it('should handle empty sinks array', async function () {

--- a/src/store/pipeline-report-sink.ts
+++ b/src/store/pipeline-report-sink.ts
@@ -96,6 +96,12 @@ export class PipelineReportSink implements ReportSink {
 
     log.verbose('Saving report...');
     let lastReportInfo = reportInfo;
+    // One sink failure must not stop the sinks behind it — a failed
+    // Arweave upload should still let the on-chain sink run. The names
+    // are collected so the caller can see that the run was partial:
+    // a `reportTxId` from an early sink is not proof that the later
+    // sinks succeeded.
+    const failedSinks: string[] = [];
     for (const { name, sink } of this.sinks) {
       try {
         log.verbose(`Saving report using ${name}...`);
@@ -107,11 +113,28 @@ export class PipelineReportSink implements ReportSink {
           report: undefined,
         });
       } catch (error: any) {
+        failedSinks.push(name);
         log.error(`Error saving report using ${name}`, {
           message: error.message,
           stack: error.stack,
         });
       }
+    }
+
+    // Report this run's failures only. An inherited value from an
+    // upstream pipeline (persistence feeding submission) is dropped so
+    // each caller reads the result of the pipeline it invoked.
+    if (failedSinks.length > 0) {
+      log.error('Report pipeline finished with sink failures', {
+        failedSinks,
+        reportTxId: lastReportInfo.reportTxId,
+      });
+      return { ...lastReportInfo, failedSinks };
+    }
+    if (lastReportInfo.failedSinks !== undefined) {
+      const cleared: ReportInfo = { ...lastReportInfo };
+      delete cleared.failedSinks;
+      return cleared;
     }
 
     return lastReportInfo;

--- a/src/store/solana-contract-report-sink.test.ts
+++ b/src/store/solana-contract-report-sink.test.ts
@@ -119,6 +119,68 @@ function makeWriteable(opts: { txId?: string; throws?: Error }): {
   };
 }
 
+type ObservationStatus = Awaited<
+  ReturnType<SolanaARIOReadable['getEpochObservationStatus']>
+>;
+
+/** The pre-flight status of a prescribed observer with work to do. */
+function openStatus(overrides: Partial<ObservationStatus> = {}) {
+  return {
+    prescribed: true,
+    observerIdx: 40,
+    alreadyObserved: false,
+    windowOpen: true,
+    endTimestampSec: Math.floor(Date.now() / 1000) + 3600,
+    ...overrides,
+  } as ObservationStatus;
+}
+
+/**
+ * A readable whose successive calls return successive statuses. The
+ * retry loop re-reads epoch state between attempts, so the first entry
+ * serves the pre-flight gate and later entries serve the retries.
+ */
+function makeSequencedReadable(
+  statuses: (ObservationStatus | Error)[],
+): SolanaARIOReadable {
+  const stub = sinon.stub();
+  statuses.forEach((status, i) => {
+    if (status instanceof Error) {
+      stub.onCall(i).rejects(status);
+    } else {
+      stub.onCall(i).resolves(status);
+    }
+  });
+  stub.resolves(statuses[statuses.length - 1]);
+  return { getEpochObservationStatus: stub } as any;
+}
+
+/** The @solana/kit error seen when a blockhash expires before commit. */
+function blockhashExpiredError(): Error {
+  const err: any = new Error(
+    'The network has progressed past the last block for which this transaction could have been committed.',
+  );
+  err.name = 'SolanaError';
+  err.context = { __code: 1 };
+  return err;
+}
+
+/** A writeable whose saveObservations follows a scripted sequence. */
+function makeSequencedWriteable(outcomes: (string | Error)[]): {
+  contract: SolanaARIOWriteable;
+  saveStub: sinon.SinonStub;
+} {
+  const saveStub = sinon.stub();
+  outcomes.forEach((outcome, i) => {
+    if (outcome instanceof Error) {
+      saveStub.onCall(i).rejects(outcome);
+    } else {
+      saveStub.onCall(i).resolves({ id: outcome });
+    }
+  });
+  return { contract: { saveObservations: saveStub } as any, saveStub };
+}
+
 // ---------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------
@@ -341,6 +403,157 @@ describe('SolanaContractReportSink', () => {
         expect(e.message).to.match(/Transaction simulation failed/);
       }
       expect(threw).to.equal(true);
+    });
+  });
+
+  describe('transient submission retry', () => {
+    /** Build a sink with retries and no backoff, for fast tests. */
+    function makeRetrySink(
+      readable: SolanaARIOReadable,
+      contract: SolanaARIOWriteable,
+      maxSubmitAttempts = 3,
+    ) {
+      return new SolanaContractReportSink({
+        log: makeLog(),
+        contract,
+        readable,
+        observerAddress: OBSERVER_PUBKEY,
+        maxSubmitAttempts,
+        retryBackoffMs: [0, 0],
+      });
+    }
+
+    it('retries a blockhash expiry and reports the signature that lands', async () => {
+      const readable = makeSequencedReadable([openStatus(), openStatus()]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        'SIG_SECOND_TRY',
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(2);
+      expect(result.interactionTxIds).to.deep.equal(['SIG_SECOND_TRY']);
+    });
+
+    it('gives up after the attempt limit and rethrows', async () => {
+      const readable = makeSequencedReadable([openStatus()]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        blockhashExpiredError(),
+        blockhashExpiredError(),
+      ]);
+      const sink = makeRetrySink(readable, contract, 3);
+
+      let threw = false;
+      try {
+        await sink.saveReport(
+          makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+        );
+      } catch (e: any) {
+        threw = true;
+        expect(e.message).to.match(/network has progressed past/);
+      }
+      expect(threw).to.equal(true);
+      expect(saveStub.callCount).to.equal(3);
+    });
+
+    it('does not retry a program revert', async () => {
+      const readable = makeSequencedReadable([openStatus()]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        new Error(
+          'Transaction simulation failed: custom program error: 0x1771',
+        ),
+        'SIG_NEVER_REACHED',
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      let threw = false;
+      try {
+        await sink.saveReport(
+          makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+        );
+      } catch {
+        threw = true;
+      }
+      expect(threw).to.equal(true);
+      expect(saveStub.callCount).to.equal(1);
+    });
+
+    it('stops when the re-read shows the observation already landed', async () => {
+      const readable = makeSequencedReadable([
+        openStatus(),
+        openStatus({ alreadyObserved: true }),
+      ]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        'SIG_DOUBLE_SUBMIT',
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      // No second submission, and no throw: the work is done on chain.
+      expect(saveStub.callCount).to.equal(1);
+      expect(result.interactionTxIds).to.equal(undefined);
+    });
+
+    it('stops when the window closes while retrying', async () => {
+      const readable = makeSequencedReadable([
+        openStatus(),
+        openStatus({ windowOpen: false }),
+      ]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        'SIG_TOO_LATE',
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(1);
+      expect(result.interactionTxIds).to.equal(undefined);
+    });
+
+    it('retries anyway when the pre-retry re-read fails', async () => {
+      const readable = makeSequencedReadable([
+        openStatus(),
+        new Error('RPC 503'),
+      ]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        'SIG_AFTER_BLIND_RETRY',
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(2);
+      expect(result.interactionTxIds).to.deep.equal(['SIG_AFTER_BLIND_RETRY']);
+    });
+
+    it('treats an already-in-use revert as a completed submission', async () => {
+      const readable = makeSequencedReadable([openStatus()]);
+      const { contract, saveStub } = makeSequencedWriteable([
+        new Error('Allocate: account Address { address: 7fxz } already in use'),
+      ]);
+      const sink = makeRetrySink(readable, contract);
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(1);
+      expect(result.interactionTxIds).to.equal(undefined);
     });
   });
 });

--- a/src/store/solana-contract-report-sink.test.ts
+++ b/src/store/solana-contract-report-sink.test.ts
@@ -522,6 +522,44 @@ describe('SolanaContractReportSink', () => {
       expect(result.interactionTxIds).to.equal(undefined);
     });
 
+    it('stops when the window closes DURING the retry backoff', async () => {
+      // Regression guard for the re-read ordering. The pre-flight read happens
+      // immediately and sees an open window; the window then closes 25ms later,
+      // inside the 50ms backoff. Only a re-read placed AFTER the delay observes
+      // that. Checking before the pause would carry a stale "open" verdict into
+      // attempt 2 and submit past epoch.end_timestamp for a terminal revert.
+      const closesAtMs = Date.now() + 25;
+      const statusStub = sinon
+        .stub()
+        .callsFake(async () =>
+          Date.now() >= closesAtMs
+            ? openStatus({ windowOpen: false })
+            : openStatus(),
+        );
+      const readable = {
+        getEpochObservationStatus: statusStub,
+      } as any as SolanaARIOReadable;
+      const { contract, saveStub } = makeSequencedWriteable([
+        blockhashExpiredError(),
+        'SIG_TOO_LATE',
+      ]);
+      const sink = new SolanaContractReportSink({
+        log: makeLog(),
+        contract,
+        readable,
+        observerAddress: OBSERVER_PUBKEY,
+        maxSubmitAttempts: 3,
+        retryBackoffMs: [50],
+      });
+
+      const result = await sink.saveReport(
+        makeReportInfo(makeReport({ epochIndex: 512 }), REPORT_TX_ID),
+      );
+
+      expect(saveStub.callCount).to.equal(1);
+      expect(result.interactionTxIds).to.equal(undefined);
+    });
+
     it('retries anyway when the pre-retry re-read fails', async () => {
       const readable = makeSequencedReadable([
         openStatus(),

--- a/src/store/solana-contract-report-sink.ts
+++ b/src/store/solana-contract-report-sink.ts
@@ -227,15 +227,19 @@ export class SolanaContractReportSink implements ReportSink {
           },
         );
 
-        if ((await this.shouldRetry(epochIndex, attempt)) === false) {
-          return reportInfo;
-        }
-
         await delay(
           this.retryBackoffMs[
             Math.min(attempt - 1, this.retryBackoffMs.length - 1)
           ],
         );
+
+        // Re-read AFTER the backoff, not before: the observation window can
+        // close during the 1s/3s pause, and submitting past
+        // `epoch.end_timestamp` is a terminal revert. Checking first would
+        // clear a stale "open" verdict and spend the next attempt anyway.
+        if ((await this.shouldRetry(epochIndex, attempt)) === false) {
+          return reportInfo;
+        }
       }
     }
 

--- a/src/store/solana-contract-report-sink.ts
+++ b/src/store/solana-contract-report-sink.ts
@@ -29,6 +29,16 @@ import type winston from 'winston';
 
 import type { ObserverReport, ReportInfo, ReportSink } from '../types.js';
 import { getFailedGatewaySummaryFromReport } from './failed-gateway-summary.js';
+import {
+  isAlreadySubmittedError,
+  isTransientSubmitError,
+} from './solana-tx-errors.js';
+
+/** Total attempts for one `save_observations` submission. */
+const DEFAULT_MAX_SUBMIT_ATTEMPTS = 3;
+
+/** Pause before attempt 2, then before attempt 3. */
+const DEFAULT_RETRY_BACKOFF_MS = [1_000, 3_000];
 
 export interface SolanaContractReportSinkConfig {
   log: winston.Logger;
@@ -45,6 +55,11 @@ export interface SolanaContractReportSinkConfig {
    *  read from `contract` so this sink can be constructed without
    *  reaching into the SDK's `signer` internals. */
   observerAddress: Address;
+  /** Total submission attempts, including the first. Defaults to 3. */
+  maxSubmitAttempts?: number;
+  /** Pause before each retry, in milliseconds. The last entry repeats
+   *  if attempts outnumber entries. Tests pass `[0, 0]`. */
+  retryBackoffMs?: number[];
 }
 
 export class SolanaContractReportSink implements ReportSink {
@@ -52,12 +67,22 @@ export class SolanaContractReportSink implements ReportSink {
   private readonly contract: SolanaARIOWriteable;
   private readonly readable: SolanaARIOReadable;
   private readonly observerAddress: Address;
+  private readonly maxSubmitAttempts: number;
+  private readonly retryBackoffMs: number[];
 
   constructor(cfg: SolanaContractReportSinkConfig) {
     this.log = cfg.log.child({ class: this.constructor.name });
     this.contract = cfg.contract;
     this.readable = cfg.readable;
     this.observerAddress = cfg.observerAddress;
+    this.maxSubmitAttempts = Math.max(
+      1,
+      cfg.maxSubmitAttempts ?? DEFAULT_MAX_SUBMIT_ATTEMPTS,
+    );
+    this.retryBackoffMs =
+      cfg.retryBackoffMs !== undefined && cfg.retryBackoffMs.length > 0
+        ? cfg.retryBackoffMs
+        : DEFAULT_RETRY_BACKOFF_MS;
   }
 
   async saveReport(reportInfo: ReportInfo): Promise<{
@@ -151,20 +176,75 @@ export class SolanaContractReportSink implements ReportSink {
       reportTxId,
     });
 
-    let interactionTxId: string;
-    try {
-      const { id } = await this.contract.saveObservations({
-        reportTxId,
-        failedGateways,
-        epochIndex,
-      });
-      interactionTxId = id;
-    } catch (err: any) {
-      this.log.error('save_observations transaction failed', {
-        epochIndex,
-        message: err.message,
-      });
-      throw err;
+    // A blockhash lives ~150 slots (~60s). If the transaction does not
+    // land inside that window, `sendAndConfirm` rejects even though the
+    // instruction is valid — the observed epoch 512 failure. Re-signing
+    // over a fresh blockhash recovers it, so retry a bounded number of
+    // times before giving the error back to the pipeline.
+    let interactionTxId: string | undefined;
+
+    for (let attempt = 1; attempt <= this.maxSubmitAttempts; attempt++) {
+      try {
+        const { id } = await this.contract.saveObservations({
+          reportTxId,
+          failedGateways,
+          epochIndex,
+        });
+        interactionTxId = id;
+        break;
+      } catch (err: any) {
+        // A confirmation timeout does not prove the transaction died.
+        // If it landed, the retry hits the `init` constraint on the
+        // Observation PDA and reverts. That revert means the work is
+        // done — report success rather than failing the epoch.
+        if (isAlreadySubmittedError(err)) {
+          this.log.warn(
+            'save_observations reverted as already submitted — treating as done',
+            { epochIndex, attempt, message: err.message },
+          );
+          return reportInfo;
+        }
+
+        const transient = isTransientSubmitError(err);
+        if (!transient || attempt >= this.maxSubmitAttempts) {
+          this.log.error('save_observations transaction failed', {
+            epochIndex,
+            attempt,
+            maxAttempts: this.maxSubmitAttempts,
+            transient,
+            message: err.message,
+          });
+          throw err;
+        }
+
+        this.log.warn(
+          'save_observations failed transiently — retrying with a fresh blockhash',
+          {
+            epochIndex,
+            attempt,
+            maxAttempts: this.maxSubmitAttempts,
+            message: err.message,
+          },
+        );
+
+        if ((await this.shouldRetry(epochIndex, attempt)) === false) {
+          return reportInfo;
+        }
+
+        await delay(
+          this.retryBackoffMs[
+            Math.min(attempt - 1, this.retryBackoffMs.length - 1)
+          ],
+        );
+      }
+    }
+
+    if (interactionTxId === undefined) {
+      // Unreachable: the loop either breaks with a signature, returns,
+      // or throws. Kept so a future edit can't produce a silent success.
+      throw new Error(
+        `save_observations produced no signature for epoch ${epochIndex}`,
+      );
     }
 
     this.log.info('save_observations submitted', {
@@ -181,4 +261,57 @@ export class SolanaContractReportSink implements ReportSink {
       interactionTxIds: [interactionTxId],
     };
   }
+
+  /**
+   * Re-read epoch state between submission attempts. This is the
+   * idempotency guard for the retry loop: the gates at the top of
+   * `saveReport` ran before the first attempt and can be stale by now.
+   *
+   * Returns `false` when the caller must stop — either the observation
+   * landed after all, or the window closed while we retried. Returns
+   * `true` when another attempt is worthwhile. An RPC failure here is
+   * indeterminate, so it returns `true`: the `init` constraint on the
+   * Observation PDA still blocks a double write.
+   */
+  private async shouldRetry(
+    epochIndex: number,
+    attempt: number,
+  ): Promise<boolean> {
+    let status: Awaited<
+      ReturnType<SolanaARIOReadable['getEpochObservationStatus']>
+    >;
+    try {
+      status = await this.readable.getEpochObservationStatus(
+        epochIndex,
+        this.observerAddress,
+      );
+    } catch (err: any) {
+      this.log.warn(
+        'Epoch re-read before retry failed — retrying submission anyway',
+        { epochIndex, attempt, message: err.message },
+      );
+      return true;
+    }
+
+    if (status.alreadyObserved) {
+      this.log.info(
+        'Observation landed despite the confirmation error — no retry needed',
+        { epochIndex, attempt, observer: this.observerAddress },
+      );
+      return false;
+    }
+    if (!status.windowOpen) {
+      this.log.warn('Observation window closed while retrying — giving up', {
+        epochIndex,
+        attempt,
+        endTimestampSec: status.endTimestampSec,
+      });
+      return false;
+    }
+    return true;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/store/solana-tx-errors.test.ts
+++ b/src/store/solana-tx-errors.test.ts
@@ -1,0 +1,107 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { expect } from 'chai';
+
+import {
+  isAlreadySubmittedError,
+  isTransientSubmitError,
+} from './solana-tx-errors.js';
+
+/**
+ * The exact error shape observed for epoch 512: a @solana/kit
+ * SolanaError with `context.__code` 1 (SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED).
+ */
+function blockHeightExceededError(): Error {
+  const err: any = new Error(
+    'The network has progressed past the last block for which this transaction could have been committed.',
+  );
+  err.name = 'SolanaError';
+  err.context = {
+    __code: 1,
+    currentBlockHeight: 417090557n,
+    lastValidBlockHeight: 417090556n,
+  };
+  return err;
+}
+
+describe('solana-tx-errors', () => {
+  describe('isTransientSubmitError', () => {
+    it('matches the observed blockhash-expiry error', () => {
+      expect(isTransientSubmitError(blockHeightExceededError())).to.equal(true);
+    });
+
+    it('matches on context.__code alone when the message is reworded', () => {
+      const err: any = new Error('confirmation gave up');
+      err.context = { __code: 1 };
+      expect(isTransientSubmitError(err)).to.equal(true);
+    });
+
+    it('matches an error nested under `cause`', () => {
+      // The SDK wraps the kit error before it reaches the sink.
+      const err: any = new Error('sendAndConfirm failed');
+      err.cause = blockHeightExceededError();
+      expect(isTransientSubmitError(err)).to.equal(true);
+    });
+
+    it('matches RPC transport blips', () => {
+      expect(isTransientSubmitError(new Error('socket hang up'))).to.equal(
+        true,
+      );
+      expect(isTransientSubmitError(new Error('fetch failed'))).to.equal(true);
+    });
+
+    it('does not match a program revert', () => {
+      const err: any = new Error(
+        'Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1771',
+      );
+      err.context = { __code: 4615000 };
+      expect(isTransientSubmitError(err)).to.equal(false);
+    });
+
+    it('does not match insufficient funds', () => {
+      expect(
+        isTransientSubmitError(
+          new Error(
+            'Attempt to debit an account but found no record of a prior credit',
+          ),
+        ),
+      ).to.equal(false);
+    });
+
+    it('tolerates null and non-error input', () => {
+      expect(isTransientSubmitError(undefined)).to.equal(false);
+      expect(isTransientSubmitError(null)).to.equal(false);
+      expect(isTransientSubmitError('socket hang up')).to.equal(true);
+    });
+  });
+
+  describe('isAlreadySubmittedError', () => {
+    it('matches the init-constraint allocation failure', () => {
+      expect(
+        isAlreadySubmittedError(
+          new Error(
+            'Allocate: account Address { address: 7fxz..., base: None } already in use',
+          ),
+        ),
+      ).to.equal(true);
+    });
+
+    it('matches a duplicate signature', () => {
+      expect(
+        isAlreadySubmittedError(
+          new Error('This transaction has already been processed'),
+        ),
+      ).to.equal(true);
+    });
+
+    it('does not match a blockhash expiry', () => {
+      expect(isAlreadySubmittedError(blockHeightExceededError())).to.equal(
+        false,
+      );
+    });
+  });
+});

--- a/src/store/solana-tx-errors.ts
+++ b/src/store/solana-tx-errors.ts
@@ -1,0 +1,128 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * Classify errors thrown while a Solana transaction is sent and
+ * confirmed. Two questions matter to a submission retry loop:
+ *
+ *   1. Is the failure transient? A blockhash that expires before the
+ *      transaction lands says nothing about the instruction. The same
+ *      instruction, re-signed over a fresh blockhash, usually lands.
+ *   2. Did the transaction already land? A confirmation timeout does
+ *      not prove the transaction is dead. It can be committed while
+ *      the client stops watching. A retry then hits the `init`
+ *      constraint on the Observation PDA and reverts. That revert is a
+ *      success signal, not a failure.
+ *
+ * Errors from @solana/kit carry a numeric `context.__code` and nest a
+ * root cause under `cause`. Both are inspected. String matching is the
+ * fallback because the RPC layer, the SDK, and the program each wrap
+ * errors differently.
+ */
+
+/** Substrings that mark a retryable send/confirm failure. */
+const TRANSIENT_PATTERNS = [
+  // Blockhash expiry — the confirmed cause of the epoch 512 miss.
+  'network has progressed past the last block',
+  'block height exceeded',
+  'blockheightexceeded',
+  'blockhash not found',
+  'blockhash expired',
+  // Confirmation gave up before the cluster answered.
+  'transactionexpiredtimeout',
+  'was not confirmed',
+  'timed out awaiting confirmation',
+  'confirmation timeout',
+  // RPC transport blips. The transaction may or may not have been
+  // forwarded; the pre-retry state re-read settles that.
+  'socket hang up',
+  'fetch failed',
+  'econnreset',
+  'etimedout',
+  'econnrefused',
+  'service unavailable',
+  'gateway timeout',
+  'too many requests',
+];
+
+/** Substrings that mark "this observation is already on-chain". */
+const ALREADY_SUBMITTED_PATTERNS = [
+  // The Observation PDA is `init`-constrained. A second submission for
+  // the same (epochIndex, observer) fails to allocate.
+  'already in use',
+  // The identical signed transaction was already committed.
+  'already been processed',
+];
+
+/**
+ * `SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED` from @solana/errors. Matched
+ * numerically as well as by message so a reworded error still counts.
+ */
+const SOLANA_ERROR_BLOCK_HEIGHT_EXCEEDED = 1;
+
+/** Flatten an error and its `cause` chain into lowercased text. */
+function errorText(err: unknown): string {
+  const parts: string[] = [];
+  let current: any = err;
+  for (
+    let depth = 0;
+    current !== null && current !== undefined && depth < 5;
+    depth++
+  ) {
+    if (typeof current === 'string') {
+      parts.push(current);
+      break;
+    }
+    if (typeof current.message === 'string') {
+      parts.push(current.message);
+    }
+    if (typeof current.name === 'string') {
+      parts.push(current.name);
+    }
+    current = current.cause;
+  }
+  return parts.join(' ').toLowerCase();
+}
+
+/** Collect `context.__code` from an error and its `cause` chain. */
+function errorCodes(err: unknown): number[] {
+  const codes: number[] = [];
+  let current: any = err;
+  for (
+    let depth = 0;
+    current !== null && current !== undefined && depth < 5;
+    depth++
+  ) {
+    const code = current.context?.__code;
+    if (typeof code === 'number') {
+      codes.push(code);
+    }
+    current = current.cause;
+  }
+  return codes;
+}
+
+/**
+ * True when the failure is a send/confirm timing problem rather than a
+ * rejected instruction. Callers should re-read on-chain state before
+ * acting on this — see {@link isAlreadySubmittedError}.
+ */
+export function isTransientSubmitError(err: unknown): boolean {
+  if (errorCodes(err).includes(SOLANA_ERROR_BLOCK_HEIGHT_EXCEEDED)) {
+    return true;
+  }
+  const text = errorText(err);
+  return TRANSIENT_PATTERNS.some((pattern) => text.includes(pattern));
+}
+
+/**
+ * True when the error says the observation is already recorded on
+ * chain. The caller should treat this as a completed submission.
+ */
+export function isAlreadySubmittedError(err: unknown): boolean {
+  const text = errorText(err);
+  return ALREADY_SUBMITTED_PATTERNS.some((pattern) => text.includes(pattern));
+}

--- a/src/system.ts
+++ b/src/system.ts
@@ -416,6 +416,7 @@ const solanaRpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
       enableCleanup: config.ENABLE_CLEANUP,
       cleanupBatchSize: config.CLEANUP_BATCH_SIZE,
       maxCleanupTxsPerCycle: config.MAX_CLEANUP_TXS_PER_CYCLE,
+      cleanupToReturnedTxsPerCycle: config.CLEANUP_TO_RETURNED_TXS_PER_CYCLE,
       cleanupFailureThreshold: config.CLEANUP_FAILURE_THRESHOLD,
       altReclaimScanLimit: config.ALT_RECLAIM_SCAN_LIMIT,
       cleanupMinIntervalMs,

--- a/src/types.ts
+++ b/src/types.ts
@@ -219,6 +219,17 @@ export interface ReportInfo {
   report: ObserverReport;
   reportTxId?: string;
   interactionTxIds?: string[];
+  /**
+   * Names of the sinks that threw during the last {@link ReportSink}
+   * run. `PipelineReportSink` logs a sink failure and continues to the
+   * next sink, so the returned `ReportInfo` can carry a `reportTxId`
+   * from an earlier sink while a later one failed. Without this field a
+   * caller cannot tell that partial state apart from full success.
+   *
+   * Each pipeline run replaces the field with its own result. An empty
+   * list is reported as `undefined`.
+   */
+  failedSinks?: string[];
 }
 
 export interface ReportSink {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.2.tgz#421cf300112e6698b53d000eaad45237437e7d53"
-  integrity sha512-4AyS67lkKa62L6BAWrNbXx3S1GG/AKWeMNZCGkqpkwwKldLGLyq3ZQrylku2bcSJKqRKL/SmYS76OPqIC6o3aQ==
+"@ar.io/sdk@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.4.tgz#8ff7941d51fadac21cc57271aa08adf97ef289f1"
+  integrity sha512-5Nm6SP+KePW74jFn8qA68iio8/dvYzR5OxFC3euLjTzJ5YKsrl2G44qVbo9powU/XFarKmxYJhgMYZDSU7MGxw==
   dependencies:
     "@ar.io/solana-contracts" "1.1.0"
     "@noble/hashes" "^1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.0.tgz#a8fa42c6bb99339480371a2dcfcea71e930f42cd"
-  integrity sha512-eW4OjjNDZhOHYqRVHM3hq7iGFlp+mYYAHYv4LPI9/q6paM490uoPB+TBOVteGIi+HYvGPUNlAONfy4QYfOiWfg==
+"@ar.io/sdk@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.2.tgz#421cf300112e6698b53d000eaad45237437e7d53"
+  integrity sha512-4AyS67lkKa62L6BAWrNbXx3S1GG/AKWeMNZCGkqpkwwKldLGLyq3ZQrylku2bcSJKqRKL/SmYS76OPqIC6o3aQ==
   dependencies:
     "@ar.io/solana-contracts" "1.1.0"
     "@noble/hashes" "^1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,7 +40,7 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/solana-contracts@1.1.0":
+"@ar.io/solana-contracts@1.1.0", "@ar.io/solana-contracts@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.1.0.tgz#900784dad9b0867ae76678dc177d346692f5e61f"
   integrity sha512-qX8ttp5GoZYMMNNgVzGMdBmaym3g1XL3Y7GyApbbXo4e4SSgt3DXMKl6PCISij5snhkec21LAhHxzHuLyoOe8w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.1.4":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.4.tgz#8ff7941d51fadac21cc57271aa08adf97ef289f1"
-  integrity sha512-5Nm6SP+KePW74jFn8qA68iio8/dvYzR5OxFC3euLjTzJ5YKsrl2G44qVbo9powU/XFarKmxYJhgMYZDSU7MGxw==
+"@ar.io/sdk@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.2.0.tgz#7282cfefae0cc76e2b99b6f1fcbfd056a5c423f2"
+  integrity sha512-kbMVGytA2jNJf11Ka6FPJcTi4DPucYNQCPc+F02ZHZ0XAstGoXm3KwwT4dV95m32OHbBVl/F9xlLnMbE9ovhLg==
   dependencies:
     "@ar.io/solana-contracts" "1.1.0"
     "@noble/hashes" "^1.8.0"


### PR DESCRIPTION
Brings `main` up to `develop` (`4d1c9046`) so the release marker reflects what actually ships. It had drifted to #121 (`@ar.io/sdk` 4.1.0) — **15 commits behind**.

## What it carries

**#128 — `@ar.io/sdk` 4.1.4 → 4.2.0** ([ar-io-sdk#717](https://github.com/ar-io/ar-io-sdk/pull/717))

`saveObservations` derived `gateway_count` from a **live** registry read, but the chain validates it against the epoch's frozen `Epoch.active_gateway_count`. One gateway joining mid-epoch desynced the two and rejected **every observer's** submission with `InvalidObservation` (6041) for the rest of the epoch.

Mainnet **epoch 523** closed with `observations_submitted = 0` across all 50 prescribed observers. 4.2.0 also refuses to submit when a `finalize_gone` swap-remove has reordered registry slots, since the observation bitmap is positional and would otherwise land silently with results attributed to the wrong gateways.

**#127 — cranker error table from the generated IDL**

The hand-maintained Anchor codes had drifted **+2** for everything at or above 6032. Real failures were swallowed as "already done" — 6041 is `InvalidObservation`, 6049 is `InvalidGatewayAccount` — while genuine already-done races were reported as real errors.

## On the conflict resolution

Resolved by taking `develop`'s tree wholesale, the standing remedy for this repo's squash-induced promotion conflicts. I verified nothing was discarded rather than assuming:

- All **9** `main`-only commits are themselves `release: promote develop → main` squashes — no unique work
- The content `main` holds that `develop` lacks is only the *older revision* of files `develop` has since changed, including the very error table #127 corrects
- The resulting tree is **byte-identical to `develop`** (`git diff develop` → 0 files)

The merge commit records both parents (`4d1ab03`, `4d1c904`), so history stays traceable.

## Verification

On the promotion tree: `@ar.io/sdk` resolves to **4.2.0**, **400 tests passing / 0 failing**, `tsconfig.prod.json` typecheck clean, lint clean.

This image is already running on a production gateway (since 02:12 UTC, healthy, 0 errors) and is now the default pin in ar-io-node ([#871](https://github.com/ar-io/ar-io-node/pull/871)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kexn8mPZfVRHiWCW2k4kU3