### PR TITLE
feat: stop observing gateways that are leaving the network

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,14 @@ The system uses a pluggable architecture with interfaces defined in `src/types.t
   `StaticArnsNameList` overrides via `ARNS_NAMES`.
 - **Host Sources**: `SolanaHostsSource` reads the on-chain
   `GatewayRegistry` via the SDK (`getGateways({limit})`) and maps each
-  to a `GatewayHost`. `StaticHostsSource` overrides via
-  `OBSERVED_GATEWAY_HOSTS`.
+  to a `GatewayHost`. Gateways with no FQDN are skipped, as are those the
+  registry reports as `leaving` — terminal, already outside the reward
+  set, and over half the registry in practice (334 of 646 on 2026-08-30).
+  Only an explicit `leaving` is excluded, so a registry that stops
+  reporting status degrades to observing everyone rather than no one; set
+  `SKIP_LEAVING_GATEWAYS=false` to restore the old behaviour. Exclusions
+  are counted by `observer_gateways_skipped_leaving_total`.
+  `StaticHostsSource` overrides via `OBSERVED_GATEWAY_HOSTS`.
 - **Epoch Sources**: `SolanaEpochSource` reads the current Epoch PDA via
   the SDK (`getEpoch(undefined)`), caches for 30s, and invalidates the
   moment `now > endTimestamp`. `getEpochStartHeight()` returns a 0

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,6 +133,33 @@ export const GATEWAY_ASSESSMENT_CONCURRENCY = +env.varOrDefault(
   '10',
 );
 
+// Exclude gateways the registry reports as `leaving` from observation.
+//
+// A gateway is `leaving` either because its operator withdrew it or because
+// the network demoted it after 30 consecutive failed epochs, which makes the
+// status a consensus liveness signal rather than a mere statement of intent.
+//
+// Observing one accomplishes nothing in either case: `leaving` is terminal
+// (`join_network -> leaving -> finalize_gone`, with no path back), such a
+// gateway is already outside the reward set, and having been demoted it
+// cannot be demoted again -- its failure counter simply increments forever.
+//
+// The cost is not marginal. On mainnet 2026-08-30, 334 of 646 registered
+// gateways were `leaving`: 51.7% of the registry, and at
+// OBSERVATIONS_PER_GATEWAY=3 roughly half of every epoch's observation budget
+// spent confirming that gateways which already announced their exit are, in
+// fact, down. They also fail essentially without exception (84 of 84 sampled
+// in one epoch, against 22 of 87 for joined gateways), so the cohort puts a
+// hard ~50% floor under the reported failure rate and consumes most of the
+// headroom below OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD, above which the
+// whole report is suppressed.
+//
+// Only an explicit 'leaving' is excluded; unknown or absent status is kept,
+// so a registry that stops reporting status degrades to the previous
+// behaviour instead of emptying the host list. Set false to restore that.
+export const SKIP_LEAVING_GATEWAYS =
+  env.varOrDefault('SKIP_LEAVING_GATEWAYS', 'true') === 'true';
+
 export const NAME_ASSESSMENT_CONCURRENCY = +env.varOrDefault(
   'NAME_ASSESSMENT_CONCURRENCY',
   '5',

--- a/src/hosts/solana-hosts-source.test.ts
+++ b/src/hosts/solana-hosts-source.test.ts
@@ -113,4 +113,101 @@ describe('SolanaHostsSource', () => {
     await src.getHosts();
     expect(stub.firstCall.args[0]).to.deep.equal({ limit: 3000 });
   });
+
+  describe('leaving-gateway filtering', () => {
+    // Deliberately mixes every status case, including the two that must NOT be
+    // excluded: an absent status, and an unrecognised one. Without those two
+    // present the fail-open behaviour would be assumed rather than exercised.
+    const MIXED = [
+      {
+        gatewayAddress: 'JOINED',
+        status: 'joined',
+        settings: { fqdn: 'joined.example.com', port: 443, protocol: 'https' },
+      },
+      {
+        gatewayAddress: 'LEAVING',
+        status: 'leaving',
+        settings: { fqdn: 'leaving.example.com', port: 443, protocol: 'https' },
+      },
+      {
+        gatewayAddress: 'NO_STATUS',
+        settings: {
+          fqdn: 'nostatus.example.com',
+          port: 443,
+          protocol: 'https',
+        },
+      },
+      {
+        gatewayAddress: 'UNKNOWN_STATUS',
+        status: 'someFutureStatus',
+        settings: { fqdn: 'weird.example.com', port: 443, protocol: 'https' },
+      },
+    ];
+
+    const walletsOf = (hosts: { wallet: string }[]) =>
+      hosts.map((h) => h.wallet);
+
+    it('excludes gateways the registry reports as leaving', async () => {
+      const src = new SolanaHostsSource({
+        readable: makeReadable(MIXED),
+        log: makeLog(),
+      });
+      expect(walletsOf(await src.getHosts())).to.not.include('LEAVING');
+    });
+
+    it('keeps gateways whose status is absent or unrecognised (fail open)', async () => {
+      // The guard that matters. A registry or SDK that stops reporting status
+      // must degrade to observing everyone, never to observing no one -- an
+      // empty host list would silently produce an empty report.
+      const src = new SolanaHostsSource({
+        readable: makeReadable(MIXED),
+        log: makeLog(),
+      });
+      const got = walletsOf(await src.getHosts());
+      expect(got).to.include('NO_STATUS');
+      expect(got).to.include('UNKNOWN_STATUS');
+      expect(got).to.include('JOINED');
+      expect(got).to.have.length(3);
+    });
+
+    it('does not empty the host list when no gateway reports a status', async () => {
+      const src = new SolanaHostsSource({
+        readable: makeReadable([
+          {
+            gatewayAddress: 'A',
+            settings: { fqdn: 'a.example.com', port: 443, protocol: 'https' },
+          },
+          {
+            gatewayAddress: 'B',
+            settings: { fqdn: 'b.example.com', port: 443, protocol: 'https' },
+          },
+        ]),
+        log: makeLog(),
+      });
+      expect(await src.getHosts()).to.have.length(2);
+    });
+
+    it('keeps leaving gateways when skipLeaving is disabled', async () => {
+      const src = new SolanaHostsSource({
+        readable: makeReadable(MIXED),
+        log: makeLog(),
+        skipLeaving: false,
+      });
+      expect(walletsOf(await src.getHosts())).to.include('LEAVING');
+    });
+
+    it('still skips an empty fqdn even when the gateway is joined', async () => {
+      const src = new SolanaHostsSource({
+        readable: makeReadable([
+          {
+            gatewayAddress: 'JOINED_NO_FQDN',
+            status: 'joined',
+            settings: { fqdn: '', port: 443, protocol: 'https' },
+          },
+        ]),
+        log: makeLog(),
+      });
+      expect(await src.getHosts()).to.deep.equal([]);
+    });
+  });
 });

--- a/src/hosts/solana-hosts-source.ts
+++ b/src/hosts/solana-hosts-source.ts
@@ -14,6 +14,7 @@
 import type winston from 'winston';
 
 import type { SolanaARIOReadable } from '@ar.io/sdk';
+import * as metrics from '../metrics.js';
 import type { GatewayHost, GatewayHostsSource } from '../types.js';
 
 export interface SolanaHostsSourceConfig {
@@ -22,22 +23,36 @@ export interface SolanaHostsSourceConfig {
   /** Cap on how many gateways to return per call. The on-chain
    *  registry can hold up to 3,000; on devnet-shrunk it's 30. */
   limit?: number;
+  /** Exclude gateways the registry reports as `leaving`. Defaults to
+   *  true; `system.ts` injects `config.SKIP_LEAVING_GATEWAYS`. */
+  skipLeaving?: boolean;
 }
 
 export class SolanaHostsSource implements GatewayHostsSource {
   private readonly readable: SolanaARIOReadable;
   private readonly log: winston.Logger;
   private readonly limit: number;
+  private readonly skipLeaving: boolean;
 
   constructor(cfg: SolanaHostsSourceConfig) {
     this.readable = cfg.readable;
     this.log = cfg.log.child({ class: this.constructor.name });
     this.limit = cfg.limit ?? 3000;
+    this.skipLeaving = cfg.skipLeaving ?? true;
   }
 
+  /**
+   * Read the gateway registry and return the hosts to assess this epoch.
+   *
+   * Two kinds of gateway are dropped: those with no FQDN (nothing to
+   * request), and — unless `skipLeaving` is false — those the registry
+   * reports as `leaving`. Only an explicit `leaving` is excluded; see the
+   * comment on the filter for why unknown status is deliberately kept.
+   */
   async getHosts(): Promise<GatewayHost[]> {
     const page = await this.readable.getGateways({ limit: this.limit });
     const hosts: GatewayHost[] = [];
+    let skippedLeaving = 0;
     for (const g of page.items) {
       const s = g.settings;
       // Defensive: skip gateways with no FQDN — their HTTP path can't
@@ -45,6 +60,37 @@ export class SolanaHostsSource implements GatewayHostsSource {
       if (!s.fqdn || s.fqdn.length === 0) {
         continue;
       }
+
+      // Skip gateways the registry says are on their way out.
+      //
+      // A gateway is `leaving` either because its operator withdrew it or
+      // because the network demoted it after 30 consecutive failed epochs,
+      // so the status doubles as a consensus liveness signal. Neither kind
+      // can be affected by observing it: `leaving` is terminal (there is no
+      // path back to `joined`), such a gateway is already excluded from the
+      // reward set, and it cannot be demoted again. Assessing it only
+      // rediscovers, one DNS timeout at a time, what the registry already
+      // says.
+      //
+      // Measured on mainnet 2026-08-30: 334 of 646 registered gateways were
+      // `leaving` — 51.7% of the registry and, at OBSERVATIONS_PER_GATEWAY=3,
+      // roughly half the epoch's observation budget. Of those sampled that
+      // epoch, 84 of 84 failed while joined gateways failed 22 of 87, so the
+      // cohort also puts a hard ~50% floor under the reported failure rate,
+      // consuming most of the headroom below
+      // OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD (0.9), above which the whole
+      // report is suppressed.
+      //
+      // Deliberately excludes ONLY an explicit 'leaving'. A gateway whose
+      // status is absent or unrecognised is kept, so a registry or SDK that
+      // stops reporting status degrades to the previous behaviour rather
+      // than emptying the host list — which would silently produce an empty
+      // report rather than an obviously broken one.
+      if (this.skipLeaving && g.status === 'leaving') {
+        skippedLeaving++;
+        continue;
+      }
+
       hosts.push({
         fqdn: s.fqdn,
         port: s.port,
@@ -52,9 +98,11 @@ export class SolanaHostsSource implements GatewayHostsSource {
         wallet: g.gatewayAddress,
       });
     }
+    metrics.gatewaysSkippedLeavingCounter.inc(skippedLeaving);
     this.log.verbose('Loaded gateway hosts', {
       count: hosts.length,
       totalScanned: page.items.length,
+      skippedLeaving,
     });
     return hosts;
   }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -44,6 +44,12 @@ export const gatewayAssessmentsCounter = new Counter({
   registers: [register],
 });
 
+export const gatewaysSkippedLeavingCounter = new Counter({
+  name: 'observer_gateways_skipped_leaving_total',
+  help: 'Gateways excluded from observation because the registry reports them as leaving the network',
+  registers: [register],
+});
+
 export const reportsGeneratedCounter = new Counter({
   name: 'observer_reports_generated_total',
   help: 'Total reports generated',

--- a/src/system.ts
+++ b/src/system.ts
@@ -454,6 +454,7 @@ const observedGatewayHostList =
     : new SolanaHostsSource({
         readable: networkContract,
         log,
+        skipLeaving: config.SKIP_LEAVING_GATEWAYS,
       });
 
 if (


### PR DESCRIPTION
Observation-side companion to [ar-io-node#873](https://github.com/ar-io/ar-io-node/pull/873), which applies the same signal to the data-retrieval peer pool.

`SolanaHostsSource.getHosts` admits every gateway in the registry and filters exactly one thing — an empty FQDN. Gateways the registry reports as `leaving` are assessed every epoch like any other. The observer already fetches this status on every registry read and then discards it.

A gateway is `leaving` either because its operator withdrew it, or because the network demoted it after **30 consecutive failed epochs** — which makes the status a consensus liveness signal, not a statement of intent.

### Observing one accomplishes nothing

- `leaving` is **terminal**: `join_network → leaving → finalize_gone`, with no path back. (`cancel_withdrawal` is scoped to a delegation/withdrawal, not to gateway status.)
- It is **already outside the reward set** — the on-chain epoch accounts size `totalEligibleRewards` to exactly the `joined` count (312 for epochs 526–529; 316 for 525, the joined count then). Note `Epoch.activeGatewayCount` reads 646 — that is a registry-size snapshot, not an eligibility count.
- Having been demoted, it **cannot be demoted again**. Its failure counter simply increments forever.

### Measured impact

Mainnet, 2026-08-30:

```
TOTAL gateways in GAR: 646
  leaving: 334  (51.7%)
  joined:  312  (48.3%)
```

At `OBSERVATIONS_PER_GATEWAY=3` that is **~1,002 of 1,938 observations per epoch**.

The cohort also fails essentially without exception. Sampled in one epoch:

| status | pass | fail | fail rate |
|---|---|---|---|
| `joined` | 65 | 22 | 25% |
| `leaving` | 0 | 84 | **100%** |

So it puts a hard ~50% floor under the reported failure rate and consumes most of the headroom below `OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD` (0.9), above which the entire report is suppressed. It also accounts for epoch 526’s `failedGatewayCount: 414` almost exactly (334 + ~25% of 312 ≈ 412).

### Design

Mirrors #873: excludes **only** an explicit `leaving`. A gateway whose status is absent or unrecognised is kept, so a registry or SDK that stops reporting status degrades to observing everyone rather than no one — an empty host list would silently produce an empty report rather than an obviously broken one. Making the guard fail-closed (`!== "joined"`) breaks four tests, two of them pre-existing.

Note this repo already has the fail-*closed* form at `src/reference/network-gateway-source.ts:112`. That is fine for reference-gateway selection, where an empty result falls back; it is not the right shape for the observation target list.

- `SKIP_LEAVING_GATEWAYS` (default `true`) to disable
- `observer_gateways_skipped_leaving_total` counts exclusions

Filtering is per-gateway rather than per-FQDN, which matters where one FQDN carries two registrations: `treex.online` is registered by both a joined and a leaving wallet, and only the leaving one is dropped.

### Testing

`lint:check`, `test` and `build` all clean — the three jobs the workflow runs. 405 passing, 0 failing (400 on the baseline, +5 new). Failing-first verified in both directions: the exclusion test fails without the filter, and the two fail-open tests plus two pre-existing ones fail if the guard is made fail-closed.

Verified end to end against the live mainnet registry:

```
skipLeaving=false   : 646 hosts  (old behaviour)
skipLeaving=true    : 312 hosts
default (no option) : 312 hosts
excluded            : 334
leaked by wallet    : 0
joined-with-fqdn    : 312  == filtered count (exact match)
metric              : observer_gateways_skipped_leaving_total{release="dev"} 334
```

### Note for reviewers

A `leaving` gateway may still serve correctly until its exit completes, so in principle this drops assessable gateways. Unlike #873 there is no retrieval downside — they earn nothing and cannot be demoted further, so omitting them changes no payout — but the assumption worth challenging is whether any consumer depends on failure reports covering the full registry rather than the reward-eligible set. It is behind a flag for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015R5EBQvBycT5dbNq2YRAgJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gateways reported as “leaving” are now excluded from observation by default.
  * Gateways with missing or unrecognized status remain observable.
  * Added configuration to restore the previous behavior.
  * Added monitoring for gateways skipped due to their leaving status.

* **Documentation**
  * Documented filtering behavior, configuration, and monitoring details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->