### PR TITLE
chore(deps): bump @ar.io/sdk to 4.3.0-alpha.2 for ADR-0029

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.2.0",
-    "@ar.io/solana-contracts": "^1.1.0",
+    "@ar.io/sdk": "4.3.0-alpha.2",
+    "@ar.io/solana-contracts": "1.2.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,12 +23,12 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.2.0.tgz#7282cfefae0cc76e2b99b6f1fcbfd056a5c423f2"
-  integrity sha512-kbMVGytA2jNJf11Ka6FPJcTi4DPucYNQCPc+F02ZHZ0XAstGoXm3KwwT4dV95m32OHbBVl/F9xlLnMbE9ovhLg==
+"@ar.io/sdk@4.3.0-alpha.2":
+  version "4.3.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.3.0-alpha.2.tgz#edf9393667a0b9ce23b3330b7cc7e7e51dae136d"
+  integrity sha512-0EMpFhYkUUMgTAG3st4Zm4IKzU5/mGROjooD8VV2CvYoY4RN7DqD6GGaUHAGyTluECjsYcSST70BJm1U1AqB9Q==
   dependencies:
-    "@ar.io/solana-contracts" "1.1.0"
+    "@ar.io/solana-contracts" "1.2.0"
     "@noble/hashes" "^1.8.0"
     "@solana-program/address-lookup-table" "^0.11.0"
     "@solana-program/compute-budget" "^0.15.0"
@@ -40,10 +40,10 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/solana-contracts@1.1.0", "@ar.io/solana-contracts@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.1.0.tgz#900784dad9b0867ae76678dc177d346692f5e61f"
-  integrity sha512-qX8ttp5GoZYMMNNgVzGMdBmaym3g1XL3Y7GyApbbXo4e4SSgt3DXMKl6PCISij5snhkec21LAhHxzHuLyoOe8w==
+"@ar.io/solana-contracts@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.2.0.tgz#3e56cdbce36c295001572a105fe689690cb77236"
+  integrity sha512-g/zqlYNK3geFzjaiYhicFniGsBu2T3MDM+Gh7IuOmQXV1HSPakib3oP1p0wWeJ0ho1SipoPvW+KncUaM9KVQHA==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
The mainnet `ario-gar` program was upgraded on 2026-08-30 (slot 442893933). `close_epoch` now refunds the Epoch account's ~0.0664 SOL rent to the account recorded in a new `EpochRentReceipt` PDA — the `create_epoch` payer — instead of to whoever signs the close. Upgrading is how a cranking gateway starts receiving that refund for the epochs it creates.

Un-upgraded clients keep working, so this is not urgent for anyone who is not cranking. For anyone who is, it is the difference between paying for every epoch they create and being repaid for it.

### Both packages, together

`@ar.io/solana-contracts` is a **direct** dependency of this repo (`^1.1.0`), not merely transitive, and `@ar.io/sdk@4.3.0-alpha.2` pins it to exactly `1.2.0`. Bumping only the SDK leaves the root hoisted at 1.1.0 with 1.2.0 nested underneath, so the observer's own code would run 1.1.0 IDLs against the upgraded program. Both move in one commit.

### Exact pins, deliberately

`4.3.0-alpha.2` is a prerelease, and npm caret ranges do not match prereleases — `^4.2.0` does **not** admit it, and the `latest` dist-tag is still `4.2.0`. So `yarn upgrade @ar.io/sdk` alone silently resolves back to 4.2.0, a no-op that looks like success. The ranges are pinned exactly rather than with carets, which also keeps resolution deterministic on a path that moves real SOL. Worth revisiting to `^4.3.0` once it ships stable.

### What the new version carries

`@ar.io/solana-contracts@1.2.0` adds the `EpochRentReceipt` account, whose `creator` field is documented as "the `create_epoch` payer, and therefore the only valid recipient of this epoch's reclaimed rent", derived from `["epoch_rent_receipt", epoch_index]`, plus an `admin_close_orphaned_epoch_rent_receipt` instruction. The SDK's `crankEpochStep` wires it through `getEpochRentReceiptPDA` / `hasRentReceipt`, with new `MissingEpochRentReceipt` / `InvalidEpochRentReceipt` errors.

Note the close path keys on `Epoch.hasRentReceipt` — program state — rather than on whether the caller passed a receipt, so a scavenger cannot omit the accounts to force the legacy `close = payer` branch. Pre-ADR-0029 epochs have the flag clear and need no extra accounts, which is what keeps the mixed-version transition window working in both directions.

### Testing

`lint:check`, `test` and `build` all clean — the three jobs the workflow runs, run locally since this repo has no PR CI. 405 passing, 0 failing.

Deployed and soaking on a mainnet cranking gateway since 2026-08-30 15:36 UTC: container healthy, zero errors, observation state restored mid-window without losing the epoch (1,016 pending observations resumed), and `getEpochRentReceiptPDA` confirmed absent for every pre-upgrade epoch (522-529) as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015R5EBQvBycT5dbNq2YRAgJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package versions to newer releases for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->