### PR TITLE
release: promote develop → main (SDK 4.3.0 / ADR-0029)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,14 @@ The system uses a pluggable architecture with interfaces defined in `src/types.t
   `StaticArnsNameList` overrides via `ARNS_NAMES`.
 - **Host Sources**: `SolanaHostsSource` reads the on-chain
   `GatewayRegistry` via the SDK (`getGateways({limit})`) and maps each
-  to a `GatewayHost`. `StaticHostsSource` overrides via
-  `OBSERVED_GATEWAY_HOSTS`.
+  to a `GatewayHost`. Gateways with no FQDN are skipped, as are those the
+  registry reports as `leaving` — terminal, already outside the reward
+  set, and over half the registry in practice (334 of 646 on 2026-08-30).
+  Only an explicit `leaving` is excluded, so a registry that stops
+  reporting status degrades to observing everyone rather than no one; set
+  `SKIP_LEAVING_GATEWAYS=false` to restore the old behaviour. Exclusions
+  are counted by `observer_gateways_skipped_leaving_total`.
+  `StaticHostsSource` overrides via `OBSERVED_GATEWAY_HOSTS`.
 - **Epoch Sources**: `SolanaEpochSource` reads the current Epoch PDA via
   the SDK (`getEpoch(undefined)`), caches for 30s, and invalidates the
   moment `now > endTimestamp`. `getEpochStartHeight()` returns a 0

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.2.0",
-    "@ar.io/solana-contracts": "^1.1.0",
+    "@ar.io/sdk": "4.3.0-alpha.2",
+    "@ar.io/solana-contracts": "1.2.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ar-io/ar-io-observer"
   },
   "dependencies": {
-    "@ar.io/sdk": "4.3.0-alpha.2",
+    "@ar.io/sdk": "^4.3.0",
     "@ar.io/solana-contracts": "1.2.0",
     "@ardrive/ardrive-promise-cache": "^1.1.4",
     "@ardrive/turbo-sdk": "^1.23.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,6 +133,33 @@ export const GATEWAY_ASSESSMENT_CONCURRENCY = +env.varOrDefault(
   '10',
 );
 
+// Exclude gateways the registry reports as `leaving` from observation.
+//
+// A gateway is `leaving` either because its operator withdrew it or because
+// the network demoted it after 30 consecutive failed epochs, which makes the
+// status a consensus liveness signal rather than a mere statement of intent.
+//
+// Observing one accomplishes nothing in either case: `leaving` is terminal
+// (`join_network -> leaving -> finalize_gone`, with no path back), such a
+// gateway is already outside the reward set, and having been demoted it
+// cannot be demoted again -- its failure counter simply increments forever.
+//
+// The cost is not marginal. On mainnet 2026-08-30, 334 of 646 registered
+// gateways were `leaving`: 51.7% of the registry, and at
+// OBSERVATIONS_PER_GATEWAY=3 roughly half of every epoch's observation budget
+// spent confirming that gateways which already announced their exit are, in
+// fact, down. They also fail essentially without exception (84 of 84 sampled
+// in one epoch, against 22 of 87 for joined gateways), so the cohort puts a
+// hard ~50% floor under the reported failure rate and consumes most of the
+// headroom below OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD, above which the
+// whole report is suppressed.
+//
+// Only an explicit 'leaving' is excluded; unknown or absent status is kept,
+// so a registry that stops reporting status degrades to the previous
+// behaviour instead of emptying the host list. Set false to restore that.
+export const SKIP_LEAVING_GATEWAYS =
+  env.varOrDefault('SKIP_LEAVING_GATEWAYS', 'true') === 'true';
+
 export const NAME_ASSESSMENT_CONCURRENCY = +env.varOrDefault(
   'NAME_ASSESSMENT_CONCURRENCY',
   '5',

--- a/src/hosts/solana-hosts-source.test.ts
+++ b/src/hosts/solana-hosts-source.test.ts
@@ -113,4 +113,101 @@ describe('SolanaHostsSource', () => {
     await src.getHosts();
     expect(stub.firstCall.args[0]).to.deep.equal({ limit: 3000 });
   });
+
+  describe('leaving-gateway filtering', () => {
+    // Deliberately mixes every status case, including the two that must NOT be
+    // excluded: an absent status, and an unrecognised one. Without those two
+    // present the fail-open behaviour would be assumed rather than exercised.
+    const MIXED = [
+      {
+        gatewayAddress: 'JOINED',
+        status: 'joined',
+        settings: { fqdn: 'joined.example.com', port: 443, protocol: 'https' },
+      },
+      {
+        gatewayAddress: 'LEAVING',
+        status: 'leaving',
+        settings: { fqdn: 'leaving.example.com', port: 443, protocol: 'https' },
+      },
+      {
+        gatewayAddress: 'NO_STATUS',
+        settings: {
+          fqdn: 'nostatus.example.com',
+          port: 443,
+          protocol: 'https',
+        },
+      },
+      {
+        gatewayAddress: 'UNKNOWN_STATUS',
+        status: 'someFutureStatus',
+        settings: { fqdn: 'weird.example.com', port: 443, protocol: 'https' },
+      },
+    ];
+
+    const walletsOf = (hosts: { wallet: string }[]) =>
+      hosts.map((h) => h.wallet);
+
+    it('excludes gateways the registry reports as leaving', async () => {
+      const src = new SolanaHostsSource({
+        readable: makeReadable(MIXED),
+        log: makeLog(),
+      });
+      expect(walletsOf(await src.getHosts())).to.not.include('LEAVING');
+    });
+
+    it('keeps gateways whose status is absent or unrecognised (fail open)', async () => {
+      // The guard that matters. A registry or SDK that stops reporting status
+      // must degrade to observing everyone, never to observing no one -- an
+      // empty host list would silently produce an empty report.
+      const src = new SolanaHostsSource({
+        readable: makeReadable(MIXED),
+        log: makeLog(),
+      });
+      const got = walletsOf(await src.getHosts());
+      expect(got).to.include('NO_STATUS');
+      expect(got).to.include('UNKNOWN_STATUS');
+      expect(got).to.include('JOINED');
+      expect(got).to.have.length(3);
+    });
+
+    it('does not empty the host list when no gateway reports a status', async () => {
+      const src = new SolanaHostsSource({
+        readable: makeReadable([
+          {
+            gatewayAddress: 'A',
+            settings: { fqdn: 'a.example.com', port: 443, protocol: 'https' },
+          },
+          {
+            gatewayAddress: 'B',
+            settings: { fqdn: 'b.example.com', port: 443, protocol: 'https' },
+          },
+        ]),
+        log: makeLog(),
+      });
+      expect(await src.getHosts()).to.have.length(2);
+    });
+
+    it('keeps leaving gateways when skipLeaving is disabled', async () => {
+      const src = new SolanaHostsSource({
+        readable: makeReadable(MIXED),
+        log: makeLog(),
+        skipLeaving: false,
+      });
+      expect(walletsOf(await src.getHosts())).to.include('LEAVING');
+    });
+
+    it('still skips an empty fqdn even when the gateway is joined', async () => {
+      const src = new SolanaHostsSource({
+        readable: makeReadable([
+          {
+            gatewayAddress: 'JOINED_NO_FQDN',
+            status: 'joined',
+            settings: { fqdn: '', port: 443, protocol: 'https' },
+          },
+        ]),
+        log: makeLog(),
+      });
+      expect(await src.getHosts()).to.deep.equal([]);
+    });
+  });
 });

--- a/src/hosts/solana-hosts-source.ts
+++ b/src/hosts/solana-hosts-source.ts
@@ -14,6 +14,7 @@
 import type winston from 'winston';
 
 import type { SolanaARIOReadable } from '@ar.io/sdk';
+import * as metrics from '../metrics.js';
 import type { GatewayHost, GatewayHostsSource } from '../types.js';
 
 export interface SolanaHostsSourceConfig {
@@ -22,22 +23,36 @@ export interface SolanaHostsSourceConfig {
   /** Cap on how many gateways to return per call. The on-chain
    *  registry can hold up to 3,000; on devnet-shrunk it's 30. */
   limit?: number;
+  /** Exclude gateways the registry reports as `leaving`. Defaults to
+   *  true; `system.ts` injects `config.SKIP_LEAVING_GATEWAYS`. */
+  skipLeaving?: boolean;
 }
 
 export class SolanaHostsSource implements GatewayHostsSource {
   private readonly readable: SolanaARIOReadable;
   private readonly log: winston.Logger;
   private readonly limit: number;
+  private readonly skipLeaving: boolean;
 
   constructor(cfg: SolanaHostsSourceConfig) {
     this.readable = cfg.readable;
     this.log = cfg.log.child({ class: this.constructor.name });
     this.limit = cfg.limit ?? 3000;
+    this.skipLeaving = cfg.skipLeaving ?? true;
   }
 
+  /**
+   * Read the gateway registry and return the hosts to assess this epoch.
+   *
+   * Two kinds of gateway are dropped: those with no FQDN (nothing to
+   * request), and — unless `skipLeaving` is false — those the registry
+   * reports as `leaving`. Only an explicit `leaving` is excluded; see the
+   * comment on the filter for why unknown status is deliberately kept.
+   */
   async getHosts(): Promise<GatewayHost[]> {
     const page = await this.readable.getGateways({ limit: this.limit });
     const hosts: GatewayHost[] = [];
+    let skippedLeaving = 0;
     for (const g of page.items) {
       const s = g.settings;
       // Defensive: skip gateways with no FQDN — their HTTP path can't
@@ -45,6 +60,37 @@ export class SolanaHostsSource implements GatewayHostsSource {
       if (!s.fqdn || s.fqdn.length === 0) {
         continue;
       }
+
+      // Skip gateways the registry says are on their way out.
+      //
+      // A gateway is `leaving` either because its operator withdrew it or
+      // because the network demoted it after 30 consecutive failed epochs,
+      // so the status doubles as a consensus liveness signal. Neither kind
+      // can be affected by observing it: `leaving` is terminal (there is no
+      // path back to `joined`), such a gateway is already excluded from the
+      // reward set, and it cannot be demoted again. Assessing it only
+      // rediscovers, one DNS timeout at a time, what the registry already
+      // says.
+      //
+      // Measured on mainnet 2026-08-30: 334 of 646 registered gateways were
+      // `leaving` — 51.7% of the registry and, at OBSERVATIONS_PER_GATEWAY=3,
+      // roughly half the epoch's observation budget. Of those sampled that
+      // epoch, 84 of 84 failed while joined gateways failed 22 of 87, so the
+      // cohort also puts a hard ~50% floor under the reported failure rate,
+      // consuming most of the headroom below
+      // OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD (0.9), above which the whole
+      // report is suppressed.
+      //
+      // Deliberately excludes ONLY an explicit 'leaving'. A gateway whose
+      // status is absent or unrecognised is kept, so a registry or SDK that
+      // stops reporting status degrades to the previous behaviour rather
+      // than emptying the host list — which would silently produce an empty
+      // report rather than an obviously broken one.
+      if (this.skipLeaving && g.status === 'leaving') {
+        skippedLeaving++;
+        continue;
+      }
+
       hosts.push({
         fqdn: s.fqdn,
         port: s.port,
@@ -52,9 +98,11 @@ export class SolanaHostsSource implements GatewayHostsSource {
         wallet: g.gatewayAddress,
       });
     }
+    metrics.gatewaysSkippedLeavingCounter.inc(skippedLeaving);
     this.log.verbose('Loaded gateway hosts', {
       count: hosts.length,
       totalScanned: page.items.length,
+      skippedLeaving,
     });
     return hosts;
   }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -44,6 +44,12 @@ export const gatewayAssessmentsCounter = new Counter({
   registers: [register],
 });
 
+export const gatewaysSkippedLeavingCounter = new Counter({
+  name: 'observer_gateways_skipped_leaving_total',
+  help: 'Gateways excluded from observation because the registry reports them as leaving the network',
+  registers: [register],
+});
+
 export const reportsGeneratedCounter = new Counter({
   name: 'observer_reports_generated_total',
   help: 'Total reports generated',

--- a/src/system.ts
+++ b/src/system.ts
@@ -454,6 +454,7 @@ const observedGatewayHostList =
     : new SolanaHostsSource({
         readable: networkContract,
         log,
+        skipLeaving: config.SKIP_LEAVING_GATEWAYS,
       });
 
 if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@4.3.0-alpha.2":
-  version "4.3.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.3.0-alpha.2.tgz#edf9393667a0b9ce23b3330b7cc7e7e51dae136d"
-  integrity sha512-0EMpFhYkUUMgTAG3st4Zm4IKzU5/mGROjooD8VV2CvYoY4RN7DqD6GGaUHAGyTluECjsYcSST70BJm1U1AqB9Q==
+"@ar.io/sdk@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.3.0.tgz#557e6d6fd7e77a20ac226b6a8f7cf1ca1fce0490"
+  integrity sha512-NL7kCxsQxI3BLVNvt6S/NxV/eeeTmZKIPCczoq81HzYU7HjQdhS5tGyk90NJyWvXyNnNotBYoe6lRCk+rHodzg==
   dependencies:
     "@ar.io/solana-contracts" "1.2.0"
     "@noble/hashes" "^1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,12 +23,12 @@
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
 
-"@ar.io/sdk@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.2.0.tgz#7282cfefae0cc76e2b99b6f1fcbfd056a5c423f2"
-  integrity sha512-kbMVGytA2jNJf11Ka6FPJcTi4DPucYNQCPc+F02ZHZ0XAstGoXm3KwwT4dV95m32OHbBVl/F9xlLnMbE9ovhLg==
+"@ar.io/sdk@4.3.0-alpha.2":
+  version "4.3.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.3.0-alpha.2.tgz#edf9393667a0b9ce23b3330b7cc7e7e51dae136d"
+  integrity sha512-0EMpFhYkUUMgTAG3st4Zm4IKzU5/mGROjooD8VV2CvYoY4RN7DqD6GGaUHAGyTluECjsYcSST70BJm1U1AqB9Q==
   dependencies:
-    "@ar.io/solana-contracts" "1.1.0"
+    "@ar.io/solana-contracts" "1.2.0"
     "@noble/hashes" "^1.8.0"
     "@solana-program/address-lookup-table" "^0.11.0"
     "@solana-program/compute-budget" "^0.15.0"
@@ -40,10 +40,10 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/solana-contracts@1.1.0", "@ar.io/solana-contracts@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.1.0.tgz#900784dad9b0867ae76678dc177d346692f5e61f"
-  integrity sha512-qX8ttp5GoZYMMNNgVzGMdBmaym3g1XL3Y7GyApbbXo4e4SSgt3DXMKl6PCISij5snhkec21LAhHxzHuLyoOe8w==
+"@ar.io/solana-contracts@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.2.0.tgz#3e56cdbce36c295001572a105fe689690cb77236"
+  integrity sha512-g/zqlYNK3geFzjaiYhicFniGsBu2T3MDM+Gh7IuOmQXV1HSPakib3oP1p0wWeJ0ho1SipoPvW+KncUaM9KVQHA==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
Promotes `develop` to `main`.

## Why this matters beyond the usual

The image workflow tags `:latest` from **both** branches:

```yaml
on: push: branches: [develop, main]
tags: ghcr.io/ar-io/ar-io-observer:latest
```

`:latest` currently comes from the `develop` build and carries ADR-0029. But `main` still pins `^4.2.0`, so **the next push to `main` rebuilds `:latest` from a 4.2.0 SDK with no ADR-0029 support** — silently reverting every operator who pulls `:latest` afterwards.

That failure is invisible: an un-upgraded observer attempting to close a receipted epoch fails with `MissingEpochRentReceipt (6093)`, which `crankEpochStep` swallows in its own catch. No error logged, no metric moved, health checks stay green — the epoch just never closes. Mainnet epoch 530 is already receipted and becomes closeable at index 537.

Promoting closes that window.

## Contents

Four commits, including the `@ar.io/sdk` bump for ADR-0029 (#131) and the leaving-gateways change (#130).

Best merged **after** #132, which moves the pin off the `4.3.0-alpha.2` prerelease onto stable `^4.3.0` — otherwise `main` inherits the prerelease pin.

## Context

ADR-0029 makes `close_epoch` refund the Epoch account's ~0.0664 SOL rent to whoever **created** the epoch rather than whoever closes it. The `ario-gar` contract is live on mainnet (slot `442893933`, `sha256 7f09326f…`, byte-verified) and has been running clean for three days with zero failed transactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKeNoHyV6m1Z3sh81Jykkf