### PR TITLE
chore(deps): move @ar.io/sdk off the prerelease pin to ^4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "4.3.0-alpha.2",
+    "@ar.io/sdk": "^4.3.0",
     "@ar.io/solana-contracts": "1.2.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@4.3.0-alpha.2":
-  version "4.3.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.3.0-alpha.2.tgz#edf9393667a0b9ce23b3330b7cc7e7e51dae136d"
-  integrity sha512-0EMpFhYkUUMgTAG3st4Zm4IKzU5/mGROjooD8VV2CvYoY4RN7DqD6GGaUHAGyTluECjsYcSST70BJm1U1AqB9Q==
+"@ar.io/sdk@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.3.0.tgz#557e6d6fd7e77a20ac226b6a8f7cf1ca1fce0490"
+  integrity sha512-NL7kCxsQxI3BLVNvt6S/NxV/eeeTmZKIPCczoq81HzYU7HjQdhS5tGyk90NJyWvXyNnNotBYoe6lRCk+rHodzg==
   dependencies:
     "@ar.io/solana-contracts" "1.2.0"
     "@noble/hashes" "^1.8.0"


### PR DESCRIPTION
`develop` pinned `4.3.0-alpha.2` **exactly**, because at the time npm caret ranges couldn't reach it — `^4.1.4` does not satisfy `4.3.0-alpha.2` and silently resolves to `4.2.0`, which has no ADR-0029 support. `4.3.0` is now published as stable, so the caret works and the exact pin is no longer needed.

Same code either way; this is about the shipped image running a released SDK rather than a prerelease.

## Notes

- Installed with **`corepack yarn@1.22.22`**. A bare `yarn` here resolves to Berry 3.8.7 and rewrites `yarn.lock` into Berry format (~10k-line diff) plus a stray `.yarnrc.yml`. The correct diff is **9 lines**.
- Verified `node_modules` rather than the installer's exit code — we hit a case in `ar-io-cranker` where `npm install` reported "up to date" while leaving the old SDK in place.

```
@ar.io/sdk               4.3.0
@ar.io/solana-contracts  1.2.0
npx mocha --no-warnings  405 passing, 0 failing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKeNoHyV6m1Z3sh81Jykkf